### PR TITLE
Pandoc Dof docx to md

### DIFF
--- a/README_DOFDOCX.md
+++ b/README_DOFDOCX.md
@@ -16,7 +16,7 @@ Estos scripts son necesarios para crear la estructura de directorios apropiada y
 El script espera la siguiente estructura de directorios (creada por los scripts prerrequisito):
 
 ```
-dof_word/
+dof_docx/
 ├── 2023/
 │   ├── 01/
 │   │   ├── 02012023/

--- a/README_DOFDOCX.md
+++ b/README_DOFDOCX.md
@@ -1,0 +1,141 @@
+# DOF DOCX to Markdown Converter
+
+Convierte archivos DOCX del Diario Oficial de la Federación (DOF) a formato Markdown usando Pandoc y filtros LUA personalizados.
+
+## Prerrequisitos
+
+Antes de usar este script, **DEBES** haber ejecutado los siguientes scripts en orden:
+
+1. **`get_word_dof.py`** - Descarga archivos DOCX del DOF desde el sitio web oficial
+2. **`dof_processor.py`** - Procesa y organiza los archivos DOCX descargados
+
+Estos scripts son necesarios para crear la estructura de directorios apropiada y obtener los archivos DOCX que este convertidor procesará.
+
+### Estructura de Directorios Esperada
+
+El script espera la siguiente estructura de directorios (creada por los scripts prerrequisito):
+
+```
+dof_word/
+├── 2023/
+│   ├── 01/
+│   │   ├── 02012023/
+│   │   │   ├── MAT/
+│   │   │   │   └── archivo1.docx
+│   │   │   └── VES/
+│   │   │       └── archivo2.docx
+│   │   ├── 03012023/
+│   │   └── ...
+│   └── 02/
+└── 2024/
+    └── 01/
+```
+
+## Requisitos
+
+- Python 3.7+
+- Pandoc
+- Filtros LUA personalizados (incluidos en el repositorio)
+- Dependencias Python:
+  - typer
+
+## Instalación de dependencias
+
+### 1. Instalar Pandoc
+
+#### Windows
+- Descarga el instalador desde la [página oficial de Pandoc](https://github.com/jgm/pandoc/releases/latest) y ejecútalo.
+- Alternativamente, puedes instalarlo con Chocolatey:
+  ```pwsh
+  choco install pandoc
+  ```
+- O con Winget:
+  ```pwsh
+  winget install --source winget --exact --id JohnMacFarlane.Pandoc
+  ```
+
+#### Linux
+- Usando el gestor de paquetes (puede estar desactualizado):
+  ```bash
+  sudo apt-get install pandoc
+  # o en Fedora
+  sudo dnf install pandoc
+  ```
+- Para la última versión, descarga el paquete desde la [página oficial](https://github.com/jgm/pandoc/releases/latest) y sigue las instrucciones:
+  ```bash
+  sudo dpkg -i <archivo.deb>
+  # o
+  tar xvzf <archivo.tar.gz> --strip-components 1 -C /usr/local/
+  ```
+
+#### macOS
+- Descarga el instalador desde la [página oficial de Pandoc](https://github.com/jgm/pandoc/releases/latest) y ejecútalo.
+- Alternativamente, puedes instalarlo con Homebrew:
+  ```bash
+  brew install pandoc
+  ```
+- O con MacPorts:
+  ```bash
+  port install pandoc
+  ```
+
+### 2. Instalar dependencias Python con UV
+
+Ejecuta:
+```bash
+uv add typer
+```
+
+## Uso
+
+Ejecuta el script desde la terminal usando UV:
+
+- Procesar todos los archivos:
+  ```bash
+  uv run dof_docx_to_md.py
+  ```
+- Procesar archivos de una fecha específica:
+  ```bash
+  uv run dof_docx_to_md.py 22/01/2025
+  ```
+- Procesar archivos en un rango de fechas:
+  ```bash
+  uv run dof_docx_to_md.py 01/01/2025 31/01/2025
+  ```
+
+## Estructura de Salida
+
+El script crea la siguiente estructura de salida:
+
+```
+dof_word_md/
+├── 2023/
+│   ├── 01/
+│   │   ├── 02012023/
+│   │   │   ├── MAT/
+│   │   │   │   ├── archivo1.md
+│   │   │   │   └── images/
+│   │   │   │       ├── img_001.png
+│   │   │   │       └── img_002.jpg
+│   │   │   └── VES/
+│   │   │       ├── archivo2.md
+│   │   │       └── images/
+│   │   └── ...
+│   └── 02/
+└── 2024/
+```
+
+
+Puedes especificar directorios de entrada/salida y nivel de log:
+```bash
+uv run dof_docx_to_md.py 02/01/2020 --input-dir dof_word --output-dir dof_word_md --log-level DEBUG
+```
+
+## Notas
+- Procesa siempre ambas ediciones (MAT y VES).
+- Revisa el archivo de log `convert_docx_to_md.log` para detalles y errores.
+- Asegúrate de que el filtro LUA `pandoc_filters/dof_headers.lua` exista antes de ejecutar el script.
+
+## Recursos
+- [Documentación oficial de Pandoc](https://pandoc.org/installing.html)
+- [Repositorio de Pandoc](https://github.com/jgm/pandoc)

--- a/README_DOFDOCX.md
+++ b/README_DOFDOCX.md
@@ -1,19 +1,17 @@
 # DOF DOCX to Markdown Converter
 
-Convierte archivos DOCX del Diario Oficial de la Federación (DOF) a formato Markdown usando Pandoc y filtros LUA personalizados.
+Convierte archivos DOCX del DOF a Markdown usando Pandoc.
 
 ## Prerrequisitos
 
 Antes de usar este script, **DEBES** haber ejecutado los siguientes scripts en orden:
 
-1. **`get_word_dof.py`** - Descarga archivos DOCX del DOF desde el sitio web oficial
-2. **`dof_processor.py`** - Procesa y organiza los archivos DOCX descargados
+1. `get_word_dof.py` - Descarga archivos DOCX del DOF
+2. `dof_processor.py` - Organiza los archivos descargados
 
-Estos scripts son necesarios para crear la estructura de directorios apropiada y obtener los archivos DOCX que este convertidor procesará.
+### Estructura esperada
 
-### Estructura de Directorios Esperada
-
-El script espera la siguiente estructura de directorios (creada por los scripts prerrequisito):
+Los scripts anteriores crean esta estructura:
 
 ```
 dof_docx/
