### PR TITLE
feat(scripts): compare custom chunker vs Chonkie RecursiveChunker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,9 @@ dependencies = [
     "pyarrow>=18.0.0",
     "transformers>=4.53.3",
     "torch>=2.8.0",
-    "accelerate>=1.10.1"
+    "accelerate>=1.10.1",
+    "chonkie>=1.7.0",
+    "jsonschema>=4.26.0",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "transformers>=4.53.3",
     "torch>=2.8.0",
     "accelerate>=1.10.1",
-    "chonkie>=1.7.0",
+    "chonkie[table]>=1.7.0",
     "jsonschema>=4.26.0",
 ]
 

--- a/reports/chunker_comparison.md
+++ b/reports/chunker_comparison.md
@@ -1,0 +1,40 @@
+# Comparación: chunker custom vs Chonkie RecursiveChunker
+
+Muestra: **1,000** archivos markdown de `./dof_md`
+Límite de tokens por chunk: **800**
+
+## Resumen general
+
+| Chunker | Archivos | Errores | Chunks total | Chunks/archivo (med) | Tiempo (s) | Chunks/s |
+|---|---|---|---|---|---|---|
+| Custom | 1,000 | 0 | 25,779 | 1.0 | 28.50 | 904.6 |
+| Chonkie Recursive | 992 | 8 | 6,540 | 2.0 | 19.66 | 332.7 |
+
+## Tokens por chunk
+
+| Chunker | Media | Mediana | P95 | Máx | Archivos con chunks >10% over max |
+|---|---|---|---|---|---|
+| Custom | 172.8 | 35.0 | 794.0 | 2,986 | 291 (29.1%) |
+| Chonkie Recursive | 599.0 | 703.5 | 796.0 | 800 | 0 (0.0%) |
+
+## Distribución de patrones (chunker custom)
+
+| Patrón | Archivos | Chunks/archivo (media) |
+|---|---|---|
+| bold_headers | 113 | 10.5 |
+| giant_table | 110 | 205.6 |
+| h2_compound | 33 | 34.0 |
+| plain_text | 19 | 6.8 |
+| small | 725 | 1.0 |
+
+## Observaciones
+
+- El chunker custom clasifica el documento antes de dividir; Chonkie RecursiveChunker aplica una regla markdown genérica.
+- El contador de tokens es el mismo para ambos (tokenizer de `pplx-embed-context-v1-0.6b`) para hacer la comparación justa.
+- Chonkie también ofrece `TableChunker` para documentos dominados por tablas; no se incluyó en esta comparación.
+
+## Conclusión provisional
+
+- **Custom**: chunks más pequeños (mediana 35 tokens) pero 291 archivos (29.1%) con chunks que exceden el límite. Máximo observado: 2,986 tokens.
+- **Chonkie Recursive**: respeta el límite en todos los casos (máx 800), chunks más grandes (mediana 704 tokens), y 8 errores.
+- El custom es más adecuado para el DOF por su granularidad y preservación de estructura, pero se debe trabajar en acotar los chunks oversized (especialmente tablas gigantes y documentos justo por debajo del umbral `small`).

--- a/reports/chunker_comparison.md
+++ b/reports/chunker_comparison.md
@@ -7,13 +7,14 @@ Límite de tokens por chunk: **800**
 
 | Chunker | Archivos | Errores | Chunks total | Chunks/archivo (med) | Tiempo (s) | Chunks/s |
 |---|---|---|---|---|---|---|
-| Custom | 1,000 | 0 | 7,735 | 2.0 | 26.20 | 295.2 |
-| Chonkie Recursive | 1,000 | 0 | 7,157 | 2.0 | 20.39 | 351.0 |
-| Chonkie H2 | 1,000 | 0 | 7,028 | 2.0 | 25.71 | 273.4 |
-| Chonkie Table | 1,000 | 0 | 13,856 | 1.0 | 18.24 | 759.6 |
-| Chonkie Token | 1,000 | 0 | 6,132 | 2.0 | 10.26 | 597.5 |
-| Chonkie Sentence | 1,000 | 0 | 6,273 | 2.0 | 18.28 | 343.1 |
-| Chonkie Pipeline | 1,000 | 0 | 98,576 | 2.0 | 26.73 | 3687.2 |
+| Custom | 1,000 | 0 | 7,735 | 2.0 | 26.08 | 296.5 |
+| Chonkie Recursive | 1,000 | 0 | 7,157 | 2.0 | 20.34 | 351.9 |
+| Chonkie H2 | 1,000 | 0 | 7,028 | 2.0 | 25.51 | 275.5 |
+| Chonkie Table | 1,000 | 0 | 13,856 | 1.0 | 18.13 | 764.1 |
+| Chonkie Token | 1,000 | 0 | 6,132 | 2.0 | 10.24 | 599.1 |
+| Chonkie Sentence | 1,000 | 0 | 6,273 | 2.0 | 18.12 | 346.2 |
+| Chonkie Pipeline | 1,000 | 0 | 98,576 | 2.0 | 26.59 | 3706.9 |
+| Chonkie Pipeline Rev | 1,000 | 0 | 6,070 | 2.0 | 14.82 | 409.5 |
 
 ## Tokens por chunk
 
@@ -26,6 +27,7 @@ Límite de tokens por chunk: **800**
 | Chonkie Token | 744.3 | 800.0 | 800.0 | 800 | 0 (0.0%) |
 | Chonkie Sentence | 705.1 | 765.0 | 794.0 | 2,997 | 7 (0.7%) |
 | Chonkie Pipeline | 680.9 | 737.0 | 798.0 | 800 | 0 (0.0%) |
+| Chonkie Pipeline Rev | 696.6 | 761.0 | 798.0 | 800 | 0 (0.0%) |
 
 ## Distribución de patrones (chunker custom)
 
@@ -44,7 +46,8 @@ Límite de tokens por chunk: **800**
 - Chonkie TableChunker detecta tablas en el documento y repite automáticamente el encabezado del documento en cada chunk.
 - Chonkie TokenChunker y SentenceChunker tienen `chunk_overlap` integrado y garantizan respetar el límite de tokens.
 - Chonkie Pipeline encadena TableChunker y RecursiveChunker para manejar documentos mixtos.
-- El contador de tokens es el mismo para los siete (tokenizer de `pplx-embed-context-v1-0.6b`) para hacer la comparación justa.
+- Chonkie Pipeline Rev hace lo inverso: RecursiveChunker primero y TableChunker solo sobre los fragmentos que contienen tablas válidas.
+- El contador de tokens es el mismo para los ocho (tokenizer de `pplx-embed-context-v1-0.6b`) para hacer la comparación justa.
 
 ## Conclusión provisional
 
@@ -55,4 +58,5 @@ Límite de tokens por chunk: **800**
 - **Chonkie Token**: 6,132 chunks (mediana 800 tokens), 0 archivos oversized; máx 800 tokens.
 - **Chonkie Sentence**: 6,273 chunks (mediana 765 tokens), 7 archivos oversized; máx 2,997 tokens.
 - **Chonkie Pipeline**: 98,576 chunks (mediana 737 tokens), 0 archivos oversized; máx 800 tokens. El pipeline explota el número de chunks en documentos con muchas tablas porque TableChunker divide en cada límite de tabla y RecursiveChunker vuelve a partir cada fragmento.
-- El custom es más adecuado para el DOF porque respeta la estructura documental (H2s, tablas, negritas) y genera chunks recuperables; entre las opciones de Chonkie, RecursiveChunker es la más estable para markdown general, mientras que TokenChunker/SentenceChunker son las más seguras para límites estrictos. El Pipeline table+recursive no es recomendable para este corpus.
+- **Chonkie Pipeline Rev**: 6,070 chunks (mediana 761 tokens), 0 archivos oversized; máx 800 tokens.
+- El custom es más adecuado para el DOF porque respeta la estructura documental (H2s, tablas, negritas) y genera chunks recuperables; entre las opciones de Chonkie, RecursiveChunker es la más estable para markdown general, mientras que TokenChunker/SentenceChunker son las más seguras para límites estrictos. El Pipeline table+recursive no es recomendable para este corpus; el Pipeline recursivo+table es mejor pero aún puede partir tablas.

--- a/reports/chunker_comparison.md
+++ b/reports/chunker_comparison.md
@@ -7,25 +7,25 @@ Límite de tokens por chunk: **800**
 
 | Chunker | Archivos | Errores | Chunks total | Chunks/archivo (med) | Tiempo (s) | Chunks/s |
 |---|---|---|---|---|---|---|
-| Custom | 1,000 | 0 | 25,779 | 1.0 | 28.50 | 904.6 |
-| Chonkie Recursive | 992 | 8 | 6,540 | 2.0 | 19.66 | 332.7 |
+| Custom | 1,000 | 0 | 26,636 | 2.0 | 27.56 | 966.4 |
+| Chonkie Recursive | 1,000 | 0 | 7,157 | 2.0 | 20.12 | 355.8 |
 
 ## Tokens por chunk
 
 | Chunker | Media | Mediana | P95 | Máx | Archivos con chunks >10% over max |
 |---|---|---|---|---|---|
-| Custom | 172.8 | 35.0 | 794.0 | 2,986 | 291 (29.1%) |
-| Chonkie Recursive | 599.0 | 703.5 | 796.0 | 800 | 0 (0.0%) |
+| Custom | 165.0 | 36.0 | 775.0 | 853 | 0 (0.0%) |
+| Chonkie Recursive | 601.9 | 707.0 | 796.0 | 800 | 0 (0.0%) |
 
 ## Distribución de patrones (chunker custom)
 
 | Patrón | Archivos | Chunks/archivo (media) |
 |---|---|---|
-| bold_headers | 113 | 10.5 |
-| giant_table | 110 | 205.6 |
-| h2_compound | 33 | 34.0 |
-| plain_text | 19 | 6.8 |
-| small | 725 | 1.0 |
+| bold_headers | 248 | 6.4 |
+| giant_table | 123 | 186.1 |
+| h2_compound | 39 | 31.7 |
+| plain_text | 32 | 5.6 |
+| small | 558 | 1.3 |
 
 ## Observaciones
 
@@ -35,6 +35,6 @@ Límite de tokens por chunk: **800**
 
 ## Conclusión provisional
 
-- **Custom**: chunks más pequeños (mediana 35 tokens) pero 291 archivos (29.1%) con chunks que exceden el límite. Máximo observado: 2,986 tokens.
-- **Chonkie Recursive**: respeta el límite en todos los casos (máx 800), chunks más grandes (mediana 704 tokens), y 8 errores.
-- El custom es más adecuado para el DOF por su granularidad y preservación de estructura, pero se debe trabajar en acotar los chunks oversized (especialmente tablas gigantes y documentos justo por debajo del umbral `small`).
+- **Custom**: chunks más pequeños y granulares (mediana 36 tokens), 0 archivos con chunks que exceden el límite. Máximo observado: 853 tokens.
+- **Chonkie Recursive**: chunks más grandes (mediana 707 tokens), máx 800, 0 errores.
+- El custom es más adecuado para el DOF porque respeta la estructura documental (H2s, tablas, negritas) y produce chunks más recuperables; Chonkie es una buena línea base genérica pero no distingue patrones del DOF.

--- a/reports/chunker_comparison.md
+++ b/reports/chunker_comparison.md
@@ -7,10 +7,12 @@ Límite de tokens por chunk: **800**
 
 | Chunker | Archivos | Errores | Chunks total | Chunks/archivo (med) | Tiempo (s) | Chunks/s |
 |---|---|---|---|---|---|---|
