### PR TITLE
Readme activacion uv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,5 +178,5 @@ cython_debug/
 .aider*
 .DS_Store
 
-#DB
+# DB 
 dof_db/*

--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,6 @@ cython_debug/
 .pypirc
 .aider*
 .DS_Store
+
+#DB
+dof_db/*

--- a/README.md
+++ b/README.md
@@ -11,14 +11,31 @@ Una vez instalado uv, ejecuta el siguiente comando para iniciar el proyecto:
 uv venv # Crear un entorno virtual
 uv sync # Sincronizar dependencias
 ```
+## Activacion del Entorno Virtual
+Cada vez que trabajes en el proyecto, activa el entorno virtual:
+
+* ### **Linux/macOs:**
+```bash
+source .venv/bin/activate
+```
+
+* ### **Windows:**
+```bash
+.venv\Scripts\activate
+```
+
+Para desactivar el entorno virtual, ejecuta:
+```bash
+deactivate
+```
 
 ## Bajar archivos del DOF
 
 Para bajar archivos del DOF se usa el script get_dof.py de la siguiente manera:
 
 ```bash
-uv run get_dof.py --help
-uv run get_dof.py --start-year=2025 --end-year=2023
+python get_dof.py --help
+python get_dof.py --start-year=2025 --end-year=2023
 ```
 
 Esto crea directorios como:


### PR DESCRIPTION
## Descripción

Este PR actualiza el flujo de trabajo y la configuración del proyecto:
- Cambia `uv run` por `python` en los scripts para ejecución directa dentro del entorno virtual.
- Incluye instrucciones para activar el entorno virtual con `source .venv/bin/activate` (Linux/macOS) o `.venv\Scripts\activate` (Windows).
- Excluye `dof_db/*` en `.gitignore` para evitar que la base de datos SQLite se suba al repositorio.