@@ -45,14 +43,7 @@ dof_docx/
 
 #### Windows
 - Descarga el instalador desde la [página oficial de Pandoc](https://github.com/jgm/pandoc/releases/latest) y ejecútalo.
-- Alternativamente, puedes instalarlo con Chocolatey:
-  ```pwsh
-  choco install pandoc
-  ```
-- O con Winget:
-  ```pwsh
-  winget install --source winget --exact --id JohnMacFarlane.Pandoc
-  ```
+
 
 #### Linux
 - Usando el gestor de paquetes (puede estar desactualizado):
@@ -69,19 +60,11 @@ dof_docx/
   ```
 
 #### macOS
-- Descarga el instalador desde la [página oficial de Pandoc](https://github.com/jgm/pandoc/releases/latest) y ejecútalo.
-- Alternativamente, puedes instalarlo con Homebrew:
-  ```bash
-  brew install pandoc
-  ```
-- O con MacPorts:
-  ```bash
-  port install pandoc
-  ```
+```bash
+brew install pandoc
+```
 
-### 2. Instalar dependencias Python con UV
-
-Ejecuta:
+### 2. Instalar typer
 ```bash
 uv add typer
 ```
@@ -114,19 +97,21 @@ dof_word_md/
 │   │   ├── 02012023/
 │   │   │   ├── MAT/
 │   │   │   │   ├── archivo1.md
-│   │   │   │   └── images/
-│   │   │   │       ├── img_001.png
-│   │   │   │       └── img_002.jpg
+│   │   │   │   └── media_temp/
+│   │   │   │       └── media/
+│   │   │   │           ├── image1.png
+│   │   │   │           └── image2.jpg
 │   │   │   └── VES/
 │   │   │       ├── archivo2.md
-│   │   │       └── images/
+│   │   │       └── media_temp/
+│   │   │           └── media/
 │   │   └── ...
 │   └── 02/
 └── 2024/
 ```
 
 
-Puedes especificar directorios de entrada/salida y nivel de log:
+### Opciones
 ```bash
 uv run dof_docx_to_md.py 02/01/2020 --input-dir dof_word --output-dir dof_word_md --log-level DEBUG
 ```

--- a/dof_docx_to_md.py
+++ b/dof_docx_to_md.py
@@ -225,7 +225,7 @@ def find_docx_files(input_dir: Path, date_str: Optional[str] = None,
 def main(
     date: Optional[str] = typer.Argument(None, help="Date (DD/MM/YYYY) or start date for range - optional"),
     end_date: Optional[str] = typer.Argument(None, help="End date (DD/MM/YYYY) - optional for date range"),
-    input_dir: str = typer.Option("./dof_word", help="Input directory with DOCX files"),
+    input_dir: str = typer.Option("./dof_docx", help="Input directory with DOCX files"),
     output_dir: str = typer.Option("./dof_word_md", help="Output directory for Markdown files"),
     log_level: str = typer.Option("INFO", help="Logging level: DEBUG, INFO, WARNING, ERROR")
 ):
@@ -236,13 +236,13 @@ def main(
     
     Usage examples:
     # Process all files:
-    uv run convert_docx_to_md.py
+    uv run dof_docx_to_md.py
     
     # For a specific date:
-    uv run convert_docx_to_md.py 22/01/2025
+    uv run dof_docx_to_md.py 22/01/2025
     
     # For a date range:
-    uv run convert_docx_to_md.py 01/01/2025 31/01/2025
+    uv run dof_docx_to_md.py 01/01/2025 31/01/2025
     """
     
     log_levels = {

--- a/dof_docx_to_md.py
+++ b/dof_docx_to_md.py
@@ -43,6 +43,7 @@ def convert_docx_to_markdown(docx_path: Path, output_path: Path,
             '--wrap=preserve',
             '--extract-media', str(images_dir),
             '--lua-filter', str(lua_filter_headers),
+            '--columns=120',
             '-o', str(output_path)
         ]
         

--- a/dof_docx_to_md.py
+++ b/dof_docx_to_md.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+# /// script
+# dependencies = [
+#   "typer"
+# ]
+# ///
+"""
+DOF DOCX to Markdown Converter
+
+Converts DOF (Diario Oficial de la Federación) DOCX files to Markdown format
+using Pandoc with custom LUA filters.
+
+"""
+
+import sys
+import shutil
+import logging
+import subprocess
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import List, Optional
+from enum import Enum
+
+import typer
+
+
+class ProcessResult(Enum):
+    SUCCESS = "success"
+    FAILED = "failed"
+
+
+def convert_docx_to_markdown(docx_path: Path, output_path: Path, 
+                           images_dir: Path, lua_filter_headers: Path) -> bool:
+    """
+    Converts a DOCX file to Markdown using Pandoc with optimized configuration
+    
+    Args:
+        docx_path: Path to input DOCX file
+        output_path: Path to output Markdown file
+        images_dir: Directory where to extract images
+        lua_filter_headers: Path to custom LUA filter for headers
+        
+    Returns:
+        True if conversion was successful, False otherwise
+    """
+    try:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        images_dir.mkdir(parents=True, exist_ok=True)
+        
+        pandoc_cmd = [
+            'pandoc',
+            str(docx_path),
+            '-f', 'docx+styles',
+            '-t', 'markdown',
+            '--wrap=preserve',
+            '--extract-media', str(images_dir),
+            '--lua-filter', str(lua_filter_headers),
+            '-o', str(output_path)
+        ]
+        
+        logging.info(f"Executing: {' '.join(pandoc_cmd)}")
+        
+        file_size_mb = docx_path.stat().st_size / (1024 * 1024)
+        timeout_seconds = min(600, max(300, int(file_size_mb * 30)))
+        
+        logging.info(f"File size {file_size_mb:.2f} MB, timeout: {timeout_seconds} seconds")
+        result = subprocess.run(pandoc_cmd, capture_output=True, text=True, timeout=timeout_seconds)
+        
+        if result.returncode == 0:
+            logging.info(f"Successful conversion: {docx_path.name} -> {output_path.name}")
+            
+            if output_path.exists() and output_path.stat().st_size > 0:
+                return True
+            else:
+                logging.error(f"Output file empty or doesn't exist: {output_path}")
+                return False
+        else:
+            logging.error(f"Pandoc error: {result.stderr}")
+            return False
+            
+    except subprocess.TimeoutExpired:
+        logging.error(f"Timeout in conversion of {docx_path}")
+        return False
+    except Exception as e:
+        logging.error(f"Error converting {docx_path}: {e}")
+        return False
+
+
+def organize_images(images_dir: Path, target_images_dir: Path) -> int:
+    """
+    Organizes extracted images in the target directory
+    
+    Args:
+        images_dir: Temporary directory with images extracted by Pandoc
+        target_images_dir: Target directory for images
+        
+    Returns:
+        Number of organized images
+    """
+    organized_count = 0
+    
+    try:
+        if not images_dir.exists():
+            return 0
+        
+        target_images_dir.mkdir(parents=True, exist_ok=True)
+        
+        for image_file in images_dir.rglob('*'):
+            if image_file.is_file() and image_file.suffix.lower() in ['.png', '.jpg', '.jpeg', '.gif', '.bmp', '.svg', '.emf', '.wmf']:
+                target_name = f"img_{organized_count + 1:03d}{image_file.suffix}"
+                target_path = target_images_dir / target_name
+                
+                shutil.copy2(image_file, target_path)
+                organized_count += 1
+                logging.info(f"Image organized: {image_file.name} -> {target_name}")
+        
+        if images_dir.exists():
+            shutil.rmtree(images_dir, ignore_errors=True)
+        
+        return organized_count
+        
+    except Exception as e:
+        logging.error(f"Error organizing images: {e}")
+        return organized_count
+
+
+def process_docx_file(docx_path: Path, output_base_dir: Path, lua_filter_headers: Path) -> ProcessResult:
+    """
+    Processes an individual DOCX file. Always overwrites existing files.
+    
+    Args:
+        docx_path: Path to DOCX file
+        output_base_dir: Base output directory
+        lua_filter_headers: Path to LUA filter for headers
+        
+    """
+    try:
+        path_parts = docx_path.parts
+        logging.debug(f"Path parts: {path_parts}")
+        
+        if len(path_parts) < 5:
+            logging.error(f"Invalid path structure: {docx_path}")
+            return False
+        
+        year = path_parts[-5]
+        month = path_parts[-4]
+        date_dir = path_parts[-3]
+        edition = path_parts[-2]  # MAT or VES
+        
+        logging.info(f"Extracted - Year: {year}, Month: {month}, Date: {date_dir}, Edition: {edition}")
+        
+        output_dir = output_base_dir / year / month / date_dir / edition
+        output_dir.mkdir(parents=True, exist_ok=True)
+        
+        md_filename = docx_path.stem + '.md'
+        md_path = output_dir / md_filename
+        
+        images_dir = output_dir / 'images'
+        temp_media_dir = output_dir / 'media_temp'
+        
+        logging.info(f"Processing: {docx_path} -> {md_path}")
+        
+        if convert_docx_to_markdown(docx_path, md_path, temp_media_dir, lua_filter_headers):
+            images_count = organize_images(temp_media_dir, images_dir)
+            if images_count > 0:
+                logging.info(f"Extracted {images_count} images")
+            
+            return ProcessResult.SUCCESS
+        else:
+            return ProcessResult.FAILED
+            
+    except Exception as e:
+        logging.error(f"Error processing {docx_path}: {e}")
+        return ProcessResult.FAILED
+
+
+def find_docx_files(input_dir: Path, date_str: Optional[str] = None, 
+                   end_date_str: Optional[str] = None) -> List[Path]:
+    """
+    Finds DOCX files to process. Always processes both MAT and VES editions.
+    
+    Args:
+        input_dir: Input directory
+        date_str: Specific date (DD/MM/YYYY) or None for all
+        end_date_str: End date for range or None
+        
+    Returns:
+        List of paths to DOCX files
+    """
+    docx_files = []
+    
+    try:
+        if date_str:
+            start_date = datetime.strptime(date_str, "%d/%m/%Y")
+            end_date = datetime.strptime(end_date_str, "%d/%m/%Y") if end_date_str else start_date
+            
+            current_date = start_date
+            while current_date <= end_date:
+                year = current_date.strftime("%Y")
+                month = current_date.strftime("%m")
+                day = current_date.strftime("%d")
+                date_folder = f"{day}{month}{year}"
+                
+                editions_to_process = ['MAT', 'VES']  # Always process both editions
+                
+                for edition in editions_to_process:
+                    edition_dir = input_dir / year / month / date_folder / edition
+                    if edition_dir.exists():
+                        for docx_file in edition_dir.glob('*.docx'):
+                            docx_files.append(docx_file)
+                
+                current_date += timedelta(days=1)
+        else:
+            for docx_file in input_dir.rglob('*.docx'):
+                docx_files.append(docx_file)
+        
+        logging.info(f"Found {len(docx_files)} DOCX files to process")
+        return docx_files
+        
+    except Exception as e:
+        logging.error(f"Error searching DOCX files: {e}")
+        return []
+
+
+def main(
+    date: Optional[str] = typer.Argument(None, help="Date (DD/MM/YYYY) or start date for range - optional"),
+    end_date: Optional[str] = typer.Argument(None, help="End date (DD/MM/YYYY) - optional for date range"),
+    input_dir: str = typer.Option("./dof_word", help="Input directory with DOCX files"),
+    output_dir: str = typer.Option("./dof_word_md", help="Output directory for Markdown files"),
+    log_level: str = typer.Option("INFO", help="Logging level: DEBUG, INFO, WARNING, ERROR")
+):
+    """
+    Converts DOF DOCX files to Markdown format using Pandoc
+    with custom LUA filters and image extraction.
+    Always processes both MAT and VES editions and overwrites existing files.
+    
+    Usage examples:
+    # Process all files:
+    uv run convert_docx_to_md.py
+    
+    # For a specific date:
+    uv run convert_docx_to_md.py 22/01/2025
+    
+    # For a date range:
+    uv run convert_docx_to_md.py 01/01/2025 31/01/2025
+    """
+    
+    log_levels = {
+        'DEBUG': logging.DEBUG,
+        'INFO': logging.INFO,
+        'WARNING': logging.WARNING,
+        'ERROR': logging.ERROR
+    }
+    
+    logging.basicConfig(
+        level=log_levels.get(log_level.upper(), logging.INFO),
+        format='%(asctime)s - %(levelname)s - %(message)s',
+        handlers=[
+            logging.FileHandler('convert_docx_to_md.log'),
+            logging.StreamHandler()
+        ]
+    )
+    
+    logging.info("=== Starting DOCX to Markdown conversion ===")
+    
+    input_path = Path(input_dir)
+    output_path = Path(output_dir)
+    
+    if not input_path.exists():
+        logging.error(f"Input directory does not exist: {input_path}")
+        sys.exit(1)
+    
+    if date:
+        try:
+            datetime.strptime(date, "%d/%m/%Y")
+            if end_date:
+                datetime.strptime(end_date, "%d/%m/%Y")
+        except ValueError:
+            logging.error("Dates must be in DD/MM/YYYY format")
+            sys.exit(1)
+    
+    try:
+        lua_filter_headers = Path("./pandoc_filters/dof_headers.lua")
+        
+        if not lua_filter_headers.exists():
+            logging.error(f"LUA headers filter not found: {lua_filter_headers}")
+            logging.error("Please ensure the LUA filter exists before running the script")
+            sys.exit(1)
+        
+        docx_files = find_docx_files(input_path, date, end_date)
+        
+        if not docx_files:
+            logging.warning("No DOCX files found to process")
+            return
+        
+        successful_conversions = 0
+        failed_conversions = 0
+        
+        for docx_file in docx_files:
+            logging.info(f"Processing {docx_file.name}...")
+            
+            result = process_docx_file(docx_file, output_path, lua_filter_headers)
+            
+            if result == ProcessResult.SUCCESS:
+                successful_conversions += 1
+            elif result == ProcessResult.FAILED:
+                failed_conversions += 1
+        
+        logging.info("=== Conversion summary ===")
+        logging.info(f"Files processed successfully: {successful_conversions}")
+        logging.info(f"Files with errors: {failed_conversions}")
+        logging.info(f"Total files: {len(docx_files)}")
+        
+        if successful_conversions > 0:
+            logging.info(f"Markdown files generated in: {output_path}")
+        
+    except KeyboardInterrupt:
+        logging.info("Process interrupted by user")
+        sys.exit(1)
+    except Exception as e:
+        logging.error(f"Unexpected error: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/pandoc_filters/dof_headers.lua
+++ b/pandoc_filters/dof_headers.lua
@@ -1,0 +1,97 @@
+
+-- DOF Headers Filter: Convert Word styles to Markdown headers and clean unwanted attributes
+
+local style_map = {
+  ["CABEZA"] = 1,
+  ["Titulo 1"] = 2,
+  ["Titulo 2"] = 3,
+  ["ANOTACION"] = 4,
+}
+
+local text_styles = {
+  "texto", "texto1", "text", "normal", "párrafo", "parrafo", "paragraph",
+  "romanos", "Plain Text", "Hyperlink", "footnote text", "INCISO",
+  "Footnote Characters", "Notas al pie", "Estilo", "footnote reference", "Normal (Web)"
+}
+
+local function get_custom_style(attr)
+  return attr and attr.attributes and 
+    (attr.attributes["custom-style"] or attr.attributes["custom-style-name"] or attr.attributes["style"])
+end
+
+local function is_text_style(style)
+  if not style then return false end
+  local style_lower = style:lower()
+  for _, text_style in ipairs(text_styles) do
+    if style_lower == text_style:lower() then
+      return true
+    end
+  end
+  return false
+end
+
+function Div(el)
+  local style = get_custom_style(el.attr)
+  
+  if is_text_style(style) then
+    return el.content
+  end
+  
+  local level = style and style_map[style]
+  if not level then return nil end
+
+  local new_blocks = {}
+  local header_created = false
+
+  for _, blk in ipairs(el.content) do
+    if not header_created and (blk.t == "Para" or blk.t == "Plain") then
+      table.insert(new_blocks, pandoc.Header(level, blk.content))
+      header_created = true
+    else
+      table.insert(new_blocks, blk)
+    end
+  end
+
+  if header_created then
+    return new_blocks
+  else
+    local txt = pandoc.utils.stringify(el)
+    if txt ~= "" then
+      return { pandoc.Header(level, { pandoc.Str(txt) }) }
+    end
+  end
+end
+
+function Span(el)
+  local style = get_custom_style(el.attr)
+  if is_text_style(style) then
+    return el.content
+  end
+  return el
+end
+
+function Link(el)
+  local style = get_custom_style(el.attr)
+  if is_text_style(style) then
+    return pandoc.Link(el.content, el.target, el.title)
+  end
+  return el
+end
+
+function Image(el)
+  if el.attr and el.attr.attributes then
+    local new_attributes = {}
+    for key, value in pairs(el.attr.attributes) do
+      if key ~= "width" and key ~= "height" then
+        new_attributes[key] = value
+      end
+    end
+    local new_attr = {el.attr.identifier or "", el.attr.classes or {}, new_attributes}
+    return pandoc.Image(el.content or {}, el.src, el.title or "", new_attr)
+  end
+  return el
+end
+
+function Underline(el)
+  return el.content
+end


### PR DESCRIPTION
Se agrega un script en Python que convierte archivos DOCX del Diario Oficial de la Federación (DOF) a formato Markdown. Utiliza Pandoc con filtros LUA personalizados para mantener la estructura de los documentos (Encabezados) y extraer imágenes automáticamente.