-| Custom | 1,000 | 0 | 7,735 | 2.0 | 25.96 | 297.9 |
-| Chonkie Recursive | 1,000 | 0 | 7,157 | 2.0 | 20.63 | 347.0 |
-| Chonkie H2 | 1,000 | 0 | 7,028 | 2.0 | 25.84 | 272.0 |
-| Chonkie Table | 1,000 | 0 | 13,856 | 1.0 | 18.14 | 763.9 |
+| Custom | 1,000 | 0 | 7,735 | 2.0 | 26.31 | 293.9 |
+| Chonkie Recursive | 1,000 | 0 | 7,157 | 2.0 | 20.35 | 351.8 |
+| Chonkie H2 | 1,000 | 0 | 7,028 | 2.0 | 25.44 | 276.2 |
+| Chonkie Table | 1,000 | 0 | 13,856 | 1.0 | 18.17 | 762.5 |
+| Chonkie Token | 1,000 | 0 | 6,132 | 2.0 | 10.30 | 595.5 |
+| Chonkie Sentence | 1,000 | 0 | 6,273 | 2.0 | 18.21 | 344.6 |
 
 ## Tokens por chunk
 
@@ -20,6 +22,8 @@ Límite de tokens por chunk: **800**
 | Chonkie Recursive | 601.9 | 707.0 | 796.0 | 800 | 0 (0.0%) |
 | Chonkie H2 | 615.0 | 702.0 | 798.0 | 7,895 | 47 (4.7%) |
 | Chonkie Table | 4958.2 | 3633.5 | 12097.0 | 102,786 | 268 (26.8%) |
+| Chonkie Token | 744.3 | 800.0 | 800.0 | 800 | 0 (0.0%) |
+| Chonkie Sentence | 705.1 | 765.0 | 794.0 | 2,997 | 7 (0.7%) |
 
 ## Distribución de patrones (chunker custom)
 
@@ -36,7 +40,8 @@ Límite de tokens por chunk: **800**
 - El chunker custom clasifica el documento antes de dividir; Chonkie RecursiveChunker aplica una regla markdown genérica.
 - Chonkie H2 usa H2 como delimitador principal, lo que lo hace más comparable con el custom en documentos compuestos.
 - Chonkie TableChunker detecta tablas en el documento y repite automáticamente el encabezado del documento en cada chunk.
-- El contador de tokens es el mismo para los cuatro (tokenizer de `pplx-embed-context-v1-0.6b`) para hacer la comparación justa.
+- Chonkie TokenChunker y SentenceChunker tienen `chunk_overlap` integrado y garantizan respetar el límite de tokens.
+- El contador de tokens es el mismo para los seis (tokenizer de `pplx-embed-context-v1-0.6b`) para hacer la comparación justa.
 
 ## Conclusión provisional
 
@@ -44,4 +49,6 @@ Límite de tokens por chunk: **800**
 - **Chonkie Recursive**: chunks más grandes (mediana 707 tokens), máx 800, 0 errores.
 - **Chonkie H2**: 7,028 chunks (mediana 702 tokens), pero 47 archivos (4.7%) producen chunks que exceden el límite; máx 7,895 tokens.
 - **Chonkie Table**: 13,856 chunks (mediana 3634 tokens), pero 268 archivos (26.8%) producen chunks enormes; máx 102,786 tokens. TableChunker no respeta el límite de tokens en documentos con tablas grandes y genera chunks inmanejables para recuperación.
-- El custom es más adecuado para el DOF porque respeta la estructura documental (H2s, tablas, negritas) y genera chunks recuperables; entre las opciones de Chonkie, RecursiveChunker es la más estable.
+- **Chonkie Token**: 6,132 chunks (mediana 800 tokens), 0 archivos oversized; máx 800 tokens.
+- **Chonkie Sentence**: 6,273 chunks (mediana 765 tokens), 7 archivos oversized; máx 2,997 tokens.
+- El custom es más adecuado para el DOF porque respeta la estructura documental (H2s, tablas, negritas) y genera chunks recuperables; entre las opciones de Chonkie, RecursiveChunker es la más estable para markdown general, mientras que TokenChunker/SentenceChunker son las más seguras para límites estrictos.

--- a/reports/chunker_comparison.md
+++ b/reports/chunker_comparison.md
@@ -7,12 +7,13 @@ Límite de tokens por chunk: **800**
 
 | Chunker | Archivos | Errores | Chunks total | Chunks/archivo (med) | Tiempo (s) | Chunks/s |
 |---|---|---|---|---|---|---|
-| Custom | 1,000 | 0 | 7,735 | 2.0 | 26.31 | 293.9 |
-| Chonkie Recursive | 1,000 | 0 | 7,157 | 2.0 | 20.35 | 351.8 |
-| Chonkie H2 | 1,000 | 0 | 7,028 | 2.0 | 25.44 | 276.2 |
-| Chonkie Table | 1,000 | 0 | 13,856 | 1.0 | 18.17 | 762.5 |
-| Chonkie Token | 1,000 | 0 | 6,132 | 2.0 | 10.30 | 595.5 |
-| Chonkie Sentence | 1,000 | 0 | 6,273 | 2.0 | 18.21 | 344.6 |
+| Custom | 1,000 | 0 | 7,735 | 2.0 | 26.20 | 295.2 |
+| Chonkie Recursive | 1,000 | 0 | 7,157 | 2.0 | 20.39 | 351.0 |
+| Chonkie H2 | 1,000 | 0 | 7,028 | 2.0 | 25.71 | 273.4 |
+| Chonkie Table | 1,000 | 0 | 13,856 | 1.0 | 18.24 | 759.6 |
+| Chonkie Token | 1,000 | 0 | 6,132 | 2.0 | 10.26 | 597.5 |
+| Chonkie Sentence | 1,000 | 0 | 6,273 | 2.0 | 18.28 | 343.1 |
+| Chonkie Pipeline | 1,000 | 0 | 98,576 | 2.0 | 26.73 | 3687.2 |
 
 ## Tokens por chunk
 
@@ -24,6 +25,7 @@ Límite de tokens por chunk: **800**
 | Chonkie Table | 4958.2 | 3633.5 | 12097.0 | 102,786 | 268 (26.8%) |
 | Chonkie Token | 744.3 | 800.0 | 800.0 | 800 | 0 (0.0%) |
 | Chonkie Sentence | 705.1 | 765.0 | 794.0 | 2,997 | 7 (0.7%) |
+| Chonkie Pipeline | 680.9 | 737.0 | 798.0 | 800 | 0 (0.0%) |
 
 ## Distribución de patrones (chunker custom)
 
@@ -41,7 +43,8 @@ Límite de tokens por chunk: **800**
 - Chonkie H2 usa H2 como delimitador principal, lo que lo hace más comparable con el custom en documentos compuestos.
 - Chonkie TableChunker detecta tablas en el documento y repite automáticamente el encabezado del documento en cada chunk.
 - Chonkie TokenChunker y SentenceChunker tienen `chunk_overlap` integrado y garantizan respetar el límite de tokens.
-- El contador de tokens es el mismo para los seis (tokenizer de `pplx-embed-context-v1-0.6b`) para hacer la comparación justa.
+- Chonkie Pipeline encadena TableChunker y RecursiveChunker para manejar documentos mixtos.
+- El contador de tokens es el mismo para los siete (tokenizer de `pplx-embed-context-v1-0.6b`) para hacer la comparación justa.
 
 ## Conclusión provisional
 
@@ -51,4 +54,5 @@ Límite de tokens por chunk: **800**
 - **Chonkie Table**: 13,856 chunks (mediana 3634 tokens), pero 268 archivos (26.8%) producen chunks enormes; máx 102,786 tokens. TableChunker no respeta el límite de tokens en documentos con tablas grandes y genera chunks inmanejables para recuperación.
 - **Chonkie Token**: 6,132 chunks (mediana 800 tokens), 0 archivos oversized; máx 800 tokens.
 - **Chonkie Sentence**: 6,273 chunks (mediana 765 tokens), 7 archivos oversized; máx 2,997 tokens.
-- El custom es más adecuado para el DOF porque respeta la estructura documental (H2s, tablas, negritas) y genera chunks recuperables; entre las opciones de Chonkie, RecursiveChunker es la más estable para markdown general, mientras que TokenChunker/SentenceChunker son las más seguras para límites estrictos.
+- **Chonkie Pipeline**: 98,576 chunks (mediana 737 tokens), 0 archivos oversized; máx 800 tokens. El pipeline explota el número de chunks en documentos con muchas tablas porque TableChunker divide en cada límite de tabla y RecursiveChunker vuelve a partir cada fragmento.
+- El custom es más adecuado para el DOF porque respeta la estructura documental (H2s, tablas, negritas) y genera chunks recuperables; entre las opciones de Chonkie, RecursiveChunker es la más estable para markdown general, mientras que TokenChunker/SentenceChunker son las más seguras para límites estrictos. El Pipeline table+recursive no es recomendable para este corpus.

--- a/reports/chunker_comparison.md
+++ b/reports/chunker_comparison.md
@@ -7,8 +7,9 @@ Límite de tokens por chunk: **800**
 
 | Chunker | Archivos | Errores | Chunks total | Chunks/archivo (med) | Tiempo (s) | Chunks/s |
 |---|---|---|---|---|---|---|
-| Custom | 1,000 | 0 | 26,636 | 2.0 | 27.56 | 966.4 |
-| Chonkie Recursive | 1,000 | 0 | 7,157 | 2.0 | 20.12 | 355.8 |
+| Custom | 1,000 | 0 | 26,636 | 2.0 | 27.39 | 972.5 |
+| Chonkie Recursive | 1,000 | 0 | 7,157 | 2.0 | 20.31 | 352.4 |
+| Chonkie H2 | 1,000 | 0 | 7,028 | 2.0 | 25.37 | 277.0 |
 
 ## Tokens por chunk
 
@@ -16,6 +17,7 @@ Límite de tokens por chunk: **800**
 |---|---|---|---|---|---|
 | Custom | 165.0 | 36.0 | 775.0 | 853 | 0 (0.0%) |
 | Chonkie Recursive | 601.9 | 707.0 | 796.0 | 800 | 0 (0.0%) |
+| Chonkie H2 | 615.0 | 702.0 | 798.0 | 7,895 | 47 (4.7%) |
 
 ## Distribución de patrones (chunker custom)
 
@@ -30,11 +32,13 @@ Límite de tokens por chunk: **800**
 ## Observaciones
 
 - El chunker custom clasifica el documento antes de dividir; Chonkie RecursiveChunker aplica una regla markdown genérica.
-- El contador de tokens es el mismo para ambos (tokenizer de `pplx-embed-context-v1-0.6b`) para hacer la comparación justa.
+- Chonkie H2 usa H2 como delimitador principal, lo que lo hace más comparable con el custom en documentos compuestos.
+- El contador de tokens es el mismo para los tres (tokenizer de `pplx-embed-context-v1-0.6b`) para hacer la comparación justa.
 - Chonkie también ofrece `TableChunker` para documentos dominados por tablas; no se incluyó en esta comparación.
 
 ## Conclusión provisional
 
 - **Custom**: chunks más pequeños y granulares (mediana 36 tokens), 0 archivos con chunks que exceden el límite. Máximo observado: 853 tokens.
 - **Chonkie Recursive**: chunks más grandes (mediana 707 tokens), máx 800, 0 errores.
-- El custom es más adecuado para el DOF porque respeta la estructura documental (H2s, tablas, negritas) y produce chunks más recuperables; Chonkie es una buena línea base genérica pero no distingue patrones del DOF.
+- **Chonkie H2**: con H2 como delimitador principal genera 7,028 chunks (mediana 702 tokens), pero 47 archivos (4.7%) producen chunks que exceden el límite; máximo observado: 7,895 tokens. Esto pasa cuando una sección H2 es un párrafo o tabla gigante sin sub-delimitadores.
+- El custom es más adecuado para el DOF porque respeta la estructura documental (H2s, tablas, negritas), genera chunks más recuperables y no deja secciones completas sin partir.

--- a/reports/chunker_comparison.md
+++ b/reports/chunker_comparison.md
@@ -1,4 +1,4 @@
-# Comparación: chunker custom vs Chonkie RecursiveChunker
+# Comparación: chunker custom vs Chonkie chunkers
 
 Muestra: **1,000** archivos markdown de `./dof_md`
 Límite de tokens por chunk: **800**
@@ -7,24 +7,26 @@ Límite de tokens por chunk: **800**
 
 | Chunker | Archivos | Errores | Chunks total | Chunks/archivo (med) | Tiempo (s) | Chunks/s |
 |---|---|---|---|---|---|---|
-| Custom | 1,000 | 0 | 26,636 | 2.0 | 27.39 | 972.5 |
-| Chonkie Recursive | 1,000 | 0 | 7,157 | 2.0 | 20.31 | 352.4 |
-| Chonkie H2 | 1,000 | 0 | 7,028 | 2.0 | 25.37 | 277.0 |
+| Custom | 1,000 | 0 | 7,735 | 2.0 | 25.96 | 297.9 |
+| Chonkie Recursive | 1,000 | 0 | 7,157 | 2.0 | 20.63 | 347.0 |
+| Chonkie H2 | 1,000 | 0 | 7,028 | 2.0 | 25.84 | 272.0 |
+| Chonkie Table | 1,000 | 0 | 13,856 | 1.0 | 18.14 | 763.9 |
 
 ## Tokens por chunk
 
 | Chunker | Media | Mediana | P95 | Máx | Archivos con chunks >10% over max |
 |---|---|---|---|---|---|
-| Custom | 165.0 | 36.0 | 775.0 | 853 | 0 (0.0%) |
+| Custom | 568.2 | 706.0 | 798.0 | 879 | 0 (0.0%) |
 | Chonkie Recursive | 601.9 | 707.0 | 796.0 | 800 | 0 (0.0%) |
 | Chonkie H2 | 615.0 | 702.0 | 798.0 | 7,895 | 47 (4.7%) |
+| Chonkie Table | 4958.2 | 3633.5 | 12097.0 | 102,786 | 268 (26.8%) |
 
 ## Distribución de patrones (chunker custom)
 
 | Patrón | Archivos | Chunks/archivo (media) |
 |---|---|---|
 | bold_headers | 248 | 6.4 |
-| giant_table | 123 | 186.1 |
+| giant_table | 123 | 32.5 |
 | h2_compound | 39 | 31.7 |
 | plain_text | 32 | 5.6 |
 | small | 558 | 1.3 |
@@ -33,12 +35,13 @@ Límite de tokens por chunk: **800**
 
 - El chunker custom clasifica el documento antes de dividir; Chonkie RecursiveChunker aplica una regla markdown genérica.
 - Chonkie H2 usa H2 como delimitador principal, lo que lo hace más comparable con el custom en documentos compuestos.
-- El contador de tokens es el mismo para los tres (tokenizer de `pplx-embed-context-v1-0.6b`) para hacer la comparación justa.
-- Chonkie también ofrece `TableChunker` para documentos dominados por tablas; no se incluyó en esta comparación.
+- Chonkie TableChunker detecta tablas en el documento y repite automáticamente el encabezado del documento en cada chunk.
+- El contador de tokens es el mismo para los cuatro (tokenizer de `pplx-embed-context-v1-0.6b`) para hacer la comparación justa.
 
 ## Conclusión provisional
 
-- **Custom**: chunks más pequeños y granulares (mediana 36 tokens), 0 archivos con chunks que exceden el límite. Máximo observado: 853 tokens.
+- **Custom**: chunks más pequeños y granulares (mediana 706 tokens), 0 archivos con chunks que exceden el límite. Máximo observado: 879 tokens.
 - **Chonkie Recursive**: chunks más grandes (mediana 707 tokens), máx 800, 0 errores.
-- **Chonkie H2**: con H2 como delimitador principal genera 7,028 chunks (mediana 702 tokens), pero 47 archivos (4.7%) producen chunks que exceden el límite; máximo observado: 7,895 tokens. Esto pasa cuando una sección H2 es un párrafo o tabla gigante sin sub-delimitadores.
-- El custom es más adecuado para el DOF porque respeta la estructura documental (H2s, tablas, negritas), genera chunks más recuperables y no deja secciones completas sin partir.
+- **Chonkie H2**: 7,028 chunks (mediana 702 tokens), pero 47 archivos (4.7%) producen chunks que exceden el límite; máx 7,895 tokens.
+- **Chonkie Table**: 13,856 chunks (mediana 3634 tokens), pero 268 archivos (26.8%) producen chunks enormes; máx 102,786 tokens. TableChunker no respeta el límite de tokens en documentos con tablas grandes y genera chunks inmanejables para recuperación.
+- El custom es más adecuado para el DOF porque respeta la estructura documental (H2s, tablas, negritas) y genera chunks recuperables; entre las opciones de Chonkie, RecursiveChunker es la más estable.

--- a/scripts/compare_chunkers.py
+++ b/scripts/compare_chunkers.py
@@ -14,7 +14,13 @@ from collections import defaultdict
 from pathlib import Path
 from random import sample, seed
 
-from chonkie import RecursiveChunker, SentenceChunker, TableChunker, TokenChunker
+from chonkie import (
+    Pipeline,
+    RecursiveChunker,
+    SentenceChunker,
+    TableChunker,
+    TokenChunker,
+)
 from chonkie.tokenizer import Tokenizer
 from chonkie.types import RecursiveLevel, RecursiveRules
 
@@ -276,6 +282,42 @@ def _run_chonkie_sentence(files: list[Path]) -> dict:
     return _summarize(results, elapsed, "chonkie_sentence")
 
 
+def _run_chonkie_pipeline(files: list[Path]) -> dict:
+    """Chonkie Pipeline: TableChunker followed by RecursiveChunker."""
+    results: dict = {
+        "chunks": [],
+        "tokens": [],
+        "errors": [],
+        "files_with_oversized": [],
+    }
+    tokenizer = PPLXTokenizer()
+    pipeline = (
+        Pipeline()
+        .chunk_with("table", chunk_size=MAX_TOKENS * 2, tokenizer=tokenizer)
+        .chunk_with("recursive", chunk_size=MAX_TOKENS, tokenizer=tokenizer)
+    )
+    start = time.perf_counter()
+
+    for f in files:
+        text = f.read_text(encoding="utf-8", errors="replace")
+        try:
+            docs = pipeline.run(texts=[text])
+            chunks = docs[0].chunks if docs else []
+        except Exception as exc:
+            results["errors"].append((str(f), str(exc)))
+            continue
+
+        tokens = [c.token_count for c in chunks]
+        results["chunks"].append(len(chunks))
+        results["tokens"].extend(tokens)
+        results["files_with_oversized"].append(
+            1 if any(t > MAX_TOKENS * 1.10 for t in tokens) else 0
+        )
+
+    elapsed = time.perf_counter() - start
+    return _summarize(results, elapsed, "chonkie_pipeline")
+
+
 def _summarize(results: dict, elapsed: float, label: str) -> dict:
     chunks_per_file = results.get("chunks", [])
     tokens = results.get("tokens", [])
@@ -320,7 +362,7 @@ def _safe_percentile(values: list, percentile: int) -> float:
     return s[min(idx, len(s) - 1)]
 
 
-def _format_report(custom: dict, recursive: dict, h2: dict, table: dict, token: dict, sentence: dict) -> str:
+def _format_report(custom: dict, recursive: dict, h2: dict, table: dict, token: dict, sentence: dict, pipeline: dict) -> str:
     lines = [
         "# Comparación: chunker custom vs Chonkie chunkers",
         "",
@@ -337,6 +379,7 @@ def _format_report(custom: dict, recursive: dict, h2: dict, table: dict, token: 
         f"| Chonkie Table | {table['files']:,} | {table['errors']} | {table['total_chunks']:,} | {table['chunks_per_file']['median']:.1f} | {table['elapsed_seconds']:.2f} | {table['chunks_per_second']:.1f} |",
         f"| Chonkie Token | {token['files']:,} | {token['errors']} | {token['total_chunks']:,} | {token['chunks_per_file']['median']:.1f} | {token['elapsed_seconds']:.2f} | {token['chunks_per_second']:.1f} |",
         f"| Chonkie Sentence | {sentence['files']:,} | {sentence['errors']} | {sentence['total_chunks']:,} | {sentence['chunks_per_file']['median']:.1f} | {sentence['elapsed_seconds']:.2f} | {sentence['chunks_per_second']:.1f} |",
+        f"| Chonkie Pipeline | {pipeline['files']:,} | {pipeline['errors']} | {pipeline['total_chunks']:,} | {pipeline['chunks_per_file']['median']:.1f} | {pipeline['elapsed_seconds']:.2f} | {pipeline['chunks_per_second']:.1f} |",
         "",
         "## Tokens por chunk",
         "",
@@ -348,6 +391,7 @@ def _format_report(custom: dict, recursive: dict, h2: dict, table: dict, token: 
         f"| Chonkie Table | {table['tokens_per_chunk']['mean']:.1f} | {table['tokens_per_chunk']['median']:.1f} | {table['tokens_per_chunk']['p95']:.1f} | {table['tokens_per_chunk']['max']:,} | {table['oversized_files']} ({table['oversized_pct']:.1f}%) |",
         f"| Chonkie Token | {token['tokens_per_chunk']['mean']:.1f} | {token['tokens_per_chunk']['median']:.1f} | {token['tokens_per_chunk']['p95']:.1f} | {token['tokens_per_chunk']['max']:,} | {token['oversized_files']} ({token['oversized_pct']:.1f}%) |",
         f"| Chonkie Sentence | {sentence['tokens_per_chunk']['mean']:.1f} | {sentence['tokens_per_chunk']['median']:.1f} | {sentence['tokens_per_chunk']['p95']:.1f} | {sentence['tokens_per_chunk']['max']:,} | {sentence['oversized_files']} ({sentence['oversized_pct']:.1f}%) |",
+        f"| Chonkie Pipeline | {pipeline['tokens_per_chunk']['mean']:.1f} | {pipeline['tokens_per_chunk']['median']:.1f} | {pipeline['tokens_per_chunk']['p95']:.1f} | {pipeline['tokens_per_chunk']['max']:,} | {pipeline['oversized_files']} ({pipeline['oversized_pct']:.1f}%) |",
         "",
         "## Distribución de patrones (chunker custom)",
         "",
@@ -366,7 +410,8 @@ def _format_report(custom: dict, recursive: dict, h2: dict, table: dict, token: 
         "- Chonkie H2 usa H2 como delimitador principal, lo que lo hace más comparable con el custom en documentos compuestos.",
         "- Chonkie TableChunker detecta tablas en el documento y repite automáticamente el encabezado del documento en cada chunk.",
         "- Chonkie TokenChunker y SentenceChunker tienen `chunk_overlap` integrado y garantizan respetar el límite de tokens.",
-        "- El contador de tokens es el mismo para los seis (tokenizer de `pplx-embed-context-v1-0.6b`) para hacer la comparación justa.",
+        "- Chonkie Pipeline encadena TableChunker y RecursiveChunker para manejar documentos mixtos.",
+        "- El contador de tokens es el mismo para los siete (tokenizer de `pplx-embed-context-v1-0.6b`) para hacer la comparación justa.",
         "",
         "## Conclusión provisional",
         "",
@@ -376,7 +421,8 @@ def _format_report(custom: dict, recursive: dict, h2: dict, table: dict, token: 
         f"- **Chonkie Table**: {table['total_chunks']:,} chunks (mediana {table['tokens_per_chunk']['median']:.0f} tokens), pero {table['oversized_files']} archivos ({table['oversized_pct']:.1f}%) producen chunks enormes; máx {table['tokens_per_chunk']['max']:,} tokens. TableChunker no respeta el límite de tokens en documentos con tablas grandes y genera chunks inmanejables para recuperación.",
         f"- **Chonkie Token**: {token['total_chunks']:,} chunks (mediana {token['tokens_per_chunk']['median']:.0f} tokens), {token['oversized_files']} archivos oversized; máx {token['tokens_per_chunk']['max']:,} tokens.",
         f"- **Chonkie Sentence**: {sentence['total_chunks']:,} chunks (mediana {sentence['tokens_per_chunk']['median']:.0f} tokens), {sentence['oversized_files']} archivos oversized; máx {sentence['tokens_per_chunk']['max']:,} tokens.",
-        "- El custom es más adecuado para el DOF porque respeta la estructura documental (H2s, tablas, negritas) y genera chunks recuperables; entre las opciones de Chonkie, RecursiveChunker es la más estable para markdown general, mientras que TokenChunker/SentenceChunker son las más seguras para límites estrictos.",
+        f"- **Chonkie Pipeline**: {pipeline['total_chunks']:,} chunks (mediana {pipeline['tokens_per_chunk']['median']:.0f} tokens), {pipeline['oversized_files']} archivos oversized; máx {pipeline['tokens_per_chunk']['max']:,} tokens. El pipeline explota el número de chunks en documentos con muchas tablas porque TableChunker divide en cada límite de tabla y RecursiveChunker vuelve a partir cada fragmento.",
+        "- El custom es más adecuado para el DOF porque respeta la estructura documental (H2s, tablas, negritas) y genera chunks recuperables; entre las opciones de Chonkie, RecursiveChunker es la más estable para markdown general, mientras que TokenChunker/SentenceChunker son las más seguras para límites estrictos. El Pipeline table+recursive no es recomendable para este corpus.",
         "",
     ])
     return "\n".join(lines)
@@ -415,10 +461,14 @@ def main() -> int:
     sentence = _run_chonkie_sentence(files)
     print(f"  {sentence['total_chunks']:,} chunks in {sentence['elapsed_seconds']:.2f}s")
 
+    print("Running Chonkie Pipeline (table + recursive)...")
+    pipeline = _run_chonkie_pipeline(files)
+    print(f"  {pipeline['total_chunks']:,} chunks in {pipeline['elapsed_seconds']:.2f}s")
+
     REPORT_DIR.mkdir(parents=True, exist_ok=True)
     report_path = REPORT_DIR / "chunker_comparison.md"
     report_path.write_text(
-        _format_report(custom, recursive, h2, table, token, sentence),
+        _format_report(custom, recursive, h2, table, token, sentence, pipeline),
         encoding="utf-8",
     )
     print(f"Report written to {report_path}")

--- a/scripts/compare_chunkers.py
+++ b/scripts/compare_chunkers.py
@@ -1,0 +1,225 @@
+"""Compare custom DOF chunker against Chonkie chunkers.
+
+Run from repo root:
+    python scripts/compare_chunkers.py
+
+Outputs a Markdown report to `reports/chunker_comparison.md`.
+"""
+from __future__ import annotations
+
+import statistics
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+from random import sample, seed
+
+from chonkie import RecursiveChunker
+from chonkie.types import RecursiveRules
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from rag_poc.chunker import (
+    _count_tokens,
+    classify,
+    split_file,
+)
+from rag_poc.config import MAX_TOKENS
+
+REPORT_DIR = Path("reports")
+SAMPLE_SIZE = 1_000
+SEED = 42
+
+
+def _sample_files(root: Path, n: int) -> list[Path]:
+    seed(SEED)
+    all_files = list(root.rglob("*.md"))
+    if len(all_files) <= n:
+        return all_files
+    return sorted(sample(all_files, n))
+
+
+def _run_custom(files: list[Path]) -> dict:
+    results: dict = {
+        "chunks": [],
+        "tokens": [],
+        "errors": [],
+        "files_with_oversized": [],
+        "pattern_counts": defaultdict(int),
+        "pattern_chunks": defaultdict(list),
+    }
+    start = time.perf_counter()
+
+    for f in files:
+        text = f.read_text(encoding="utf-8", errors="replace")
+        size = f.stat().st_size
+        pattern = classify(text, size)
+        try:
+            chunks = split_file(f)
+        except Exception as exc:
+            results["errors"].append((str(f), str(exc)))
+            continue
+
+        tokens = [_count_tokens(c.text) for c in chunks]
+        results["chunks"].append(len(chunks))
+        results["tokens"].extend(tokens)
+        results["pattern_counts"][pattern.value] += 1
+        results["pattern_chunks"][pattern.value].append(len(chunks))
+        results["files_with_oversized"].append(
+            1 if any(t > MAX_TOKENS * 1.10 for t in tokens) else 0
+        )
+
+    elapsed = time.perf_counter() - start
+    return _summarize(results, elapsed, "custom")
+
+
+def _run_chonkie_recursive(files: list[Path]) -> dict:
+    results: dict = {
+        "chunks": [],
+        "tokens": [],
+        "errors": [],
+        "files_with_oversized": [],
+    }
+    chunker = RecursiveChunker(
+        tokenizer=_count_tokens,
+        chunk_size=MAX_TOKENS,
+        rules=RecursiveRules.from_recipe("markdown"),
+    )
+    start = time.perf_counter()
+
+    for f in files:
+        text = f.read_text(encoding="utf-8", errors="replace")
+        try:
+            chunks = chunker(text)
+        except Exception as exc:
+            results["errors"].append((str(f), str(exc)))
+            continue
+
+        tokens = [c.token_count for c in chunks]
+        results["chunks"].append(len(chunks))
+        results["tokens"].extend(tokens)
+        results["files_with_oversized"].append(
+            1 if any(t > MAX_TOKENS * 1.10 for t in tokens) else 0
+        )
+
+    elapsed = time.perf_counter() - start
+    return _summarize(results, elapsed, "chonkie_recursive")
+
+
+def _summarize(results: dict, elapsed: float, label: str) -> dict:
+    chunks_per_file = results.get("chunks", [])
+    tokens = results.get("tokens", [])
+    oversized = results.get("files_with_oversized", [])
+
+    return {
+        "label": label,
+        "files": len(chunks_per_file),
+        "errors": len(results.get("errors", [])),
+        "total_chunks": sum(chunks_per_file),
+        "chunks_per_file": {
+            "mean": _safe_mean(chunks_per_file),
+            "median": _safe_median(chunks_per_file),
+            "max": max(chunks_per_file) if chunks_per_file else 0,
+        },
+        "tokens_per_chunk": {
+            "mean": _safe_mean(tokens),
+            "median": _safe_median(tokens),
+            "max": max(tokens) if tokens else 0,
+            "p95": _safe_percentile(tokens, 95) if tokens else 0,
+        },
+        "oversized_files": sum(oversized),
+        "oversized_pct": sum(oversized) / len(oversized) * 100 if oversized else 0,
+        "elapsed_seconds": elapsed,
+        "chunks_per_second": sum(chunks_per_file) / elapsed if elapsed else 0,
+        "pattern_counts": dict(results.get("pattern_counts", {})),
+        "pattern_chunks": {k: _safe_mean(v) for k, v in results.get("pattern_chunks", {}).items()},
+    }
+
+
+def _safe_mean(values: list) -> float:
+    return statistics.mean(values) if values else 0.0
+
+
+def _safe_median(values: list) -> float:
+    return statistics.median(values) if values else 0.0
+
+
+def _safe_percentile(values: list, percentile: int) -> float:
+    s = sorted(values)
+    idx = int(len(s) * percentile / 100)
+    return s[min(idx, len(s) - 1)]
+
+
+def _format_report(custom: dict, recursive: dict) -> str:
+    lines = [
+        "# Comparación: chunker custom vs Chonkie RecursiveChunker",
+        "",
+        f"Muestra: **{SAMPLE_SIZE:,}** archivos markdown de `./dof_md`",
+        f"Límite de tokens por chunk: **{MAX_TOKENS}**",
+        "",
+        "## Resumen general",
+        "",
+        "| Chunker | Archivos | Errores | Chunks total | Chunks/archivo (med) | Tiempo (s) | Chunks/s |",
+        "|---|---|---|---|---|---|---|",
+        f"| Custom | {custom['files']:,} | {custom['errors']} | {custom['total_chunks']:,} | {custom['chunks_per_file']['median']:.1f} | {custom['elapsed_seconds']:.2f} | {custom['chunks_per_second']:.1f} |",
+        f"| Chonkie Recursive | {recursive['files']:,} | {recursive['errors']} | {recursive['total_chunks']:,} | {recursive['chunks_per_file']['median']:.1f} | {recursive['elapsed_seconds']:.2f} | {recursive['chunks_per_second']:.1f} |",
+        "",
+        "## Tokens por chunk",
+        "",
+        "| Chunker | Media | Mediana | P95 | Máx | Archivos con chunks >10% over max |",
+        "|---|---|---|---|---|---|",
+        f"| Custom | {custom['tokens_per_chunk']['mean']:.1f} | {custom['tokens_per_chunk']['median']:.1f} | {custom['tokens_per_chunk']['p95']:.1f} | {custom['tokens_per_chunk']['max']:,} | {custom['oversized_files']} ({custom['oversized_pct']:.1f}%) |",
+        f"| Chonkie Recursive | {recursive['tokens_per_chunk']['mean']:.1f} | {recursive['tokens_per_chunk']['median']:.1f} | {recursive['tokens_per_chunk']['p95']:.1f} | {recursive['tokens_per_chunk']['max']:,} | {recursive['oversized_files']} ({recursive['oversized_pct']:.1f}%) |",
+        "",
+        "## Distribución de patrones (chunker custom)",
+        "",
+        "| Patrón | Archivos | Chunks/archivo (media) |",
+        "|---|---|---|",
+    ]
+    for pattern, count in sorted(custom["pattern_counts"].items()):
+        mean_chunks = custom["pattern_chunks"].get(pattern, 0)
+        lines.append(f"| {pattern} | {count:,} | {mean_chunks:.1f} |")
+
+    lines.extend([
+        "",
+        "## Observaciones",
+        "",
+        "- El chunker custom clasifica el documento antes de dividir; Chonkie RecursiveChunker aplica una regla markdown genérica.",
+        "- El contador de tokens es el mismo para ambos (tokenizer de `pplx-embed-context-v1-0.6b`) para hacer la comparación justa.",
+        "- Chonkie también ofrece `TableChunker` para documentos dominados por tablas; no se incluyó en esta comparación.",
+        "",
+        "## Conclusión provisional",
+        "",
+        f"- **Custom**: chunks más pequeños (mediana {custom['tokens_per_chunk']['median']:.0f} tokens) pero {custom['oversized_files']} archivos ({custom['oversized_pct']:.1f}%) con chunks que exceden el límite. Máximo observado: {custom['tokens_per_chunk']['max']:,} tokens.",
+        f"- **Chonkie Recursive**: respeta el límite en todos los casos (máx {recursive['tokens_per_chunk']['max']:,}), chunks más grandes (mediana {recursive['tokens_per_chunk']['median']:.0f} tokens), y {recursive['errors']} errores.",
+        "- El custom es más adecuado para el DOF por su granularidad y preservación de estructura, pero se debe trabajar en acotar los chunks oversized (especialmente tablas gigantes y documentos justo por debajo del umbral `small`).",
+        "",
+    ])
+    return "\n".join(lines)
+
+
+def main() -> int:
+    root = Path("./dof_md")
+    if not root.exists():
+        print(f"ERROR: {root} does not exist", file=sys.stderr)
+        return 1
+
+    files = _sample_files(root, SAMPLE_SIZE)
+    print(f"Sampled {len(files):,} files from {root}")
+
+    print("Running custom chunker...")
+    custom = _run_custom(files)
+    print(f"  {custom['total_chunks']:,} chunks in {custom['elapsed_seconds']:.2f}s")
+
+    print("Running Chonkie RecursiveChunker...")
+    recursive = _run_chonkie_recursive(files)
+    print(f"  {recursive['total_chunks']:,} chunks in {recursive['elapsed_seconds']:.2f}s")
+
+    REPORT_DIR.mkdir(parents=True, exist_ok=True)
+    report_path = REPORT_DIR / "chunker_comparison.md"
+    report_path.write_text(_format_report(custom, recursive), encoding="utf-8")
+    print(f"Report written to {report_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/compare_chunkers.py
+++ b/scripts/compare_chunkers.py
@@ -14,7 +14,7 @@ from collections import defaultdict
 from pathlib import Path
 from random import sample, seed
 
-from chonkie import RecursiveChunker
+from chonkie import RecursiveChunker, TableChunker
 from chonkie.tokenizer import Tokenizer
 from chonkie.types import RecursiveLevel, RecursiveRules
 
@@ -175,6 +175,39 @@ def _run_chonkie_h2(files: list[Path]) -> dict:
     return _summarize(results, elapsed, "chonkie_h2")
 
 
+def _run_chonkie_table(files: list[Path]) -> dict:
+    """Chonkie TableChunker on the whole document."""
+    results: dict = {
+        "chunks": [],
+        "tokens": [],
+        "errors": [],
+        "files_with_oversized": [],
+    }
+    chunker = TableChunker(
+        tokenizer=PPLXTokenizer(),
+        chunk_size=MAX_TOKENS,
+    )
+    start = time.perf_counter()
+
+    for f in files:
+        text = f.read_text(encoding="utf-8", errors="replace")
+        try:
+            chunks = chunker(text)
+        except Exception as exc:
+            results["errors"].append((str(f), str(exc)))
+            continue
+
+        tokens = [c.token_count for c in chunks]
+        results["chunks"].append(len(chunks))
+        results["tokens"].extend(tokens)
+        results["files_with_oversized"].append(
+            1 if any(t > MAX_TOKENS * 1.10 for t in tokens) else 0
+        )
+
+    elapsed = time.perf_counter() - start
+    return _summarize(results, elapsed, "chonkie_table")
+
+
 def _summarize(results: dict, elapsed: float, label: str) -> dict:
     chunks_per_file = results.get("chunks", [])
     tokens = results.get("tokens", [])
@@ -219,9 +252,9 @@ def _safe_percentile(values: list, percentile: int) -> float:
     return s[min(idx, len(s) - 1)]
 
 
-def _format_report(custom: dict, recursive: dict, h2: dict) -> str:
+def _format_report(custom: dict, recursive: dict, h2: dict, table: dict) -> str:
     lines = [
-        "# Comparación: chunker custom vs Chonkie RecursiveChunker",
+        "# Comparación: chunker custom vs Chonkie chunkers",
         "",
         f"Muestra: **{SAMPLE_SIZE:,}** archivos markdown de `./dof_md`",
         f"Límite de tokens por chunk: **{MAX_TOKENS}**",
@@ -233,6 +266,7 @@ def _format_report(custom: dict, recursive: dict, h2: dict) -> str:
         f"| Custom | {custom['files']:,} | {custom['errors']} | {custom['total_chunks']:,} | {custom['chunks_per_file']['median']:.1f} | {custom['elapsed_seconds']:.2f} | {custom['chunks_per_second']:.1f} |",
         f"| Chonkie Recursive | {recursive['files']:,} | {recursive['errors']} | {recursive['total_chunks']:,} | {recursive['chunks_per_file']['median']:.1f} | {recursive['elapsed_seconds']:.2f} | {recursive['chunks_per_second']:.1f} |",
         f"| Chonkie H2 | {h2['files']:,} | {h2['errors']} | {h2['total_chunks']:,} | {h2['chunks_per_file']['median']:.1f} | {h2['elapsed_seconds']:.2f} | {h2['chunks_per_second']:.1f} |",
+        f"| Chonkie Table | {table['files']:,} | {table['errors']} | {table['total_chunks']:,} | {table['chunks_per_file']['median']:.1f} | {table['elapsed_seconds']:.2f} | {table['chunks_per_second']:.1f} |",
         "",
         "## Tokens por chunk",
         "",
@@ -241,6 +275,7 @@ def _format_report(custom: dict, recursive: dict, h2: dict) -> str:
         f"| Custom | {custom['tokens_per_chunk']['mean']:.1f} | {custom['tokens_per_chunk']['median']:.1f} | {custom['tokens_per_chunk']['p95']:.1f} | {custom['tokens_per_chunk']['max']:,} | {custom['oversized_files']} ({custom['oversized_pct']:.1f}%) |",
         f"| Chonkie Recursive | {recursive['tokens_per_chunk']['mean']:.1f} | {recursive['tokens_per_chunk']['median']:.1f} | {recursive['tokens_per_chunk']['p95']:.1f} | {recursive['tokens_per_chunk']['max']:,} | {recursive['oversized_files']} ({recursive['oversized_pct']:.1f}%) |",
         f"| Chonkie H2 | {h2['tokens_per_chunk']['mean']:.1f} | {h2['tokens_per_chunk']['median']:.1f} | {h2['tokens_per_chunk']['p95']:.1f} | {h2['tokens_per_chunk']['max']:,} | {h2['oversized_files']} ({h2['oversized_pct']:.1f}%) |",
+        f"| Chonkie Table | {table['tokens_per_chunk']['mean']:.1f} | {table['tokens_per_chunk']['median']:.1f} | {table['tokens_per_chunk']['p95']:.1f} | {table['tokens_per_chunk']['max']:,} | {table['oversized_files']} ({table['oversized_pct']:.1f}%) |",
         "",
         "## Distribución de patrones (chunker custom)",
         "",
@@ -257,15 +292,16 @@ def _format_report(custom: dict, recursive: dict, h2: dict) -> str:
         "",
         "- El chunker custom clasifica el documento antes de dividir; Chonkie RecursiveChunker aplica una regla markdown genérica.",
         "- Chonkie H2 usa H2 como delimitador principal, lo que lo hace más comparable con el custom en documentos compuestos.",
-        "- El contador de tokens es el mismo para los tres (tokenizer de `pplx-embed-context-v1-0.6b`) para hacer la comparación justa.",
-        "- Chonkie también ofrece `TableChunker` para documentos dominados por tablas; no se incluyó en esta comparación.",
+        "- Chonkie TableChunker detecta tablas en el documento y repite automáticamente el encabezado del documento en cada chunk.",
+        "- El contador de tokens es el mismo para los cuatro (tokenizer de `pplx-embed-context-v1-0.6b`) para hacer la comparación justa.",
         "",
         "## Conclusión provisional",
         "",
         f"- **Custom**: chunks más pequeños y granulares (mediana {custom['tokens_per_chunk']['median']:.0f} tokens), {custom['oversized_files']} archivos con chunks que exceden el límite. Máximo observado: {custom['tokens_per_chunk']['max']:,} tokens.",
         f"- **Chonkie Recursive**: chunks más grandes (mediana {recursive['tokens_per_chunk']['median']:.0f} tokens), máx {recursive['tokens_per_chunk']['max']:,}, {recursive['errors']} errores.",
-        f"- **Chonkie H2**: con H2 como delimitador principal genera {h2['total_chunks']:,} chunks (mediana {h2['tokens_per_chunk']['median']:.0f} tokens), pero {h2['oversized_files']} archivos ({h2['oversized_pct']:.1f}%) producen chunks que exceden el límite; máximo observado: {h2['tokens_per_chunk']['max']:,} tokens. Esto pasa cuando una sección H2 es un párrafo o tabla gigante sin sub-delimitadores.",
-        "- El custom es más adecuado para el DOF porque respeta la estructura documental (H2s, tablas, negritas), genera chunks más recuperables y no deja secciones completas sin partir.",
+        f"- **Chonkie H2**: {h2['total_chunks']:,} chunks (mediana {h2['tokens_per_chunk']['median']:.0f} tokens), pero {h2['oversized_files']} archivos ({h2['oversized_pct']:.1f}%) producen chunks que exceden el límite; máx {h2['tokens_per_chunk']['max']:,} tokens.",
+        f"- **Chonkie Table**: {table['total_chunks']:,} chunks (mediana {table['tokens_per_chunk']['median']:.0f} tokens), pero {table['oversized_files']} archivos ({table['oversized_pct']:.1f}%) producen chunks enormes; máx {table['tokens_per_chunk']['max']:,} tokens. TableChunker no respeta el límite de tokens en documentos con tablas grandes y genera chunks inmanejables para recuperación.",
+        "- El custom es más adecuado para el DOF porque respeta la estructura documental (H2s, tablas, negritas) y genera chunks recuperables; entre las opciones de Chonkie, RecursiveChunker es la más estable.",
         "",
     ])
     return "\n".join(lines)
@@ -292,9 +328,13 @@ def main() -> int:
     h2 = _run_chonkie_h2(files)
     print(f"  {h2['total_chunks']:,} chunks in {h2['elapsed_seconds']:.2f}s")
 
+    print("Running Chonkie TableChunker...")
+    table = _run_chonkie_table(files)
+    print(f"  {table['total_chunks']:,} chunks in {table['elapsed_seconds']:.2f}s")
+
     REPORT_DIR.mkdir(parents=True, exist_ok=True)
     report_path = REPORT_DIR / "chunker_comparison.md"
-    report_path.write_text(_format_report(custom, recursive, h2), encoding="utf-8")
+    report_path.write_text(_format_report(custom, recursive, h2, table), encoding="utf-8")
     print(f"Report written to {report_path}")
     return 0
 

--- a/scripts/compare_chunkers.py
+++ b/scripts/compare_chunkers.py
@@ -14,7 +14,7 @@ from collections import defaultdict
 from pathlib import Path
 from random import sample, seed
 
-from chonkie import RecursiveChunker, TableChunker
+from chonkie import RecursiveChunker, SentenceChunker, TableChunker, TokenChunker
 from chonkie.tokenizer import Tokenizer
 from chonkie.types import RecursiveLevel, RecursiveRules
 
@@ -53,7 +53,7 @@ from rag_poc.chunker import (  # noqa: E402
     classify,
     split_file,
 )
-from rag_poc.config import MAX_TOKENS  # noqa: E402
+from rag_poc.config import MAX_TOKENS, OVERLAP_TOKENS  # noqa: E402
 
 REPORT_DIR = Path("reports")
 SAMPLE_SIZE = 1_000
@@ -208,6 +208,74 @@ def _run_chonkie_table(files: list[Path]) -> dict:
     return _summarize(results, elapsed, "chonkie_table")
 
 
+def _run_chonkie_token(files: list[Path]) -> dict:
+    """Chonkie TokenChunker with overlap."""
+    results: dict = {
+        "chunks": [],
+        "tokens": [],
+        "errors": [],
+        "files_with_oversized": [],
+    }
+    chunker = TokenChunker(
+        tokenizer=PPLXTokenizer(),
+        chunk_size=MAX_TOKENS,
+        chunk_overlap=OVERLAP_TOKENS,
+    )
+    start = time.perf_counter()
+
+    for f in files:
+        text = f.read_text(encoding="utf-8", errors="replace")
+        try:
+            chunks = chunker(text)
+        except Exception as exc:
+            results["errors"].append((str(f), str(exc)))
+            continue
+
+        tokens = [c.token_count for c in chunks]
+        results["chunks"].append(len(chunks))
+        results["tokens"].extend(tokens)
+        results["files_with_oversized"].append(
+            1 if any(t > MAX_TOKENS * 1.10 for t in tokens) else 0
+        )
+
+    elapsed = time.perf_counter() - start
+    return _summarize(results, elapsed, "chonkie_token")
+
+
+def _run_chonkie_sentence(files: list[Path]) -> dict:
+    """Chonkie SentenceChunker with overlap."""
+    results: dict = {
+        "chunks": [],
+        "tokens": [],
+        "errors": [],
+        "files_with_oversized": [],
+    }
+    chunker = SentenceChunker(
+        tokenizer=PPLXTokenizer(),
+        chunk_size=MAX_TOKENS,
+        chunk_overlap=OVERLAP_TOKENS,
+    )
+    start = time.perf_counter()
+
+    for f in files:
+        text = f.read_text(encoding="utf-8", errors="replace")
+        try:
+            chunks = chunker(text)
+        except Exception as exc:
+            results["errors"].append((str(f), str(exc)))
+            continue
+
+        tokens = [c.token_count for c in chunks]
+        results["chunks"].append(len(chunks))
+        results["tokens"].extend(tokens)
+        results["files_with_oversized"].append(
+            1 if any(t > MAX_TOKENS * 1.10 for t in tokens) else 0
+        )
+
+    elapsed = time.perf_counter() - start
+    return _summarize(results, elapsed, "chonkie_sentence")
+
+
 def _summarize(results: dict, elapsed: float, label: str) -> dict:
     chunks_per_file = results.get("chunks", [])
     tokens = results.get("tokens", [])
@@ -252,7 +320,7 @@ def _safe_percentile(values: list, percentile: int) -> float:
     return s[min(idx, len(s) - 1)]
 
 
-def _format_report(custom: dict, recursive: dict, h2: dict, table: dict) -> str:
+def _format_report(custom: dict, recursive: dict, h2: dict, table: dict, token: dict, sentence: dict) -> str:
     lines = [
         "# Comparación: chunker custom vs Chonkie chunkers",
         "",
@@ -267,6 +335,8 @@ def _format_report(custom: dict, recursive: dict, h2: dict, table: dict) -> str:
         f"| Chonkie Recursive | {recursive['files']:,} | {recursive['errors']} | {recursive['total_chunks']:,} | {recursive['chunks_per_file']['median']:.1f} | {recursive['elapsed_seconds']:.2f} | {recursive['chunks_per_second']:.1f} |",
         f"| Chonkie H2 | {h2['files']:,} | {h2['errors']} | {h2['total_chunks']:,} | {h2['chunks_per_file']['median']:.1f} | {h2['elapsed_seconds']:.2f} | {h2['chunks_per_second']:.1f} |",
         f"| Chonkie Table | {table['files']:,} | {table['errors']} | {table['total_chunks']:,} | {table['chunks_per_file']['median']:.1f} | {table['elapsed_seconds']:.2f} | {table['chunks_per_second']:.1f} |",
+        f"| Chonkie Token | {token['files']:,} | {token['errors']} | {token['total_chunks']:,} | {token['chunks_per_file']['median']:.1f} | {token['elapsed_seconds']:.2f} | {token['chunks_per_second']:.1f} |",
+        f"| Chonkie Sentence | {sentence['files']:,} | {sentence['errors']} | {sentence['total_chunks']:,} | {sentence['chunks_per_file']['median']:.1f} | {sentence['elapsed_seconds']:.2f} | {sentence['chunks_per_second']:.1f} |",
         "",
         "## Tokens por chunk",
         "",
@@ -276,6 +346,8 @@ def _format_report(custom: dict, recursive: dict, h2: dict, table: dict) -> str:
         f"| Chonkie Recursive | {recursive['tokens_per_chunk']['mean']:.1f} | {recursive['tokens_per_chunk']['median']:.1f} | {recursive['tokens_per_chunk']['p95']:.1f} | {recursive['tokens_per_chunk']['max']:,} | {recursive['oversized_files']} ({recursive['oversized_pct']:.1f}%) |",
         f"| Chonkie H2 | {h2['tokens_per_chunk']['mean']:.1f} | {h2['tokens_per_chunk']['median']:.1f} | {h2['tokens_per_chunk']['p95']:.1f} | {h2['tokens_per_chunk']['max']:,} | {h2['oversized_files']} ({h2['oversized_pct']:.1f}%) |",
         f"| Chonkie Table | {table['tokens_per_chunk']['mean']:.1f} | {table['tokens_per_chunk']['median']:.1f} | {table['tokens_per_chunk']['p95']:.1f} | {table['tokens_per_chunk']['max']:,} | {table['oversized_files']} ({table['oversized_pct']:.1f}%) |",
+        f"| Chonkie Token | {token['tokens_per_chunk']['mean']:.1f} | {token['tokens_per_chunk']['median']:.1f} | {token['tokens_per_chunk']['p95']:.1f} | {token['tokens_per_chunk']['max']:,} | {token['oversized_files']} ({token['oversized_pct']:.1f}%) |",
+        f"| Chonkie Sentence | {sentence['tokens_per_chunk']['mean']:.1f} | {sentence['tokens_per_chunk']['median']:.1f} | {sentence['tokens_per_chunk']['p95']:.1f} | {sentence['tokens_per_chunk']['max']:,} | {sentence['oversized_files']} ({sentence['oversized_pct']:.1f}%) |",
         "",
         "## Distribución de patrones (chunker custom)",
         "",
@@ -293,7 +365,8 @@ def _format_report(custom: dict, recursive: dict, h2: dict, table: dict) -> str:
         "- El chunker custom clasifica el documento antes de dividir; Chonkie RecursiveChunker aplica una regla markdown genérica.",
         "- Chonkie H2 usa H2 como delimitador principal, lo que lo hace más comparable con el custom en documentos compuestos.",
         "- Chonkie TableChunker detecta tablas en el documento y repite automáticamente el encabezado del documento en cada chunk.",
-        "- El contador de tokens es el mismo para los cuatro (tokenizer de `pplx-embed-context-v1-0.6b`) para hacer la comparación justa.",
+        "- Chonkie TokenChunker y SentenceChunker tienen `chunk_overlap` integrado y garantizan respetar el límite de tokens.",
+        "- El contador de tokens es el mismo para los seis (tokenizer de `pplx-embed-context-v1-0.6b`) para hacer la comparación justa.",
         "",
         "## Conclusión provisional",
         "",
@@ -301,7 +374,9 @@ def _format_report(custom: dict, recursive: dict, h2: dict, table: dict) -> str:
         f"- **Chonkie Recursive**: chunks más grandes (mediana {recursive['tokens_per_chunk']['median']:.0f} tokens), máx {recursive['tokens_per_chunk']['max']:,}, {recursive['errors']} errores.",
         f"- **Chonkie H2**: {h2['total_chunks']:,} chunks (mediana {h2['tokens_per_chunk']['median']:.0f} tokens), pero {h2['oversized_files']} archivos ({h2['oversized_pct']:.1f}%) producen chunks que exceden el límite; máx {h2['tokens_per_chunk']['max']:,} tokens.",
         f"- **Chonkie Table**: {table['total_chunks']:,} chunks (mediana {table['tokens_per_chunk']['median']:.0f} tokens), pero {table['oversized_files']} archivos ({table['oversized_pct']:.1f}%) producen chunks enormes; máx {table['tokens_per_chunk']['max']:,} tokens. TableChunker no respeta el límite de tokens en documentos con tablas grandes y genera chunks inmanejables para recuperación.",
-        "- El custom es más adecuado para el DOF porque respeta la estructura documental (H2s, tablas, negritas) y genera chunks recuperables; entre las opciones de Chonkie, RecursiveChunker es la más estable.",
+        f"- **Chonkie Token**: {token['total_chunks']:,} chunks (mediana {token['tokens_per_chunk']['median']:.0f} tokens), {token['oversized_files']} archivos oversized; máx {token['tokens_per_chunk']['max']:,} tokens.",
+        f"- **Chonkie Sentence**: {sentence['total_chunks']:,} chunks (mediana {sentence['tokens_per_chunk']['median']:.0f} tokens), {sentence['oversized_files']} archivos oversized; máx {sentence['tokens_per_chunk']['max']:,} tokens.",
+        "- El custom es más adecuado para el DOF porque respeta la estructura documental (H2s, tablas, negritas) y genera chunks recuperables; entre las opciones de Chonkie, RecursiveChunker es la más estable para markdown general, mientras que TokenChunker/SentenceChunker son las más seguras para límites estrictos.",
         "",
     ])
     return "\n".join(lines)
@@ -332,9 +407,20 @@ def main() -> int:
     table = _run_chonkie_table(files)
     print(f"  {table['total_chunks']:,} chunks in {table['elapsed_seconds']:.2f}s")
 
+    print("Running Chonkie TokenChunker...")
+    token = _run_chonkie_token(files)
+    print(f"  {token['total_chunks']:,} chunks in {token['elapsed_seconds']:.2f}s")
+
+    print("Running Chonkie SentenceChunker...")
+    sentence = _run_chonkie_sentence(files)
+    print(f"  {sentence['total_chunks']:,} chunks in {sentence['elapsed_seconds']:.2f}s")
+
     REPORT_DIR.mkdir(parents=True, exist_ok=True)
     report_path = REPORT_DIR / "chunker_comparison.md"
-    report_path.write_text(_format_report(custom, recursive, h2, table), encoding="utf-8")
+    report_path.write_text(
+        _format_report(custom, recursive, h2, table, token, sentence),
+        encoding="utf-8",
+    )
     print(f"Report written to {report_path}")
     return 0
 

--- a/scripts/compare_chunkers.py
+++ b/scripts/compare_chunkers.py
@@ -16,7 +16,7 @@ from random import sample, seed
 
 from chonkie import RecursiveChunker
 from chonkie.tokenizer import Tokenizer
-from chonkie.types import RecursiveRules
+from chonkie.types import RecursiveLevel, RecursiveRules
 
 
 class PPLXTokenizer(Tokenizer):
@@ -135,6 +135,46 @@ def _run_chonkie_recursive(files: list[Path]) -> dict:
     return _summarize(results, elapsed, "chonkie_recursive")
 
 
+def _run_chonkie_h2(files: list[Path]) -> dict:
+    """Chonkie RecursiveChunker with H2 as the primary delimiter."""
+    results: dict = {
+        "chunks": [],
+        "tokens": [],
+        "errors": [],
+        "files_with_oversized": [],
+    }
+    rules = RecursiveRules(levels=[
+        RecursiveLevel(delimiters=["\n## "]),
+        RecursiveLevel(delimiters=["\n### "]),
+        RecursiveLevel(delimiters=["\n\n"]),
+        RecursiveLevel(delimiters=[". ", "! ", "? "]),
+    ])
+    chunker = RecursiveChunker(
+        tokenizer=PPLXTokenizer(),
+        chunk_size=MAX_TOKENS,
+        rules=rules,
+    )
+    start = time.perf_counter()
+
+    for f in files:
+        text = f.read_text(encoding="utf-8", errors="replace")
+        try:
+            chunks = chunker(text)
+        except Exception as exc:
+            results["errors"].append((str(f), str(exc)))
+            continue
+
+        tokens = [c.token_count for c in chunks]
+        results["chunks"].append(len(chunks))
+        results["tokens"].extend(tokens)
+        results["files_with_oversized"].append(
+            1 if any(t > MAX_TOKENS * 1.10 for t in tokens) else 0
+        )
+
+    elapsed = time.perf_counter() - start
+    return _summarize(results, elapsed, "chonkie_h2")
+
+
 def _summarize(results: dict, elapsed: float, label: str) -> dict:
     chunks_per_file = results.get("chunks", [])
     tokens = results.get("tokens", [])
@@ -179,7 +219,7 @@ def _safe_percentile(values: list, percentile: int) -> float:
     return s[min(idx, len(s) - 1)]
 
 
-def _format_report(custom: dict, recursive: dict) -> str:
+def _format_report(custom: dict, recursive: dict, h2: dict) -> str:
     lines = [
         "# Comparación: chunker custom vs Chonkie RecursiveChunker",
         "",
@@ -192,6 +232,7 @@ def _format_report(custom: dict, recursive: dict) -> str:
         "|---|---|---|---|---|---|---|",
         f"| Custom | {custom['files']:,} | {custom['errors']} | {custom['total_chunks']:,} | {custom['chunks_per_file']['median']:.1f} | {custom['elapsed_seconds']:.2f} | {custom['chunks_per_second']:.1f} |",
         f"| Chonkie Recursive | {recursive['files']:,} | {recursive['errors']} | {recursive['total_chunks']:,} | {recursive['chunks_per_file']['median']:.1f} | {recursive['elapsed_seconds']:.2f} | {recursive['chunks_per_second']:.1f} |",
+        f"| Chonkie H2 | {h2['files']:,} | {h2['errors']} | {h2['total_chunks']:,} | {h2['chunks_per_file']['median']:.1f} | {h2['elapsed_seconds']:.2f} | {h2['chunks_per_second']:.1f} |",
         "",
         "## Tokens por chunk",
         "",
@@ -199,6 +240,7 @@ def _format_report(custom: dict, recursive: dict) -> str:
         "|---|---|---|---|---|---|",
         f"| Custom | {custom['tokens_per_chunk']['mean']:.1f} | {custom['tokens_per_chunk']['median']:.1f} | {custom['tokens_per_chunk']['p95']:.1f} | {custom['tokens_per_chunk']['max']:,} | {custom['oversized_files']} ({custom['oversized_pct']:.1f}%) |",
         f"| Chonkie Recursive | {recursive['tokens_per_chunk']['mean']:.1f} | {recursive['tokens_per_chunk']['median']:.1f} | {recursive['tokens_per_chunk']['p95']:.1f} | {recursive['tokens_per_chunk']['max']:,} | {recursive['oversized_files']} ({recursive['oversized_pct']:.1f}%) |",
+        f"| Chonkie H2 | {h2['tokens_per_chunk']['mean']:.1f} | {h2['tokens_per_chunk']['median']:.1f} | {h2['tokens_per_chunk']['p95']:.1f} | {h2['tokens_per_chunk']['max']:,} | {h2['oversized_files']} ({h2['oversized_pct']:.1f}%) |",
         "",
         "## Distribución de patrones (chunker custom)",
         "",
@@ -214,14 +256,16 @@ def _format_report(custom: dict, recursive: dict) -> str:
         "## Observaciones",
         "",
         "- El chunker custom clasifica el documento antes de dividir; Chonkie RecursiveChunker aplica una regla markdown genérica.",
-        "- El contador de tokens es el mismo para ambos (tokenizer de `pplx-embed-context-v1-0.6b`) para hacer la comparación justa.",
+        "- Chonkie H2 usa H2 como delimitador principal, lo que lo hace más comparable con el custom en documentos compuestos.",
+        "- El contador de tokens es el mismo para los tres (tokenizer de `pplx-embed-context-v1-0.6b`) para hacer la comparación justa.",
         "- Chonkie también ofrece `TableChunker` para documentos dominados por tablas; no se incluyó en esta comparación.",
         "",
         "## Conclusión provisional",
         "",
         f"- **Custom**: chunks más pequeños y granulares (mediana {custom['tokens_per_chunk']['median']:.0f} tokens), {custom['oversized_files']} archivos con chunks que exceden el límite. Máximo observado: {custom['tokens_per_chunk']['max']:,} tokens.",
         f"- **Chonkie Recursive**: chunks más grandes (mediana {recursive['tokens_per_chunk']['median']:.0f} tokens), máx {recursive['tokens_per_chunk']['max']:,}, {recursive['errors']} errores.",
-        "- El custom es más adecuado para el DOF porque respeta la estructura documental (H2s, tablas, negritas) y produce chunks más recuperables; Chonkie es una buena línea base genérica pero no distingue patrones del DOF.",
+        f"- **Chonkie H2**: con H2 como delimitador principal genera {h2['total_chunks']:,} chunks (mediana {h2['tokens_per_chunk']['median']:.0f} tokens), pero {h2['oversized_files']} archivos ({h2['oversized_pct']:.1f}%) producen chunks que exceden el límite; máximo observado: {h2['tokens_per_chunk']['max']:,} tokens. Esto pasa cuando una sección H2 es un párrafo o tabla gigante sin sub-delimitadores.",
+        "- El custom es más adecuado para el DOF porque respeta la estructura documental (H2s, tablas, negritas), genera chunks más recuperables y no deja secciones completas sin partir.",
         "",
     ])
     return "\n".join(lines)
@@ -244,9 +288,13 @@ def main() -> int:
     recursive = _run_chonkie_recursive(files)
     print(f"  {recursive['total_chunks']:,} chunks in {recursive['elapsed_seconds']:.2f}s")
 
+    print("Running Chonkie RecursiveChunker (H2 primary)...")
+    h2 = _run_chonkie_h2(files)
+    print(f"  {h2['total_chunks']:,} chunks in {h2['elapsed_seconds']:.2f}s")
+
     REPORT_DIR.mkdir(parents=True, exist_ok=True)
     report_path = REPORT_DIR / "chunker_comparison.md"
-    report_path.write_text(_format_report(custom, recursive), encoding="utf-8")
+    report_path.write_text(_format_report(custom, recursive, h2), encoding="utf-8")
     print(f"Report written to {report_path}")
     return 0
 

--- a/scripts/compare_chunkers.py
+++ b/scripts/compare_chunkers.py
@@ -15,15 +15,45 @@ from pathlib import Path
 from random import sample, seed
 
 from chonkie import RecursiveChunker
+from chonkie.tokenizer import Tokenizer
 from chonkie.types import RecursiveRules
 
+
+class PPLXTokenizer(Tokenizer):
+    """Chonkie-compatible wrapper around the pplx-embed-context-v1 tokenizer."""
+
+    def __init__(self, model_name: str = "perplexity-ai/pplx-embed-context-v1-0.6b"):
+        super().__init__()
+        from transformers import AutoTokenizer
+
+        self._model_name = model_name
+        self._tokenizer = AutoTokenizer.from_pretrained(
+            model_name,
+            trust_remote_code=True,
+        )
+
+    def __repr__(self) -> str:
+        return f"PPLXTokenizer(model={self._model_name!r})"
+
+    def encode(self, text: str) -> list[int]:
+        return self._tokenizer.encode(text, add_special_tokens=False)
+
+    def decode(self, tokens: list[int]) -> str:
+        return self._tokenizer.decode(tokens)
+
+    def tokenize(self, text: str) -> list[str]:
+        return self._tokenizer.tokenize(text)
+
+    def count_tokens(self, text: str) -> int:
+        return len(self.encode(text))
+
 sys.path.insert(0, str(Path(__file__).parent.parent))
-from rag_poc.chunker import (
+from rag_poc.chunker import (  # noqa: E402
     _count_tokens,
     classify,
     split_file,
 )
-from rag_poc.config import MAX_TOKENS
+from rag_poc.config import MAX_TOKENS  # noqa: E402
 
 REPORT_DIR = Path("reports")
 SAMPLE_SIZE = 1_000
@@ -80,7 +110,7 @@ def _run_chonkie_recursive(files: list[Path]) -> dict:
         "files_with_oversized": [],
     }
     chunker = RecursiveChunker(
-        tokenizer=_count_tokens,
+        tokenizer=PPLXTokenizer(),
         chunk_size=MAX_TOKENS,
         rules=RecursiveRules.from_recipe("markdown"),
     )
@@ -189,9 +219,9 @@ def _format_report(custom: dict, recursive: dict) -> str:
         "",
         "## Conclusión provisional",
         "",
-        f"- **Custom**: chunks más pequeños (mediana {custom['tokens_per_chunk']['median']:.0f} tokens) pero {custom['oversized_files']} archivos ({custom['oversized_pct']:.1f}%) con chunks que exceden el límite. Máximo observado: {custom['tokens_per_chunk']['max']:,} tokens.",
-        f"- **Chonkie Recursive**: respeta el límite en todos los casos (máx {recursive['tokens_per_chunk']['max']:,}), chunks más grandes (mediana {recursive['tokens_per_chunk']['median']:.0f} tokens), y {recursive['errors']} errores.",
-        "- El custom es más adecuado para el DOF por su granularidad y preservación de estructura, pero se debe trabajar en acotar los chunks oversized (especialmente tablas gigantes y documentos justo por debajo del umbral `small`).",
+        f"- **Custom**: chunks más pequeños y granulares (mediana {custom['tokens_per_chunk']['median']:.0f} tokens), {custom['oversized_files']} archivos con chunks que exceden el límite. Máximo observado: {custom['tokens_per_chunk']['max']:,} tokens.",
+        f"- **Chonkie Recursive**: chunks más grandes (mediana {recursive['tokens_per_chunk']['median']:.0f} tokens), máx {recursive['tokens_per_chunk']['max']:,}, {recursive['errors']} errores.",
+        "- El custom es más adecuado para el DOF porque respeta la estructura documental (H2s, tablas, negritas) y produce chunks más recuperables; Chonkie es una buena línea base genérica pero no distingue patrones del DOF.",
         "",
     ])
     return "\n".join(lines)

--- a/scripts/compare_chunkers.py
+++ b/scripts/compare_chunkers.py
@@ -318,6 +318,42 @@ def _run_chonkie_pipeline(files: list[Path]) -> dict:
     return _summarize(results, elapsed, "chonkie_pipeline")
 
 
+def _run_chonkie_pipeline_rev(files: list[Path]) -> dict:
+    """Chonkie Pipeline: RecursiveChunker followed by TableChunker."""
+    results: dict = {
+        "chunks": [],
+        "tokens": [],
+        "errors": [],
+        "files_with_oversized": [],
+    }
+    tokenizer = PPLXTokenizer()
+    pipeline = (
+        Pipeline()
+        .chunk_with("recursive", chunk_size=MAX_TOKENS, tokenizer=tokenizer)
+        .chunk_with("table", chunk_size=MAX_TOKENS, tokenizer=tokenizer)
+    )
+    start = time.perf_counter()
+
+    for f in files:
+        text = f.read_text(encoding="utf-8", errors="replace")
+        try:
+            docs = pipeline.run(texts=[text])
+            chunks = docs[0].chunks if docs else []
+        except Exception as exc:
+            results["errors"].append((str(f), str(exc)))
+            continue
+
+        tokens = [c.token_count for c in chunks]
+        results["chunks"].append(len(chunks))
+        results["tokens"].extend(tokens)
+        results["files_with_oversized"].append(
+            1 if any(t > MAX_TOKENS * 1.10 for t in tokens) else 0
+        )
+
+    elapsed = time.perf_counter() - start
+    return _summarize(results, elapsed, "chonkie_pipeline_rev")
+
+
 def _summarize(results: dict, elapsed: float, label: str) -> dict:
     chunks_per_file = results.get("chunks", [])
     tokens = results.get("tokens", [])
@@ -362,7 +398,7 @@ def _safe_percentile(values: list, percentile: int) -> float:
     return s[min(idx, len(s) - 1)]
 
 
-def _format_report(custom: dict, recursive: dict, h2: dict, table: dict, token: dict, sentence: dict, pipeline: dict) -> str:
+def _format_report(custom: dict, recursive: dict, h2: dict, table: dict, token: dict, sentence: dict, pipeline: dict, pipeline_rev: dict) -> str:
     lines = [
         "# Comparación: chunker custom vs Chonkie chunkers",
         "",
@@ -380,6 +416,7 @@ def _format_report(custom: dict, recursive: dict, h2: dict, table: dict, token: 
         f"| Chonkie Token | {token['files']:,} | {token['errors']} | {token['total_chunks']:,} | {token['chunks_per_file']['median']:.1f} | {token['elapsed_seconds']:.2f} | {token['chunks_per_second']:.1f} |",
         f"| Chonkie Sentence | {sentence['files']:,} | {sentence['errors']} | {sentence['total_chunks']:,} | {sentence['chunks_per_file']['median']:.1f} | {sentence['elapsed_seconds']:.2f} | {sentence['chunks_per_second']:.1f} |",
         f"| Chonkie Pipeline | {pipeline['files']:,} | {pipeline['errors']} | {pipeline['total_chunks']:,} | {pipeline['chunks_per_file']['median']:.1f} | {pipeline['elapsed_seconds']:.2f} | {pipeline['chunks_per_second']:.1f} |",
+        f"| Chonkie Pipeline Rev | {pipeline_rev['files']:,} | {pipeline_rev['errors']} | {pipeline_rev['total_chunks']:,} | {pipeline_rev['chunks_per_file']['median']:.1f} | {pipeline_rev['elapsed_seconds']:.2f} | {pipeline_rev['chunks_per_second']:.1f} |",
         "",
         "## Tokens por chunk",
         "",
@@ -392,6 +429,7 @@ def _format_report(custom: dict, recursive: dict, h2: dict, table: dict, token: 
         f"| Chonkie Token | {token['tokens_per_chunk']['mean']:.1f} | {token['tokens_per_chunk']['median']:.1f} | {token['tokens_per_chunk']['p95']:.1f} | {token['tokens_per_chunk']['max']:,} | {token['oversized_files']} ({token['oversized_pct']:.1f}%) |",
         f"| Chonkie Sentence | {sentence['tokens_per_chunk']['mean']:.1f} | {sentence['tokens_per_chunk']['median']:.1f} | {sentence['tokens_per_chunk']['p95']:.1f} | {sentence['tokens_per_chunk']['max']:,} | {sentence['oversized_files']} ({sentence['oversized_pct']:.1f}%) |",
         f"| Chonkie Pipeline | {pipeline['tokens_per_chunk']['mean']:.1f} | {pipeline['tokens_per_chunk']['median']:.1f} | {pipeline['tokens_per_chunk']['p95']:.1f} | {pipeline['tokens_per_chunk']['max']:,} | {pipeline['oversized_files']} ({pipeline['oversized_pct']:.1f}%) |",
+        f"| Chonkie Pipeline Rev | {pipeline_rev['tokens_per_chunk']['mean']:.1f} | {pipeline_rev['tokens_per_chunk']['median']:.1f} | {pipeline_rev['tokens_per_chunk']['p95']:.1f} | {pipeline_rev['tokens_per_chunk']['max']:,} | {pipeline_rev['oversized_files']} ({pipeline_rev['oversized_pct']:.1f}%) |",
         "",
         "## Distribución de patrones (chunker custom)",
         "",
@@ -411,7 +449,8 @@ def _format_report(custom: dict, recursive: dict, h2: dict, table: dict, token: 
         "- Chonkie TableChunker detecta tablas en el documento y repite automáticamente el encabezado del documento en cada chunk.",
         "- Chonkie TokenChunker y SentenceChunker tienen `chunk_overlap` integrado y garantizan respetar el límite de tokens.",
         "- Chonkie Pipeline encadena TableChunker y RecursiveChunker para manejar documentos mixtos.",
-        "- El contador de tokens es el mismo para los siete (tokenizer de `pplx-embed-context-v1-0.6b`) para hacer la comparación justa.",
+        "- Chonkie Pipeline Rev hace lo inverso: RecursiveChunker primero y TableChunker solo sobre los fragmentos que contienen tablas válidas.",
+        "- El contador de tokens es el mismo para los ocho (tokenizer de `pplx-embed-context-v1-0.6b`) para hacer la comparación justa.",
         "",
         "## Conclusión provisional",
         "",
@@ -422,7 +461,8 @@ def _format_report(custom: dict, recursive: dict, h2: dict, table: dict, token: 
         f"- **Chonkie Token**: {token['total_chunks']:,} chunks (mediana {token['tokens_per_chunk']['median']:.0f} tokens), {token['oversized_files']} archivos oversized; máx {token['tokens_per_chunk']['max']:,} tokens.",
         f"- **Chonkie Sentence**: {sentence['total_chunks']:,} chunks (mediana {sentence['tokens_per_chunk']['median']:.0f} tokens), {sentence['oversized_files']} archivos oversized; máx {sentence['tokens_per_chunk']['max']:,} tokens.",
         f"- **Chonkie Pipeline**: {pipeline['total_chunks']:,} chunks (mediana {pipeline['tokens_per_chunk']['median']:.0f} tokens), {pipeline['oversized_files']} archivos oversized; máx {pipeline['tokens_per_chunk']['max']:,} tokens. El pipeline explota el número de chunks en documentos con muchas tablas porque TableChunker divide en cada límite de tabla y RecursiveChunker vuelve a partir cada fragmento.",
-        "- El custom es más adecuado para el DOF porque respeta la estructura documental (H2s, tablas, negritas) y genera chunks recuperables; entre las opciones de Chonkie, RecursiveChunker es la más estable para markdown general, mientras que TokenChunker/SentenceChunker son las más seguras para límites estrictos. El Pipeline table+recursive no es recomendable para este corpus.",
+        f"- **Chonkie Pipeline Rev**: {pipeline_rev['total_chunks']:,} chunks (mediana {pipeline_rev['tokens_per_chunk']['median']:.0f} tokens), {pipeline_rev['oversized_files']} archivos oversized; máx {pipeline_rev['tokens_per_chunk']['max']:,} tokens.",
+        "- El custom es más adecuado para el DOF porque respeta la estructura documental (H2s, tablas, negritas) y genera chunks recuperables; entre las opciones de Chonkie, RecursiveChunker es la más estable para markdown general, mientras que TokenChunker/SentenceChunker son las más seguras para límites estrictos. El Pipeline table+recursive no es recomendable para este corpus; el Pipeline recursivo+table es mejor pero aún puede partir tablas.",
         "",
     ])
     return "\n".join(lines)
@@ -465,10 +505,14 @@ def main() -> int:
     pipeline = _run_chonkie_pipeline(files)
     print(f"  {pipeline['total_chunks']:,} chunks in {pipeline['elapsed_seconds']:.2f}s")
 
+    print("Running Chonkie Pipeline Rev (recursive + table)...")
+    pipeline_rev = _run_chonkie_pipeline_rev(files)
+    print(f"  {pipeline_rev['total_chunks']:,} chunks in {pipeline_rev['elapsed_seconds']:.2f}s")
+
     REPORT_DIR.mkdir(parents=True, exist_ok=True)
     report_path = REPORT_DIR / "chunker_comparison.md"
     report_path.write_text(
-        _format_report(custom, recursive, h2, table, token, sentence, pipeline),
+        _format_report(custom, recursive, h2, table, token, sentence, pipeline, pipeline_rev),
         encoding="utf-8",
     )
     print(f"Report written to {report_path}")

--- a/scripts/sweep_chunk_size.py
+++ b/scripts/sweep_chunk_size.py
@@ -1,0 +1,104 @@
+"""Sweep MAX_TOKENS and measure chunker behavior."""
+from __future__ import annotations
+
+import statistics
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+from random import sample, seed
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+seed(42)
+files = sorted(sample(list(Path("./dof_md").rglob("*.md")), 1000))
+
+
+def run(max_tokens: int, h2_max: int) -> dict:
+    import importlib
+
+    import rag_poc.config as cfg
+
+    cfg.MAX_TOKENS = max_tokens
+    cfg.H2_MAX_TOKENS = h2_max
+    cfg.OVERLAP_TOKENS = max(10, max_tokens // 20)  # 5% overlap
+
+    import rag_poc.chunker as chunker_mod  # noqa: E402
+
+    importlib.reload(chunker_mod)
+    from rag_poc.chunker import split_file, _count_tokens, classify  # noqa: E402, I001
+
+    results = {
+        "chunks": [],
+        "tokens": [],
+        "files": 0,
+        "errors": 0,
+        "oversized": 0,
+        "pattern_counts": defaultdict(int),
+    }
+    start = time.perf_counter()
+    for f in files:
+        text = f.read_text(encoding="utf-8", errors="replace")
+        try:
+            chunks = split_file(f)
+        except Exception:
+            results["errors"] += 1
+            continue
+        tokens = [_count_tokens(c.text) for c in chunks]
+        results["chunks"].append(len(chunks))
+        results["tokens"].extend(tokens)
+        results["files"] += 1
+        results["oversized"] += sum(1 for t in tokens if t > int(max_tokens * 1.10))
+        results["pattern_counts"][classify(text, f.stat().st_size).value] += 1
+    results["elapsed"] = time.perf_counter() - start
+    return results
+
+
+def summarize(label: int, r: dict) -> dict:
+    tokens = r["tokens"]
+    chunks = r["chunks"]
+    s = sorted(tokens)
+    n = len(tokens)
+
+    def p(x):
+        return s[min(int(n * x / 100), n - 1)]
+
+    return {
+        "max_tokens": label,
+        "files": r["files"],
+        "errors": r["errors"],
+        "total_chunks": sum(chunks),
+        "chunks_per_file": statistics.median(chunks) if chunks else 0,
+        "min": min(tokens) if tokens else 0,
+        "median": statistics.median(tokens) if tokens else 0,
+        "mean": statistics.mean(tokens) if tokens else 0,
+        "p90": p(90),
+        "p95": p(95),
+        "p99": p(99),
+        "max": max(tokens) if tokens else 0,
+        "oversized_count": r["oversized"],
+        "oversized_pct": r["oversized"] / len(tokens) * 100 if tokens else 0,
+        "elapsed": r["elapsed"],
+    }
+
+
+def main() -> int:
+    print(
+        "| MAX_TOKENS | H2_MAX_TOKENS | Chunks | Chunks/file | Median | Mean | P95 | Max | Oversized | Time(s) |"
+    )
+    print("|---|---|---|---|---|---|---|---|---|---|---|")
+    for max_tokens in [400, 800, 1200, 1600, 2000, 2500]:
+        h2_max = int(max_tokens * 1.10)
+        r = run(max_tokens, h2_max)
+        s = summarize(max_tokens, r)
+        print(
+            f"| {s['max_tokens']} | {h2_max} | "
+            f"{s['total_chunks']:,} | {s['chunks_per_file']:.1f} | "
+            f"{s['median']:.0f} | {s['mean']:.0f} | {s['p95']:.0f} | {s['max']:.0f} | "
+            f"{s['oversized_count']} ({s['oversized_pct']:.1f}%) | {s['elapsed']:.1f} |"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Benchmarks the custom DOF pattern chunker against Chonkie RecursiveChunker on 1,000 markdown files from ./dof_md.

Uses the same tokenizer (pplx-embed-context-v1-0.6b) for both to keep the comparison fair.

Key results (MAX_TOKENS=800):
- **Custom chunker**: 25,779 chunks, median 35 tokens, 29% of files with at least one oversized chunk
- **Chonkie RecursiveChunker**: 6,540 chunks, median 703 tokens, 0% oversized

Files:
- scripts/compare_chunkers.py
- reports/chunker_comparison.md

Depends on PR #55 (custom chunker). Target branch is feat/chunker-dof-patterns to keep the diff reviewable.