### PR TITLE
Full-corpus build: multi-source schema, binary vector store, 6.73M chunks

### DIFF
--- a/corpus_store/chunk_index.py
+++ b/corpus_store/chunk_index.py
@@ -260,6 +260,7 @@ def main() -> None:
     stats_by_pattern: dict[str, int] = {}
     batch: list[tuple] = []
     for doc_id, path, raw in iter_documents(corpus):
+        doc_t0 = time.time()
         done = chunks.execute(
             "SELECT 1 FROM chunks WHERE document_id = ? AND chunker_version = ?"
             " LIMIT 1", (doc_id, CHUNKER_VERSION)).fetchone()
@@ -316,6 +317,10 @@ def main() -> None:
             n_chunks += 1
             stats_by_pattern[pat] = stats_by_pattern.get(pat, 0) + 1
         n_docs += 1
+        doc_dt = time.time() - doc_t0
+        if doc_dt > 60:
+            print(f"  SLOW doc {doc_id} ({doc_dt:.0f}s, {len(raw) / 2**20:.1f} MiB,"
+                  f" {len(doc_chunks)} chunks): {path}", flush=True)
         if len(batch) >= 5000:
             with chunks:
                 chunks.executemany(

--- a/corpus_store/embed.py
+++ b/corpus_store/embed.py
@@ -1,0 +1,267 @@
+"""Resumable chunk embedding into a sign-quantized (binary) vector store.
+
+Per the post-PoC decision (see docs/corpus-storage-architecture.md), the
+full-corpus build stores jina binary embeddings: sign() runs in this
+pipeline on the in-memory fp32 vector returned by llama.cpp and only the
+packed 128-byte bit blob (1024 dims / 8) touches disk. No fp32 vectors are
+ever written, sidestepping both the ~27 GB fp32 disk problem and the extra
+quantization pass (sqlite-vector's vector_quantize requires stored fp32
+blobs). Hamming scan (XOR+popcount) is the fastest exact scan option.
+
+CRITICAL (jina via llama.cpp): chunks MUST be prefixed with "Document: "
+and queries with "Query: " or embeddings silently degrade
+(cosine 0.958 vs 0.9999 agreement with the reference implementation).
+
+Chunk text comes from recipe reconstruction (fast, hash-verified at chunk
+build time): decompress doc -> normalized text -> slice spans.
+
+Resumability (the full run is ~14 days and will be interrupted):
+- chunks are processed in chunk_id order and inserted contiguously, so
+  resume = continue after MAX(chunk_id) already in chunk_vectors;
+- every batch commits inside one transaction;
+- vector_meta records model/prefix/packing config; a resume with a
+  mismatched config aborts instead of silently mixing embeddings.
+
+Usage:
+    uv run python -m corpus_store.embed \
+        --corpus-db poc/data/dof_corpus_l3.sqlite \
+        --chunks-db poc/data/dof_chunks.sqlite \
+        --vectors-db poc/data/dof_vectors_jina_binary.sqlite \
+        --gguf ~/dof-gguf/jina-v5-small-retrieval-F16.gguf
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+import numpy as np
+
+from rag_poc.chunker import DocPattern
+from corpus_store.chunk_index import normalized_text, reconstruct
+from corpus_store.db import connect, fetch_document_text
+
+MODEL_ID = "jinaai/jina-embeddings-v5-text-small"
+PREFIX_DOCUMENT = "Document: "
+PREFIX_QUERY = "Query: "
+QUANTIZATION = "sign-packbits-big"  # bits = (fp32 >= 0), np.packbits bitorder='big'
+DIMS = 1024
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS chunk_vectors (
+    chunk_id INTEGER PRIMARY KEY,
+    embedding BLOB NOT NULL
+);
+CREATE TABLE IF NOT EXISTS vector_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+"""
+
+INSERT_EVERY = 2048  # vectors per committed batch
+
+
+def start_server(gguf: Path, ctx: int, port: int) -> subprocess.Popen:
+    proc = subprocess.Popen(
+        [
+            "llama-server", "-m", str(gguf),
+            "--embedding", "--port", str(port),
+            "-c", str(ctx), "-b", "8192", "-ub", "4096",
+            "--log-disable",
+        ],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+    for _ in range(180):
+        try:
+            urllib.request.urlopen(f"http://127.0.0.1:{port}/health", timeout=1)
+            return proc
+        except Exception:
+            time.sleep(1)
+    raise RuntimeError("llama-server did not become healthy")
+
+
+def embed_batch(texts: list[str], port: int, retries: int = 6) -> np.ndarray:
+    """fp32 embeddings from llama-server /v1/embeddings, with backoff.
+
+    Retries ride out transient server hiccups during multi-day runs; on
+    persistent failure the exception propagates and the run stops with all
+    prior batches already committed (resume-safe).
+    """
+    body = json.dumps({"input": texts}).encode()
+    delay = 2.0
+    for attempt in range(retries):
+        try:
+            req = urllib.request.Request(
+                f"http://127.0.0.1:{port}/v1/embeddings", data=body,
+                headers={"Content-Type": "application/json"})
+            with urllib.request.urlopen(req, timeout=600) as resp:
+                data = json.load(resp)
+            data["data"].sort(key=lambda d: d["index"])
+            return np.array([d["embedding"] for d in data["data"]],
+                            dtype=np.float32)
+        except Exception:
+            if attempt == retries - 1:
+                raise
+            time.sleep(delay)
+            delay = min(delay * 2, 60)
+    raise AssertionError("unreachable")
+
+
+def pack_binary(emb: np.ndarray) -> bytes:
+    """sign() quantization: (emb >= 0) packed to DIMS/8 bytes."""
+    return np.packbits(emb >= 0).tobytes()
+
+
+def init_vectors_db(path: Path, meta: dict[str, str]) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(path))
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA synchronous = NORMAL")
+    conn.executescript(SCHEMA)
+    for k, v in meta.items():
+        conn.execute("INSERT INTO vector_meta VALUES (?, ?)", (k, v))
+    conn.commit()
+    return conn
+
+
+def check_meta(conn: sqlite3.Connection, expected: dict[str, str]) -> None:
+    """Resume guard: refuse to mix embedding configs in one store."""
+    stored = dict(conn.execute("SELECT key, value FROM vector_meta"))
+    for k, v in expected.items():
+        if k in stored and stored[k] != v:
+            sys.exit(f"vector_meta mismatch on {k!r}: stored {stored[k]!r}, "
+                     f"requested {v!r} — refusing to mix embedding configs")
+
+
+def iter_pending(chunks: sqlite3.Connection, after_id: int):
+    """(chunk_id, document_id, spans_json, pattern) in chunk_id order."""
+    cur = chunks.execute(
+        "SELECT chunk_id, document_id, spans_json, pattern FROM chunks"
+        " WHERE chunk_id > ? ORDER BY chunk_id", (after_id,))
+    while True:
+        rows = cur.fetchmany(4096)
+        if not rows:
+            return
+        yield from rows
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--corpus-db", required=True)
+    ap.add_argument("--chunks-db", required=True)
+    ap.add_argument("--vectors-db", required=True)
+    ap.add_argument("--gguf", type=Path,
+                    default=Path.home() / "dof-gguf/jina-v5-small-retrieval-F16.gguf")
+    ap.add_argument("--batch-size", type=int, default=64)
+    ap.add_argument("--ctx", type=int, default=8192)
+    ap.add_argument("--port", type=int, default=8085)
+    ap.add_argument("--max-chunks", type=int, default=None,
+                    help="embed at most N chunks this run (pilot sizing)")
+    args = ap.parse_args()
+
+    meta = {
+        "model": MODEL_ID,
+        "gguf": str(args.gguf),
+        "dims": str(DIMS),
+        "quantization": QUANTIZATION,
+        "prefix_document": PREFIX_DOCUMENT,
+        "prefix_query": PREFIX_QUERY,
+    }
+
+    vectors_path = Path(args.vectors_db)
+    vectors_path.parent.mkdir(parents=True, exist_ok=True)
+    fresh = not vectors_path.exists()
+    vectors = (init_vectors_db(vectors_path, meta) if fresh
+               else sqlite3.connect(str(vectors_path)))
+    if not fresh:
+        check_meta(vectors, meta)
+    last_id = vectors.execute(
+        "SELECT COALESCE(MAX(chunk_id), 0) FROM chunk_vectors").fetchone()[0]
+
+    corpus = connect(args.corpus_db)
+    chunks = sqlite3.connect(args.chunks_db)
+    total = chunks.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
+    pending_total = total - chunks.execute(
+        "SELECT COUNT(*) FROM chunks WHERE chunk_id <= ?", (last_id,)).fetchone()[0]
+    if args.max_chunks:
+        pending_total = min(pending_total, args.max_chunks)
+    print(f"{total:,} chunks in store, {last_id:,} already embedded, "
+          f"embedding {pending_total:,}", flush=True)
+    if pending_total == 0:
+        return
+
+    proc = start_server(args.gguf, args.ctx, args.port)
+    try:
+        # probe: dims sanity + prefix applied (the request is what it is;
+        # the pilot's MRR spot check validates prefix correctness)
+        probe = embed_batch([PREFIX_DOCUMENT + "probe"], args.port)
+        if probe.shape[1] != DIMS:
+            sys.exit(f"embedding dims {probe.shape[1]} != expected {DIMS}")
+
+        buf: list[tuple[int, str]] = []  # (chunk_id, prefixed text)
+        n_done = 0
+        t0 = time.time()
+        cur_doc = None
+        c_text = ""
+        for chunk_id, doc_id, spans_json, pattern in iter_pending(chunks, last_id):
+            if doc_id != cur_doc:
+                # first row seen per doc carries the doc-level pattern that
+                # chunk_index used to build normalized text
+                raw = fetch_document_text(corpus, doc_id)
+                c_text = normalized_text(raw, DocPattern(pattern))
+                cur_doc = doc_id
+            text = reconstruct(json.loads(spans_json), c_text)
+            buf.append((chunk_id, PREFIX_DOCUMENT + text))
+            if len(buf) >= INSERT_EVERY:
+                n_done += flush(vectors, buf, args.port, args.batch_size)
+                log_progress(n_done, pending_total, t0)
+            if n_done + len(buf) >= pending_total:
+                break
+        if buf and n_done < pending_total:
+            del buf[pending_total - n_done:]
+            n_done += flush(vectors, buf, args.port, args.batch_size)
+            log_progress(n_done, pending_total, t0)
+        vectors.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        size = vectors_path.stat().st_size
+        dt = time.time() - t0
+        print(f"\nDone: {n_done:,} vectors in {dt / 3600:.1f}h "
+              f"({n_done / max(dt, 1):.2f} chunks/s), "
+              f"db size {size / 2**20:.1f} MiB "
+              f"({size / max(n_done + last_id, 1):.0f} B/vec incl. overhead)")
+    finally:
+        proc.terminate()
+        proc.wait()
+    vectors.close()
+
+
+def flush(vectors: sqlite3.Connection, buf: list[tuple[int, str]],
+          port: int, batch_size: int) -> int:
+    """Embed the buffer in sub-batches and insert in one transaction.
+
+    chunk_ids in the buffer are contiguous, so MAX(chunk_id) remains a
+    valid resume checkpoint. Returns the number of vectors inserted.
+    """
+    rows: list[tuple[int, bytes]] = []
+    for i in range(0, len(buf), batch_size):
+        part = buf[i:i + batch_size]
+        emb = embed_batch([t for _, t in part], port)
+        rows.extend((cid, pack_binary(e)) for (cid, _), e in zip(part, emb))
+    with vectors:
+        vectors.executemany(
+            "INSERT INTO chunk_vectors (chunk_id, embedding) VALUES (?, ?)", rows)
+    n = len(buf)
+    buf.clear()
+    return n
+
+
+def log_progress(done: int, total: int, t0: float) -> None:
+    dt = time.time() - t0
+    rate = done / max(dt, 1)
+    eta_h = (total - done) / max(rate, 1e-9) / 3600
+    print(f"  {done:,}/{total:,} vectors ({rate:.2f} chunks/s, "
+          f"ETA {eta_h:.1f}h)", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/corpus_store/ingest.py
+++ b/corpus_store/ingest.py
@@ -147,6 +147,71 @@ def enable_compression(conn: sqlite3.Connection, level: int) -> None:
     conn.execute(ENABLE_ZSTD.format(level=level))
     conn.execute(ENABLE_ZSTD_SEGMENTS.format(level=level))
     conn.commit()
+    # The maintenance todo query GROUPs BY the dict_chooser expression over
+    # all uncompressed rows; without this index SQLite spills the whole
+    # uncompressed corpus to a temp b-tree (26+ GiB at full scale — fills
+    # the disk, SQLITE_FULL). The expression must match dict_chooser.
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS _group_dict_idx ON _documents_zstd"
+        "(_markdown_dict, printf('%s_%d', source, year))")
+    conn.commit()
+
+
+def pretrain_dicts(conn: sqlite3.Connection, source: str = "dof",
+                   max_sample_bytes: int = int(1.8 * 2**30)) -> None:
+    """Train per-source-year dicts via the year index, before maintenance.
+
+    The extension's own training path runs one unindexed query per chooser
+    group (full-table scan each), and reservoir-samples ALL rows of groups
+    larger than ~2 GiB, which exceeds ZDICT's 2 GB sample limit (the 2011
+    group is 2.35 GiB). Indexed per-year queries with a reservoir cap avoid
+    both. Idempotent: skips chooser keys that already have a dict. Mirrors
+    the extension defaults: dict target = 1% of group bytes (min 5000).
+    """
+    groups = conn.execute(
+        "SELECT year, COUNT(*), SUM(byte_length) FROM documents"
+        " WHERE source = ? GROUP BY year", (source,)).fetchall()
+    for year, count, total in groups:
+        key = f"{source}_{year}"
+        if conn.execute("SELECT 1 FROM _zstd_dicts WHERE chooser_key = ?",
+                        (key,)).fetchone():
+            continue
+        avg = total / count
+        dict_target = max(int(0.01 * total), 5000)
+        samples = min(count, int(max_sample_bytes / avg))
+        t0 = time.time()
+        conn.execute(
+            "SELECT zstd_train_dict_and_save(markdown, ?, ?, ?)"
+            " FROM documents WHERE year = ? AND source = ?",
+            (dict_target, float(samples), key, year, source)).fetchone()
+        conn.commit()
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        print(f"  trained {key}: target={dict_target} samples={samples}"
+              f" ({time.time() - t0:.0f}s)", flush=True)
+
+
+def run_maintenance(conn: sqlite3.Connection, pass_seconds: int = 1800,
+                    max_passes: int = 24) -> None:
+    """Dict training + recompression until done, checkpointing between passes.
+
+    One long call risks a giant WAL (disk-full on the full corpus) and loses
+    all progress on failure; bounded passes with wal_checkpoint(TRUNCATE)
+    keep peak disk use low and every pass resumable. The function returns 0
+    when no work remains.
+    """
+    for i in range(max_passes):
+        t0 = time.time()
+        remaining = conn.execute(
+            f"SELECT zstd_incremental_maintenance({pass_seconds}, 1.0)"
+        ).fetchone()[0]
+        conn.commit()
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        print(f"  maintenance pass {i + 1}: {time.time() - t0:.0f}s, "
+              f"remaining={remaining}", flush=True)
+        if not remaining:
+            return
+    print(f"WARN: maintenance not finished after {max_passes} passes; "
+          "re-run to continue", file=sys.stderr)
 
 
 def main() -> None:
@@ -214,17 +279,16 @@ def main() -> None:
         t1 = time.time()
         enable_compression(conn, args.level)
         print(f"  compression enabled in {time.time() - t1:.0f}s")
-        print("Running incremental maintenance (dict training + recompression)...")
+        pretrain_dicts(conn, args.source)
+        print("Running incremental maintenance (recompression)...")
         t2 = time.time()
-        rows = conn.execute("SELECT zstd_incremental_maintenance(3600, 1.0)").fetchall()
-        conn.commit()
-        print(f"  maintenance in {time.time() - t2:.0f}s: {rows}")
+        run_maintenance(conn)
+        print(f"  maintenance in {time.time() - t2:.0f}s")
     else:
         print("Database already compressed; running maintenance on new rows...")
         conn.commit()
-        rows = conn.execute("SELECT zstd_incremental_maintenance(3600, 1.0)").fetchall()
-        conn.commit()
-        print(f"  maintenance: {rows}")
+        pretrain_dicts(conn, args.source)
+        run_maintenance(conn)
 
     print(f"DB file size: {db_path.stat().st_size / 2**20:.1f} MiB")
     conn.close()

--- a/corpus_store/ingest.py
+++ b/corpus_store/ingest.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import re
 import sqlite3
 import sys
 import time
@@ -29,13 +30,16 @@ from pathlib import Path
 
 from corpus_store.db import connect, init_fresh_db
 
-CORPUS_VERSION = "poc-10k-seed42"
+CORPUS_VERSION = "poc-10k-seed42"  # default; full builds pass --corpus-version
 BATCH_SIZE = 256
+
+SOURCE_RE = re.compile(r"^[a-z0-9_]+$")  # safe for dict_chooser group names
 
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS documents (
     document_id INTEGER PRIMARY KEY,
     path TEXT NOT NULL UNIQUE,
+    source TEXT NOT NULL DEFAULT 'dof',
     year INTEGER NOT NULL,
     publication_date TEXT,
     section TEXT,
@@ -44,6 +48,7 @@ CREATE TABLE IF NOT EXISTS documents (
     sha256 BLOB NOT NULL,
     corpus_version TEXT NOT NULL
 );
+CREATE INDEX IF NOT EXISTS documents_source_idx ON documents(source);
 CREATE INDEX IF NOT EXISTS documents_year_idx ON documents(year);
 CREATE INDEX IF NOT EXISTS documents_section_idx ON documents(section);
 
@@ -65,10 +70,13 @@ CREATE TABLE IF NOT EXISTS ingestion_log (
 );
 """
 
+# dict_chooser is source-aware so future sources (constitucion, state laws)
+# train their own dictionaries instead of diluting the DOF ones. Changing
+# the chooser expression is safe: decompression uses the stored dict ids.
 ENABLE_ZSTD = """SELECT zstd_enable_transparent('{{
     "table": "documents", "column": "markdown",
     "compression_level": {level},
-    "dict_chooser": "printf(''year_%d'', year)"
+    "dict_chooser": "printf(''%s_%d'', source, year)"
 }}')"""
 ENABLE_ZSTD_SEGMENTS = """SELECT zstd_enable_transparent('{{
     "table": "document_segments", "column": "segment_text",
@@ -84,8 +92,14 @@ def already_compressed(conn: sqlite3.Connection) -> bool:
 
 
 def ingest_batch(conn: sqlite3.Connection, corpus: Path, batch: list[dict],
-                 segment_threshold: int) -> tuple[int, int]:
-    """Insert one batch inside a single transaction. Returns (docs, bytes)."""
+                 segment_threshold: int, source: str = "dof",
+                 corpus_version: str = CORPUS_VERSION) -> tuple[int, int]:
+    """Insert one batch inside a single transaction. Returns (docs, bytes).
+
+    documents.path is namespaced per source: DOF keeps its historical
+    relpaths (1999/01/...); future sources must prefix their paths with
+    '<source>/' (e.g. 'constitucion/...') so path stays globally UNIQUE.
+    """
     n_docs = n_bytes = 0
     with conn:
         for rec in batch:
@@ -101,11 +115,11 @@ def ingest_batch(conn: sqlite3.Connection, corpus: Path, batch: list[dict],
             if size > segment_threshold:
                 # metadata row with empty text; content lives in segments
                 cur = conn.execute(
-                    "INSERT INTO documents (path, year, publication_date, section,"
+                    "INSERT INTO documents (path, source, year, publication_date, section,"
                     " markdown, byte_length, sha256, corpus_version)"
-                    " VALUES (?, ?, ?, ?, '', ?, ?, ?)",
-                    (rel, rec["year"], rec["publication_date"], rec["section"],
-                     size, digest, CORPUS_VERSION))
+                    " VALUES (?, ?, ?, ?, ?, '', ?, ?, ?)",
+                    (rel, source, rec["year"], rec["publication_date"], rec["section"],
+                     size, digest, corpus_version))
                 doc_id = cur.lastrowid
                 for i, start in enumerate(range(0, size, segment_threshold)):
                     seg = text[start:start + segment_threshold]
@@ -115,11 +129,11 @@ def ingest_batch(conn: sqlite3.Connection, corpus: Path, batch: list[dict],
                         (doc_id, i, start, start + len(seg), seg))
             else:
                 conn.execute(
-                    "INSERT INTO documents (path, year, publication_date, section,"
+                    "INSERT INTO documents (path, source, year, publication_date, section,"
                     " markdown, byte_length, sha256, corpus_version)"
-                    " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                    (rel, rec["year"], rec["publication_date"], rec["section"],
-                     text, size, digest, CORPUS_VERSION))
+                    " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (rel, source, rec["year"], rec["publication_date"], rec["section"],
+                     text, size, digest, corpus_version))
             n_docs += 1
             n_bytes += size
         conn.execute(
@@ -142,9 +156,20 @@ def main() -> None:
     ap.add_argument("--db", required=True)
     ap.add_argument("--level", type=int, default=3, choices=[3, 19])
     ap.add_argument("--segment-threshold", type=int, default=32 * 2**20)
+    ap.add_argument("--source", default="dof",
+                    help="corpus source id; recorded per row and used by the"
+                         " zstd dict_chooser (groups per source_year). Future"
+                         " sources must namespace their manifest relpaths as"
+                         " '<source>/...' to keep documents.path UNIQUE.")
+    ap.add_argument("--corpus-version", default=CORPUS_VERSION,
+                    help="recorded on every row and in corpus_meta")
     ap.add_argument("--max-docs", type=int, default=None,
                     help="ingest only the first N manifest docs (resume testing)")
     args = ap.parse_args()
+
+    if not SOURCE_RE.match(args.source):
+        sys.exit(f"--source must match {SOURCE_RE.pattern!r} "
+                 f"(it is used in zstd dict group names), got {args.source!r}")
 
     corpus = Path(args.corpus)
     db_path = Path(args.db)
@@ -159,7 +184,9 @@ def main() -> None:
         init_fresh_db(conn)
         conn.executescript(SCHEMA)
         conn.execute("INSERT INTO corpus_meta VALUES ('corpus_version', ?)",
-                     (CORPUS_VERSION,))
+                     (args.corpus_version,))
+        conn.execute("INSERT INTO corpus_meta VALUES ('source', ?)",
+                     (args.source,))
         conn.execute("INSERT INTO corpus_meta VALUES ('source_manifest', ?)",
                      (str(args.manifest),))
         conn.execute("INSERT INTO corpus_meta VALUES ('compression_level', ?)",
@@ -170,7 +197,8 @@ def main() -> None:
     total_docs = total_bytes = 0
     for i in range(0, len(manifest), BATCH_SIZE):
         d, b = ingest_batch(conn, corpus, manifest[i:i + BATCH_SIZE],
-                            args.segment_threshold)
+                            args.segment_threshold, args.source,
+                            args.corpus_version)
         total_docs += d
         total_bytes += b
         done = conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0]

--- a/corpus_store/sampler.py
+++ b/corpus_store/sampler.py
@@ -77,6 +77,8 @@ def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--corpus", default="../dof_md")
     ap.add_argument("--n", type=int, default=10_000)
+    ap.add_argument("--all", action="store_true",
+                    help="manifest the entire corpus (full build), not a sample")
     ap.add_argument("--seed", type=int, default=42)
     ap.add_argument("--out", default="poc/data/manifest_10k.jsonl")
     args = ap.parse_args()
@@ -96,8 +98,8 @@ def main() -> None:
         print(f"WARN: {n_dataless:,} dataless (non-materialized) files in corpus", file=sys.stderr)
 
     rng = random.Random(args.seed)
-    sampled = rng.sample(entries, min(args.n, total))
-    sampled.sort()
+    sampled = entries if args.all else rng.sample(entries, min(args.n, total))
+    sampled = sorted(sampled)
 
     n_skipped = 0
     with out.open("w") as f:

--- a/docs/corpus-storage-architecture.md
+++ b/docs/corpus-storage-architecture.md
@@ -9,9 +9,11 @@ The active text corpus contains approximately:
 
 - 657,867 Markdown files
 - 31.47 GiB of Markdown
-- ~5.1 million expected chunks at the current 800-token configuration
+- ~6.6–6.7 million expected chunks at the current 800-token configuration
+  (the PoC measured 10.1 chunks/doc on 10k documents, more than the ~5.1M
+  originally estimated)
 
-A 1,024-dimensional float32 vector index for all chunks would require approximately 20.8 GiB before database and index overhead. Storing another copy of every chunk's text would add roughly 33–40 GiB, making the combined source/chunk/vector layout difficult to maintain on a 460 GiB MacBook disk.
+A 1,024-dimensional float32 vector index for all chunks would require approximately 27 GiB before database and index overhead — this does not fit the disk budget, so the production build uses binary (sign) quantization instead (see "Vector store"). Storing another copy of every chunk's text would add roughly 33–40 GiB, making the combined source/chunk/vector layout difficult to maintain on a 460 GiB MacBook disk.
 
 The architecture should store document text once, avoid duplicated chunk text, and keep vector indexes reproducible from versioned corpus metadata.
 
@@ -78,6 +80,7 @@ Illustrative schema:
 CREATE TABLE documents (
     document_id INTEGER PRIMARY KEY,
     path TEXT NOT NULL UNIQUE,
+    source TEXT NOT NULL DEFAULT 'dof',
     year INTEGER NOT NULL,
     publication_date TEXT,
     section TEXT,
@@ -87,15 +90,49 @@ CREATE TABLE documents (
     corpus_version TEXT NOT NULL
 );
 
+CREATE INDEX documents_source_idx ON documents(source);
 CREATE INDEX documents_year_idx ON documents(year);
 CREATE INDEX documents_section_idx ON documents(section);
 ```
 
+`source` identifies the corpus a document belongs to (`'dof'` for the
+current corpus; future sources such as the federal constitution or state
+laws get their own ids). Because the compressed schema is
+migrate-by-rebuild, this column had to land before the full-corpus build.
+`documents.path` is namespaced per source: DOF keeps its historical
+relpaths (`1999/01/...`), and future sources must prefix their paths with
+`'<source>/'` (e.g. `constitucion/...`) so `path` stays globally UNIQUE
+and idempotent-by-path resume keeps working.
+
 Enable transparent compression on `documents.markdown`. Start with level 3 and benchmark level 19 afterward; level 3 may provide most of the savings with much lower ingestion cost.
 
-Use dictionary groups that reflect corpus structure, such as year and optionally document-size class. Validate the exact `dict_chooser` expression during the proof of concept.
+The zstd `dict_chooser` is source-aware — `printf('%s_%d', source, year)` —
+so each source trains its own per-year dictionaries instead of diluting the
+DOF ones. Changing the chooser expression between builds is safe because
+decompression resolves dictionaries by the stored dict id, not by the
+expression.
 
 Documents above a configurable threshold, initially 32 MiB uncompressed, should be segmented rather than stored as one very large compressed row. Segment metadata should preserve ordering and byte offsets.
+
+## Multi-source readiness
+
+Adding non-DOF sources (federal constitution, state laws, regulations) is
+incremental on top of this architecture, with two deliberate constraints:
+
+- **Per-source chunkers use the existing `chunker_version` mechanism.** A
+  constitution chunker (article-aware) or a state-law chunker registers a
+  new `chunker_version` and coexists with `dof-chunker-v1` chunks in the
+  same chunk store (`UNIQUE(document_id, chunk_index, chunker_version)`).
+  Span recipes already reference normalized text per chunker, so no schema
+  change is needed.
+- **Per-source evaluation is required before mixing.** BM25 IDF statistics
+  and vector-candidate distributions change when sources with different
+  vocabulary and document sizes share one index, so each source needs its
+  own eval slice plus a mixed-corpus eval before fusion weights (α) tuned
+  on DOF-only data are trusted.
+
+The `documents.source` column and source-aware zstd dictionaries (above)
+are the only schema-level changes; everything else is additive.
 
 ## Chunk store
 
@@ -150,25 +187,49 @@ The proof of concept must validate this interaction explicitly. In particular, t
 
 ## Vector store
 
-Use [sqliteai/sqlite-vector](https://github.com/sqliteai/sqlite-vector) for the next SQLite proof of concept, but keep it in a separate database from the compressed corpus. It is actively maintained, provides macOS ARM binaries, stores vectors as ordinary `BLOB` columns, and supports SIMD exact scans plus 2-, 3-, and 4-bit TurboQuant scans. Test loading sqlite-zstd and sqlite-vector in the same Python process even if the databases remain separate.
+**Decision (post-PoC): the full-corpus build stores jina binary (sign)
+embeddings.** `sign()` runs inside the embedding pipeline on the in-memory
+fp32 vector returned by llama.cpp and only the packed 128-byte blob
+(1,024 dims / 8) touches disk — no fp32 vectors are stored and no separate
+quantization pass is needed. Rationale:
 
-TurboQuant is a scan rather than an HNSW/IVF preindex. For approximately 5.1 million 1,024-dimensional vectors, 4-bit TurboQuant should require roughly 2.7 GiB before database overhead. Based on the upstream 1-million-vector macOS ARM benchmark, a full-corpus scan may take on the order of one second when preloaded. That is acceptable for initial limited-user workloads if recall is validated; otherwise use an ANN engine.
+- Hybrid MRR is 0.649–0.650 for binary vs 0.656 for TurboQuant4/fp32
+  (~1 point; binary was already the validated production fallback).
+- fp32 storage does not fit: ~6.67M chunks × 4 KiB ≈ 27 GiB.
+- sqlite-vector's `vector_quantize` (TurboQuant) requires stored fp32
+  blobs as input, so TurboQuant cannot avoid the fp32 disk problem either.
+- Hamming scan (XOR + popcount) is the fastest exact scan option and works
+  with sqlite-vec `bit[1024]` tables (`vec_bit()`, already a dependency)
+  or sqlite-vector 1Bit mode.
 
-The extension uses a modified Elastic License 2.0. This repository is MIT-licensed, which appears to satisfy the open-source grant, but production or managed-service use should be reviewed before deployment.
+Expected store size: ~6.67M × 128 B ≈ **0.85 GiB** plus row overhead.
 
-For larger or latency-sensitive indexes, evaluate LanceDB IVF-PQ, FAISS IVF-PQ, or PostgreSQL pgvector. A quantized 1,024-dimensional index should be much smaller than the ~20.8 GiB raw float32 matrix. Build only one full production model index; continue evaluating alternative models on sampled subsets.
+TurboQuant4 remains the documented quality upgrade path if disk headroom
+improves (e.g. offloading fp32 to external storage during the build, or a
+two-stage binary-scan + int8/fp32-rerank design). The recall and hybrid
+harnesses (`scripts/poc_turboquant_recall.py`,
+`scripts/poc_hybrid_turboquant.py`) make re-validation cheap.
+
+For larger or latency-sensitive deployments, evaluate LanceDB IVF-PQ, FAISS IVF-PQ, or PostgreSQL pgvector (which also supports binary quantization with reranking). Build only one full production model index; continue evaluating alternative models on sampled subsets.
+
+The extension licenses still need review before production deployment:
+sqlite-vector uses a modified Elastic License 2.0 (this repository is
+MIT-licensed, which appears to satisfy the open-source grant) and
+sqlite-zstd is LGPL-3.0. sqlite-vec is MIT. Neither blocks the local build.
 
 ## Estimated storage
 
-Approximate full-corpus targets:
+Approximate full-corpus targets (updated with the PoC's 10.1 chunks/doc
+measurement, i.e. ~6.67M chunks):
 
 | Component | Target |
 |---|---:|
-| Compressed Markdown corpus | 2–8 GiB |
-| Chunk metadata and offsets | 1–2 GiB |
-| sqlite-vec float32 index | 25–30 GiB |
-| sqlite-vector TurboQuant4 scan | 3–6 GiB |
-| Quantized ANN index | 1–8 GiB |
+| Compressed Markdown corpus | 2.3–2.9 GiB |
+| Doc-level FTS5 | ~2.8 GiB |
+| Chunk metadata and span recipes | ~2.8 GiB |
+| Binary (sign) vector store, 128 B/vec | ~0.85 GiB |
+| TurboQuant4 upgrade path, 524 B/vec | ~3.5 GiB |
+| fp32 vectors (rejected: does not fit) | ~27 GiB |
 | Model caches | ~10 GiB |
 
 The raw Google Drive corpus may consume another ~60 GiB if fully pinned. Derived databases must remain on local APFS storage, not inside Google Drive.
@@ -240,5 +301,8 @@ Measure both sqlite-zstd level 3 and level 19. If level 19 adds little compressi
 - Keep `.bak` files and media assets out of the initial text corpus.
 - Do not store full chunk text unless a later benchmark proves that query-time reconstruction is a bottleneck.
 - Batch inserts, checkpoint the WAL regularly, and run `VACUUM` only after major ingestion phases.
-- Record corpus version, document hashes, chunker version, model ID, dimensions, and quantization settings.
+- Record corpus version, document hashes, chunker version, model ID, dimensions, quantization settings, and embedding prefixes (`Document: `/`Query: ` — required by jina via llama.cpp).
 - Keep only one full production vector index until disk headroom improves.
+- The embedding run must be resumable from the start: checkpoint by
+  contiguous `chunk_id` ranges, batch inserts in single transactions, and
+  refuse to resume with a mismatched model/prefix/packing config.

--- a/docs/corpus-storage-poc-results.md
+++ b/docs/corpus-storage-poc-results.md
@@ -187,12 +187,10 @@ with a mismatched config.
 
 ## Next steps
 
-1. Binary vector-store pilot (~100k chunks): real on-disk size, hamming
-   scan latency, spot MRR — gates the full build.
-2. Full-corpus build (657,867 docs): ~6 min/10k docs ingestion +
-  chunking pipeline; embeddings via llama.cpp GGUF f16 (~14 days at
-  5.42 chunks/s) with explicit "Document: "/"Query: " prefixes,
-  resumable by chunk_id ranges.
+1. ~~Binary vector-store pilot~~ — passed; see `docs/full-corpus-build.md`.
+2. Full-corpus build (657,867 docs): corpus store done (3.52 GiB),
+   chunk store and ~14-day embedding run tracked in
+   `docs/full-corpus-build.md`.
 3. Eval on the full corpus: the 499-doc / 3,023-query set becomes a much
    harder retrieval test (MRR will drop vs the 499-doc subset — that's
    signal, not regression); compare BM25 vs vectors vs hybrid α=0.5.

--- a/docs/corpus-storage-poc-results.md
+++ b/docs/corpus-storage-poc-results.md
@@ -95,15 +95,62 @@ from the real extension):
 TurboQuant4 is quality-equivalent to fp32 after fusion and beats the
 validated sqlite-vec binary fallback, at 7.8x smaller storage.
 
-## Full-corpus storage extrapolation (31.47 GiB, ~5.1M chunks)
+## Full-corpus storage extrapolation (31.47 GiB, ~6.67M chunks)
+
+The PoC measured 10.1 chunks/doc, so the full corpus yields ~6.6–6.7M
+chunks — more than the ~5.1M the architecture doc originally estimated.
+Per-doc extrapolations (corpus, FTS, chunk store) are unchanged; per-chunk
+figures (vectors) scale up accordingly.
 
 | Component | Estimate | Basis |
 |---|---:|---|
 | Compressed corpus (L3 / L19) | 2.9 / 2.3 GiB | 10.92x / 13.51x |
 | Doc-level FTS5 | ~2.8 GiB | 0.09x text |
 | Chunk metadata + recipes | ~2.8 GiB | 43 MiB per 10k docs |
-| TurboQuant4 vectors | ~2.5 GiB | 524 B/vec |
-| **Total** | **~11 GiB** | fits comfortably in 19 GiB free |
+| **Binary (sign) vectors (decided)** | **~0.85 GiB** | 128 B/vec |
+| TurboQuant4 vectors (upgrade path) | ~3.5 GiB | 524 B/vec |
+| fp32 vectors (rejected) | ~27 GiB | 4 KiB/vec — does not fit |
+| **Total (binary)** | **~9.4 GiB** | fits comfortably in 19 GiB free |
+
+## Post-PoC decisions
+
+### Vector store: binary (sign) quantization, not TurboQuant
+
+Decided after the PoC, before the full-corpus build. `sign()` runs in the
+embedding pipeline on the in-memory fp32 vector; only the packed 128-byte
+blob touches disk.
+
+- Hybrid MRR 0.649–0.650 (binary) vs 0.656 (turbo4/fp32) — ~1 point, and
+  binary was already the validated production config.
+- No separate quantization step; sidesteps the fp32 disk problem entirely
+  (sqlite-vector's `vector_quantize` requires stored fp32 blobs as input).
+- Hamming scan (XOR + popcount) is the fastest exact scan; works with
+  sqlite-vec `bit[1024]` (already a dependency, MIT) or sqlite-vector
+  1Bit mode — pilot picks whichever needs less new code.
+- TurboQuant4 stays as the documented quality upgrade path if disk
+  headroom improves; `poc_turboquant_recall.py` +
+  `poc_hybrid_turboquant.py` make re-validation cheap. A two-stage
+  binary-scan + int8-rerank is a possible future option.
+
+Embedding config locked in `vector_meta`: jina-v5-text-small via llama.cpp
+GGUF f16 (`~/dof-gguf/jina-v5-small-retrieval-F16.gguf`), explicit
+"Document: "/"Query: " prefixes (silently degrades to cosine 0.958 vs
+0.9999 without them), sign packing `np.packbits(emb >= 0)` big-endian.
+The run checkpoints by contiguous `chunk_id` ranges and refuses to resume
+with a mismatched config.
+
+### Multi-source schema prep (landed before the full build)
+
+- `documents.source TEXT NOT NULL DEFAULT 'dof'` — the compressed schema
+  is migrate-by-rebuild, so this had to go in first.
+- zstd `dict_chooser` is source-aware (`printf('%s_%d', source, year)`),
+  e.g. `dof_1999`; future sources train their own dictionaries.
+- `documents.path` namespaced per source (DOF keeps historical relpaths;
+  future sources prefix `<source>/`).
+- Everything else for multi-source is incremental: per-source chunkers
+  use the existing `chunker_version` mechanism; per-source eval is needed
+  because BM25 IDF and vector candidate statistics change when sources
+  mix.
 
 ## Engineering notes (gotchas worth keeping)
 
@@ -140,9 +187,15 @@ validated sqlite-vec binary fallback, at 7.8x smaller storage.
 
 ## Next steps
 
-1. Full-corpus build (657,867 docs): ~6 min/10k docs ingestion +
+1. Binary vector-store pilot (~100k chunks): real on-disk size, hamming
+   scan latency, spot MRR — gates the full build.
+2. Full-corpus build (657,867 docs): ~6 min/10k docs ingestion +
   chunking pipeline; embeddings via llama.cpp GGUF f16 (~14 days at
-  5.42 chunks/s) with explicit "Document: "/"Query: " prefixes.
-2. PostgreSQL + pgvector prototype only if limited-production
+  5.42 chunks/s) with explicit "Document: "/"Query: " prefixes,
+  resumable by chunk_id ranges.
+3. Eval on the full corpus: the 499-doc / 3,023-query set becomes a much
+   harder retrieval test (MRR will drop vs the 499-doc subset — that's
+   signal, not regression); compare BM25 vs vectors vs hybrid α=0.5.
+4. PostgreSQL + pgvector prototype only if limited-production
   concurrency is confirmed (see architecture doc).
-3. Blog post on the PoC results (dof-rag-website).
+5. Blog post on the PoC results (dof-rag-website).

--- a/docs/full-corpus-build.md
+++ b/docs/full-corpus-build.md
@@ -1,0 +1,89 @@
+# Full-Corpus Build Log
+
+Status: in progress
+Date: 2026-08-03
+Branch: `feat/full-corpus-build`
+
+Production build over all 657,867 DOF documents (31.47 GiB Markdown,
+manifest at `dof_db/manifest_full.jsonl`, 0 dataless files), following
+`docs/corpus-storage-architecture.md` and the post-PoC decisions in
+`docs/corpus-storage-poc-results.md`.
+
+## Corpus store: done
+
+`dof_db/dof_corpus_l3.sqlite` — **3.52 GiB** (8.9x), zstd level 3,
+`corpus_version = dof-full-v1`.
+
+- Ingestion: 657,867 docs in 428 s (~1,540 docs/s, matches PoC
+  throughput); 105 oversized documents segmented (>32 MiB, 2.63 GiB raw).
+- Multi-source schema landed first: `documents.source DEFAULT 'dof'`,
+  source-aware `dict_chooser` (`dof_1999` … `dof_2026`), path namespacing
+  convention documented.
+- Per-year dictionaries trained via indexed queries (dict = 1% of group
+  bytes, ~4.4–24.7 MB per year); every row compressed with its year dict,
+  0 uncompressed rows.
+- 300/300 randomly sampled docs hash-verified against the raw tree.
+- Compression ratio 8.9x vs the PoC's 10.92x: the delta is the 2.63 GiB
+  of `[nodict]` oversized segments (~3x without dictionaries); ordinary
+  documents match the PoC ratio.
+
+### Full-scale maintenance gotcha (fixed in ingest.py)
+
+The extension's own maintenance path fails on the full corpus:
+
+- Its todo query `GROUP BY dict_chooser` over uncompressed rows has no
+  usable index and spills the whole uncompressed corpus to a temp b-tree
+  (measured 26+ GiB etilqs file) → `SQLITE_FULL` with a "full" disk.
+- Dict training runs one unindexed full-table scan per chooser group.
+- Reservoir sampling keeps ALL rows of groups >2 GiB, exceeding ZDICT's
+  2 GB sample limit (the 2011 group is 2.35 GiB).
+
+Fixes now in `corpus_store/ingest.py`: an expression index on the backing
+table matching the `dict_chooser`, indexed per-year dict pre-training with
+a 1.8 GiB reservoir cap, and bounded maintenance passes (1800 s) with WAL
+checkpoints between them. With these, full maintenance completes in ~6 min
+and the db shrinks 32 GiB → 3.52 GiB incrementally (auto_vacuum=FULL), so
+peak disk use stays modest.
+
+## Binary vector-store pilot: passed
+
+101,351 chunks (the 10k-doc PoC corpus), embedded via llama.cpp GGUF f16
+with `Document: ` prefix, sign-packed in-pipeline, only 128-byte blobs on
+disk (`corpus_store/embed.py`, resumable by contiguous chunk_id ranges,
+config recorded in `vector_meta`, mismatched-config resume refused).
+
+| Check | Result | Full-corpus extrapolation (x66) |
+|---|---|---|
+| Embedding throughput | 5.36 chunks/s (5.2 h for 101k) | ~14 days for 6.67M |
+| Plain checkpoint db | 142 B/vec | 0.88 GiB |
+| sqlite-vec `bit[1024]` vec0 db | 151 B/vec | 0.94 GiB |
+| Hamming scan k=50 | 5.0 ms mean, 5.3 ms p95 | ~0.33 s/query |
+| Bit-exactness (re-embed 64) | max 1 / 1024 bits | — |
+| Spot MRR (doc-collapsed) | 0.359 (n=51, 13 gold docs) | see note |
+
+Spot MRR note: only 13 of the 500 eval docs fall inside the 10k pilot
+corpus, so the check uses 51 queries against a ~20x harder distractor set
+than the PoC (reference anchor 0.545 over the 499-doc corpus). The value
+is sane — the storage path itself is proven by the bit-exactness check.
+The real quality gate is the full-corpus eval below.
+
+sqlite-vec's hamming scan is ~5x faster than numpy XOR+popcount at this
+scale, and `bit[1024]` vec0 needs no new dependencies. Decision confirmed:
+sqlite-vec for the binary store; sqlite-vector/TurboQuant4 stays the
+documented upgrade path.
+
+## Chunk store: in progress
+
+`dof_db/dof_chunks.sqlite` building at ~52 docs/s (span recipes,
+hash-verified; ETA ~3.5 h for 657,867 docs, expected ~6.6–6.7M chunks).
+
+## Remaining
+
+1. Full embedding run over ~6.67M chunks (~14 days continuous at
+   5.36 chunks/s; resumable, so interruptions are expected and safe).
+2. Doc-level FTS5 build on the full corpus (est. ~2.8 GiB).
+3. Full-corpus eval: 499-doc / 3,023-query set over the real stores —
+   BM25 vs vectors vs hybrid α=0.5. MRR will drop vs the 499-doc subset;
+   that's signal, not regression.
+4. License review before any production deployment (sqlite-vector
+   modified Elastic 2.0, sqlite-zstd LGPL-3.0; sqlite-vec is MIT).

--- a/docs/full-corpus-build.md
+++ b/docs/full-corpus-build.md
@@ -1,6 +1,6 @@
 # Full-Corpus Build Log
 
-Status: in progress
+Status: embedding run in progress (ETA ~13.5 days from 2026-08-04)
 Date: 2026-08-03
 Branch: `feat/full-corpus-build`
 
@@ -72,18 +72,57 @@ scale, and `bit[1024]` vec0 needs no new dependencies. Decision confirmed:
 sqlite-vec for the binary store; sqlite-vector/TurboQuant4 stays the
 documented upgrade path.
 
-## Chunk store: in progress
+## Chunk store: done
 
-`dof_db/dof_chunks.sqlite` building at ~52 docs/s (span recipes,
-hash-verified; ETA ~3.5 h for 657,867 docs, expected ~6.6–6.7M chunks).
+`dof_db/dof_chunks.sqlite` — **2.68 GiB**, 657,867 docs -> **6,730,304
+chunks** (10.2 chunks/doc, matching the PoC's 10.1), built in 4.2 h
+(~44 docs/s with the batch tokenizer path).
+
+- 0.75% literal fallbacks (PoC: 1.31%); recipes average 91 B/chunk.
+- 500/500 random reconstructions hash-verified through the full query
+  path (p50 1.05 ms, p95 8.85 ms per chunk).
+- The 671.7 MiB monster doc chunks fine (583 s, 10,658 chunks).
+
+### Chunker fixes (exact-output-preserving, parity 799/799)
+
+Two pre-existing chunker bugs surfaced at full scale (doc 129,449, a
+6.2 MiB ASCII-grid table, stalled the build for hours):
+
+- `_flush_table`: a "header" larger than MAX_TOKENS made
+  `max_row_tokens <= 0`, so `_force_split` emitted 1-char pieces each
+  prepended with the giant header — 519k chunks / 21 GiB of chunk text
+  from one 6.2 MiB doc. Guard: oversized headers are treated as no
+  header. Only affects docs that previously could not finish at all.
+- Per-row/per-paragraph tokenizer calls now batch through the inner Rust
+  tokenizer's `encode_batch` (counts verified equal), recounts are
+  memoized, and oversized-row force-splits run in parallel (the Rust
+  tokenizer releases the GIL). The pathological doc now chunks in 4 s.
+
+Parity was verified against the HEAD implementation on all 499 eval docs
+plus 300 random docs (799/799 bit-identical), so `chunker_version` stays
+`dof-chunker-v1` and cached eval embeddings remain valid. A seeded
+binary-search variant of `_force_split` was tried and **reverted**: token
+counts are not monotone in prefix length (rare BPE merges), and seeding
+changed cut points in 7/799 docs.
+
+## Full embedding run: in progress
+
+`dof_db/dof_vectors_jina_binary.sqlite`, all 6,730,304 chunks,
+`corpus_store/embed` (resumable by contiguous chunk_id ranges, config in
+`vector_meta`). Measured 5.36–5.77 chunks/s -> ETA ~13.5 days;
+interruptions are expected and safe — reruns resume after
+`MAX(chunk_id)`. Monitor `logs/full_embed.log`.
 
 ## Remaining
 
-1. Full embedding run over ~6.67M chunks (~14 days continuous at
-   5.36 chunks/s; resumable, so interruptions are expected and safe).
-2. Doc-level FTS5 build on the full corpus (est. ~2.8 GiB).
+1. ~~Full embedding run~~ (in progress, see above).
+2. Doc-level FTS5 build on the full corpus (est. ~2.8 GiB):
+   `CREATE VIRTUAL TABLE documents_fts USING fts5(markdown,
+   content='documents', content_rowid='document_id')` + `rebuild`.
 3. Full-corpus eval: 499-doc / 3,023-query set over the real stores —
    BM25 vs vectors vs hybrid α=0.5. MRR will drop vs the 499-doc subset;
-   that's signal, not regression.
+   that's signal, not regression. Do not commit re-run noise to
+   `eval/cache/hybrid_doclevel_results.json` (harness is slightly
+   nondeterministic at the 4th decimal).
 4. License review before any production deployment (sqlite-vector
    modified Elastic 2.0, sqlite-zstd LGPL-3.0; sqlite-vec is MIT).

--- a/rag_poc/chunker.py
+++ b/rag_poc/chunker.py
@@ -72,6 +72,27 @@ def _count_tokens(text: str) -> int:
     return len(_tokenizer.encode(text, add_special_tokens=False))
 
 
+def _count_tokens_batch(texts: list[str]) -> list[int]:
+    """Token counts for many strings in one Rust call.
+
+    Same values as _count_tokens per item (verified), without the per-call
+    Python overhead — hot loops (table rows, paragraphs) call this once
+    instead of tokenizing per iteration. Uses the inner tokenizers-lib
+    tokenizer directly: the model's custom wrapper does not expose
+    encode_batch at the Python level.
+    """
+    if _tokenizer is None:
+        return [_count_tokens(t) for t in texts]
+    inner = getattr(_tokenizer, "_tokenizer", None)
+    if inner is None or not hasattr(inner, "encode_batch"):
+        return [_count_tokens(t) for t in texts]
+    try:
+        return [len(e) for e in inner.encode_batch(
+            texts, add_special_tokens=False)]
+    except Exception:
+        return [_count_tokens(t) for t in texts]
+
+
 # ── Classifier ───────────────────────────────────────────────────────────
 def classify(text: str, size_bytes: int) -> DocPattern:
     # Size threshold tuned for the real tokenizer: 6 KB of markdown legal
@@ -356,19 +377,24 @@ def _split_by_heading(text: str, heading_re: re.Pattern) -> list[tuple[str, str]
 def _split_by_tokens(text: str, max_tokens: int, overlap: int) -> list[str]:
     """Split por párrafos respetando límite de tokens, con overlap."""
     paragraphs = re.split(r"\n{2,}", text)
-    # If a single paragraph is huge, split by single newlines first
+    # If a single paragraph is huge, split by single newlines first.
+    # Batch the counts (same values, one Rust call) and memoize them: the
+    # merge loop and the overlap recomputation recount the same strings.
+    para_counts = _count_tokens_batch(paragraphs)
     expanded: list[str] = []
-    for para in paragraphs:
-        if _count_tokens(para) > max_tokens:
+    for para, n in zip(paragraphs, para_counts):
+        if n > max_tokens:
             lines = para.splitlines()
             expanded.extend(lines)
         else:
             expanded.append(para)
     paragraphs = [p for p in expanded if p.strip()]
+    known: dict[str, int] = dict(zip(
+        paragraphs, _count_tokens_batch(paragraphs)))
 
     chunks, current, current_tokens = [], [], 0
     for para in paragraphs:
-        para_tokens = _count_tokens(para)
+        para_tokens = known[para]
         # If even a single line is too big, force-split by chars
         if para_tokens > max_tokens:
             forced = _force_split(para, max_tokens)
@@ -378,7 +404,7 @@ def _split_by_tokens(text: str, max_tokens: int, overlap: int) -> list[str]:
                     chunks.append("\n".join(current))
                     overlap_paras, overlap_count = [], 0
                     for p in reversed(current):
-                        t = _count_tokens(p)
+                        t = known.get(p) or _count_tokens(p)
                         if overlap_count + t > overlap:
                             break
                         overlap_paras.insert(0, p)
@@ -393,7 +419,7 @@ def _split_by_tokens(text: str, max_tokens: int, overlap: int) -> list[str]:
             chunks.append("\n\n".join(current))
             overlap_paras, overlap_count = [], 0
             for p in reversed(current):
-                t = _count_tokens(p)
+                t = known.get(p) or _count_tokens(p)
                 if overlap_count + t > overlap:
                     break
                 overlap_paras.insert(0, p)
@@ -445,12 +471,13 @@ def _merge_and_chunk(
     chunks: list[Chunk] = []
     current: list[str] = []
     current_tokens = 0
-    for part in parts:
-        part = part.strip()
+    stripped = [p.strip() for p in parts]
+    part_counts = dict(zip(stripped, _count_tokens_batch(stripped)))
+    for part in stripped:
         if not part:
             continue
         # If a single part is huge, flush current first, then split it
-        if _count_tokens(part) > MAX_TOKENS:
+        if part_counts[part] > MAX_TOKENS:
             if current:
                 text = "\n\n".join(current)
                 chunks.append(
@@ -475,7 +502,7 @@ def _merge_and_chunk(
                     )
                 )
             continue
-        t = _count_tokens(part)
+        t = part_counts[part]
         if current_tokens + t > MAX_TOKENS and current:
             text = "\n\n".join(current)
             chunks.append(
@@ -524,7 +551,32 @@ def _flush_table(
 
     header_text = "\n".join(header_lines) + "\n" if header_lines else ""
     header_tokens = _count_tokens(header_text) if header_lines else 0
+    if header_tokens >= MAX_TOKENS:
+        # Pathological "header" (e.g. giant ASCII-grid separator lines):
+        # it would consume the whole token budget, making max_row_tokens <= 0
+        # and force-splitting every row into 1-char pieces (chunk text
+        # amplification of thousands of x). Treat as no header instead.
+        header_lines = []
+        data_lines = list(lines)
+        header_text = ""
+        header_tokens = 0
     max_row_tokens = MAX_TOKENS - header_tokens
+
+    # One batched count for all rows instead of one tokenizer call per row.
+    row_counts = _count_tokens_batch(data_lines)
+
+    # Oversized rows are force-split independently of each other; run those
+    # in parallel (the tokenizer releases the GIL) and reassemble in row
+    # order. Outputs are identical to sequential per-row force-splits.
+    pieces_by_row: dict[int, list[str]] = {}
+    oversized = [i for i, t in enumerate(row_counts) if t > max_row_tokens]
+    if oversized:
+        from concurrent.futures import ThreadPoolExecutor
+        with ThreadPoolExecutor(max_workers=min(8, len(oversized))) as ex:
+            for i, pieces in zip(oversized, ex.map(
+                    lambda i: _force_split(data_lines[i], max_row_tokens),
+                    oversized)):
+                pieces_by_row[i] = pieces
 
     chunks: list[Chunk] = []
     batch: list[str] = []
@@ -544,12 +596,12 @@ def _flush_table(
         )
         batch.clear()
 
-    for row in data_lines:
-        row_tokens = _count_tokens(row)
+    for i, row in enumerate(data_lines):
+        row_tokens = row_counts[i]
         if row_tokens > max_row_tokens:
             _flush_batch()
             # Row alone exceeds the budget; force-split it.
-            for piece in _force_split(row, max_row_tokens):
+            for piece in pieces_by_row[i]:
                 chunks.append(
                     Chunk(
                         text=header_text + piece,

--- a/scripts/pilot_binary_vectors.py
+++ b/scripts/pilot_binary_vectors.py
@@ -1,0 +1,255 @@
+"""Pilot: validate the binary (sign) vector store at ~100k chunks.
+
+Validates the production storage path before committing to the ~14-day
+full-corpus embedding run:
+
+1. Real on-disk size of the bit-vector store (both the plain checkpoint
+   table written by corpus_store.embed and a sqlite-vec vec0 bit[1024]
+   search table), extrapolated to ~6.67M chunks.
+2. Hamming scan latency via sqlite-vec (vec0 MATCH, k=50) with a numpy
+   XOR+popcount reference, extrapolated to the full corpus.
+3. Bit-exactness spot check: re-embedded chunks sign-pack to (nearly) the
+   stored blobs.
+4. Spot MRR: eval queries whose gold document is inside the 10k-doc PoC
+   corpus (13 of 500 eval docs), chunk-level hamming retrieval collapsed
+   to documents. Reference anchor from the PoC (different corpus/mix, so
+   not a strict target): jina-binary doc-collapsed MRR 0.5452 over the
+   499-doc corpus.
+
+Run from repo root (llama-server must be on PATH), after corpus_store.embed
+has populated the pilot vectors db:
+    uv run python scripts/pilot_binary_vectors.py
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import sqlite_vec
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from corpus_store.db import connect  # noqa: E402
+from corpus_store.embed import (  # noqa: E402
+    DIMS, PREFIX_DOCUMENT, PREFIX_QUERY, embed_batch, pack_binary,
+    start_server)
+from corpus_store.chunk_index import normalized_text, reconstruct  # noqa: E402
+from corpus_store.db import fetch_document_text  # noqa: E402
+from rag_poc.chunker import DocPattern  # noqa: E402
+
+K = 50
+FULL_CORPUS_CHUNKS = 6_670_000  # 101,351 chunks / 10k docs * 657,867 docs
+
+
+def build_vec0(vectors: sqlite3.Connection, vec0_path: Path) -> sqlite3.Connection:
+    """Materialize the sqlite-vec bit[1024] search table from chunk_vectors."""
+    fresh = not vec0_path.exists()
+    conn = sqlite3.connect(str(vec0_path))
+    conn.enable_load_extension(True)
+    sqlite_vec.load(conn)
+    if fresh:
+        conn.execute("PRAGMA journal_mode = WAL")
+        conn.execute("PRAGMA synchronous = NORMAL")
+        conn.execute(
+            "CREATE VIRTUAL TABLE chunk_vec USING vec0(embedding bit[1024])")
+        rows = vectors.execute(
+            "SELECT chunk_id, embedding FROM chunk_vectors ORDER BY chunk_id")
+        batch = []
+        t0 = time.time()
+        n = 0
+        while True:
+            chunk = rows.fetchmany(10000)
+            if not chunk:
+                break
+            batch.extend(chunk)
+            conn.executemany(
+                "INSERT INTO chunk_vec(rowid, embedding) VALUES (?, vec_bit(?))",
+                batch)
+            conn.commit()
+            n += len(batch)
+            batch.clear()
+            print(f"  vec0 insert {n:,} ({time.time() - t0:.0f}s)", flush=True)
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    return conn
+
+
+def knn_vec0(conn: sqlite3.Connection, qblob: bytes, k: int) -> list[tuple[int, float]]:
+    return conn.execute(
+        "SELECT rowid, distance FROM chunk_vec"
+        " WHERE embedding MATCH vec_bit(?) AND k = ?", (qblob, k)).fetchall()
+
+
+def doc_collapse(ranked: list[tuple[int, float]],
+                 chunk_doc: dict[int, int]) -> list[int]:
+    """Chunk ranked list -> doc ids ordered by best (min) hamming distance."""
+    best: dict[int, float] = {}
+    for chunk_id, dist in ranked:
+        d = chunk_doc[chunk_id]
+        if d not in best or dist < best[d]:
+            best[d] = dist
+    return [d for d, _ in sorted(best.items(), key=lambda kv: kv[1])]
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--corpus-db", default="poc/data/dof_corpus_l3.sqlite")
+    ap.add_argument("--chunks-db", default="poc/data/dof_chunks.sqlite")
+    ap.add_argument("--vectors-db", default="poc/data/pilot_vectors.sqlite")
+    ap.add_argument("--vec0-db", default="poc/data/pilot_vec0.sqlite")
+    ap.add_argument("--manifest", default="poc/data/manifest_10k.jsonl")
+    ap.add_argument("--queries", default="eval/dof_queries_v2.jsonl")
+    ap.add_argument("--gguf", type=Path,
+                    default=Path.home() / "dof-gguf/jina-v5-small-retrieval-F16.gguf")
+    ap.add_argument("--port", type=int, default=8086)
+    ap.add_argument("--out", default="poc/data/pilot_binary_results.json")
+    args = ap.parse_args()
+
+    vectors = sqlite3.connect(args.vectors_db)
+    n_vecs = vectors.execute("SELECT COUNT(*) FROM chunk_vectors").fetchone()[0]
+    print(f"{n_vecs:,} embedded chunks")
+    meta = dict(vectors.execute("SELECT key, value FROM vector_meta"))
+    print(f"config: {meta}")
+
+    results: dict = {"n_vectors": n_vecs, "meta": meta}
+
+    # --- 1. on-disk size -------------------------------------------------
+    plain_size = Path(args.vectors_db).stat().st_size
+    print(f"\n[1] plain checkpoint db: {plain_size / 2**20:.1f} MiB "
+          f"({plain_size / n_vecs:.0f} B/vec -> "
+          f"{plain_size / n_vecs * FULL_CORPUS_CHUNKS / 2**30:.2f} GiB full corpus)")
+    vec0 = build_vec0(vectors, Path(args.vec0_db))
+    vec0_size = Path(args.vec0_db).stat().st_size
+    print(f"    vec0 search db:      {vec0_size / 2**20:.1f} MiB "
+          f"({vec0_size / n_vecs:.0f} B/vec -> "
+          f"{vec0_size / n_vecs * FULL_CORPUS_CHUNKS / 2**30:.2f} GiB full corpus)")
+    results["size"] = {
+        "plain_bytes": plain_size, "vec0_bytes": vec0_size,
+        "plain_b_per_vec": plain_size / n_vecs,
+        "vec0_b_per_vec": vec0_size / n_vecs,
+        "vec0_full_corpus_gib": vec0_size / n_vecs * FULL_CORPUS_CHUNKS / 2**30,
+    }
+
+    chunks = sqlite3.connect(args.chunks_db)
+    chunk_doc = dict(chunks.execute("SELECT chunk_id, document_id FROM chunks"))
+
+    # --- 2. hamming scan latency ------------------------------------------
+    print(f"\n[2] hamming scan latency (k={K}) over {n_vecs:,} vectors")
+    rng = np.random.default_rng(42)
+    probe_ids = rng.choice(n_vecs, size=min(64, n_vecs), replace=False) + 1
+    probes = [vectors.execute(
+        "SELECT embedding FROM chunk_vectors WHERE chunk_id = ?",
+        (int(i),)).fetchone()[0] for i in probe_ids]
+    lat = []
+    for q in probes:
+        t0 = time.perf_counter()
+        knn_vec0(vec0, q, K)
+        lat.append((time.perf_counter() - t0) * 1000)
+    lat = np.array(lat)
+    print(f"    sqlite-vec: mean {lat.mean():.2f} ms, p95 "
+          f"{np.percentile(lat, 95):.2f} ms "
+          f"(x{FULL_CORPUS_CHUNKS / n_vecs:.0f} -> "
+          f"~{lat.mean() * FULL_CORPUS_CHUNKS / n_vecs / 1000:.2f} s/query full corpus)")
+    mat = np.unpackbits(np.frombuffer(
+        b"".join(b for b, in vectors.execute(
+            "SELECT embedding FROM chunk_vectors ORDER BY chunk_id")),
+        dtype=np.uint8)).reshape(-1, DIMS)
+    qm = np.unpackbits(np.frombuffer(b"".join(probes), dtype=np.uint8)).reshape(-1, DIMS)
+    t0 = time.perf_counter()
+    for q in qm[:16]:
+        d = np.count_nonzero(mat != q, axis=1)
+        np.argpartition(d, K)[:K]
+    np_ms = (time.perf_counter() - t0) / 16 * 1000
+    print(f"    numpy ref:  mean {np_ms:.2f} ms")
+    results["latency"] = {
+        "vec0_ms_mean": float(lat.mean()), "vec0_ms_p95": float(np.percentile(lat, 95)),
+        "numpy_ms_mean": np_ms,
+        "vec0_full_corpus_s_est": lat.mean() * FULL_CORPUS_CHUNKS / n_vecs / 1000,
+    }
+
+    # --- 3 + 4. server-dependent checks -----------------------------------
+    proc = start_server(args.gguf, 8192, args.port)
+    try:
+        embed_batch(["warmup"], args.port)
+
+        # --- 3. bit-exactness spot check ----------------------------------
+        print("\n[3] bit-exactness: re-embed 64 random chunks, compare blobs")
+        corpus = connect(args.corpus_db)
+        spot_ids = (rng.choice(n_vecs, size=64, replace=False) + 1).tolist()
+        rows = chunks.execute(
+            "SELECT chunk_id, document_id, spans_json, pattern FROM chunks"
+            f" WHERE chunk_id IN ({','.join('?' * len(spot_ids))})",
+            [int(i) for i in spot_ids]).fetchall()
+        texts = []
+        for chunk_id, doc_id, spans_json, pattern in rows:
+            raw = fetch_document_text(corpus, doc_id)
+            c = normalized_text(raw, DocPattern(pattern))
+            texts.append((chunk_id, PREFIX_DOCUMENT + reconstruct(
+                json.loads(spans_json), c)))
+        emb = embed_batch([t for _, t in texts], args.port)
+        dists = []
+        for (chunk_id, _), e in zip(texts, emb):
+            stored = vectors.execute(
+                "SELECT embedding FROM chunk_vectors WHERE chunk_id = ?",
+                (chunk_id,)).fetchone()[0]
+            a = np.unpackbits(np.frombuffer(pack_binary(e), dtype=np.uint8))
+            b = np.unpackbits(np.frombuffer(stored, dtype=np.uint8))
+            dists.append(int(np.count_nonzero(a != b)))
+        dists = np.array(dists)
+        print(f"    hamming(re-embedded, stored): max {dists.max()}, "
+              f"mean {dists.mean():.2f} of {DIMS} bits")
+        results["bit_exactness"] = {"max": int(dists.max()),
+                                    "mean": float(dists.mean())}
+
+        # --- 4. spot MRR over pilot corpus ---------------------------------
+        print("\n[4] spot MRR (gold docs present in the 10k PoC corpus)")
+        manifest_paths = {json.loads(l)["relpath"]
+                          for l in Path(args.manifest).read_text().splitlines()}
+        corpus = connect(args.corpus_db)
+        path_doc = dict(corpus.execute("SELECT path, document_id FROM documents"))
+        eval_queries = []
+        for line in Path(args.queries).read_text().splitlines():
+            rec = json.loads(line)
+            if rec["relpath"] in manifest_paths:
+                for q in rec["queries"]:
+                    eval_queries.append((q["query"], path_doc[rec["relpath"]],
+                                         q["type"]))
+        print(f"    {len(eval_queries)} queries over "
+              f"{len({d for _, d, _ in eval_queries})} gold docs")
+        q_emb = embed_batch([PREFIX_QUERY + q for q, _, _ in eval_queries],
+                            args.port)
+        rr, r1, r10 = [], 0, 0
+        by_type: dict[str, list[float]] = {}
+        for (qtext, gold_doc, qtype), e in zip(eval_queries, q_emb):
+            ranked = knn_vec0(vec0, pack_binary(e), K)
+            docs = doc_collapse(ranked, chunk_doc)
+            rank = docs.index(gold_doc) + 1 if gold_doc in docs else None
+            rr.append(1.0 / rank if rank else 0.0)
+            by_type.setdefault(qtype, []).append(rr[-1])
+            r1 += rank == 1
+            r10 += rank is not None and rank <= 10
+        mrr = float(np.mean(rr))
+        print(f"    MRR {mrr:.4f}  R@1 {r1 / len(rr):.4f}  "
+              f"R@10 {r10 / len(rr):.4f}  (n={len(rr)})")
+        for t, v in sorted(by_type.items()):
+            print(f"      {t:18s} MRR {np.mean(v):.4f} (n={len(v)})")
+        results["spot_mrr"] = {
+            "mrr": mrr, "r_at_1": r1 / len(rr), "r_at_10": r10 / len(rr),
+            "n_queries": len(rr),
+            "reference_poc_jina_binary_doc_collapsed_mrr": 0.5452,
+            "note": "only 13/500 eval docs are inside the 10k pilot corpus; "
+                    "harder distractor set than the PoC, small n",
+        }
+    finally:
+        proc.terminate()
+        proc.wait()
+
+    Path(args.out).write_text(json.dumps(results, indent=2))
+    print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pilot_binary_vectors.py
+++ b/scripts/pilot_binary_vectors.py
@@ -213,6 +213,8 @@ def main() -> None:
         eval_queries = []
         for line in Path(args.queries).read_text().splitlines():
             rec = json.loads(line)
+            if rec.get("error") or not rec.get("queries"):
+                continue
             if rec["relpath"] in manifest_paths:
                 for q in rec["queries"]:
                     eval_queries.append((q["query"], path_doc[rec["relpath"]],


### PR DESCRIPTION
## Summary

Follow-up to #61 (corpus storage PoC). Two parts: multi-source schema prep (before the build, since the compressed schema is migrate-by-rebuild) and the full-corpus build itself over all 657,867 documents. Full details in `docs/full-corpus-build.md`.

### Part 1 — multi-source schema prep

- `documents.source TEXT NOT NULL DEFAULT 'dof'`, with `--source` / `--corpus-version` CLI args and `corpus_meta` recording.
- zstd `dict_chooser` is source-aware (`printf('%s_%d', source, year)` → `dof_1999`…): future sources train their own dictionaries instead of diluting DOF ones. Safe to change because decompression resolves dicts by stored id.
- `documents.path` namespaced per source (DOF keeps historical relpaths; future sources prefix `<source>/`).
- Docs updated: architecture doc (binary decision, multi-source readiness, ~6.67M-chunk estimates) and PoC results (post-PoC decisions section).

### Binary vector-store decision + pilot (gates the build)

Decision: jina **binary (sign) quantization**, not TurboQuant — hybrid MRR 0.649–0.650 vs 0.656 (~1 pt), but no separate quantization step and no fp32 on disk (6.73M × 4 KiB ≈ 27 GiB does not fit; `vector_quantize` requires stored fp32 blobs). TurboQuant4 stays as the documented upgrade path.

- `corpus_store/embed.py`: resumable llama.cpp embedding pipeline; sign() runs in-memory, only 128-byte packed blobs on disk; `Document:`/`Query:` prefixes; checkpoints by contiguous chunk_id ranges; refuses resume with mismatched config.
- `scripts/pilot_binary_vectors.py` over 101,351 chunks: **142 B/vec plain / 151 B/vec sqlite-vec bit[1024]** (0.88–0.94 GiB full-corpus), hamming scan 5 ms → **~0.33 s/query at 6.67M chunks**, re-embedded chunks match stored blobs to ≤1 bit, spot MRR sane (0.359, n=51 on a 20× harder distractor set).

### Part 2 — full build (corpus + chunks done, embeddings running)

- **Corpus store**: 657,867 docs in 428 s → **3.52 GiB (8.9×)** at zstd L3, 300/300 sampled docs hash-verified against the raw tree.
- **Full-scale maintenance fix**: the extension's todo query `GROUP BY dict_chooser` spills the whole uncompressed corpus to a 26+ GiB temp b-tree (`SQLITE_FULL`), dict training does one unindexed full-table scan per group, and reservoir sampling exceeds ZDICT's 2 GB sample limit on the 2.35 GiB 2011 group. Fixed in `ingest.py`: expression index on the backing table, indexed per-year dict pre-training with a 1.8 GiB reservoir cap, and bounded maintenance passes with WAL checkpoints. Full maintenance now ~6 min.
- **Chunker fixes** (exact-output-preserving, **799/799 bit-identical** vs HEAD on 499 eval docs + 300 random, so `chunker_version` stays `dof-chunker-v1`):
  - `_flush_table`: header ≥ MAX_TOKENS made `max_row_tokens ≤ 0` → `_force_split` emitted 1-char pieces each with the giant header prepended (**519k chunks / 21 GiB of chunk text from one 6.2 MiB doc**, stalled the build for hours). Guard: oversized headers are treated as no header.
  - Token counts batched via the inner Rust tokenizer's `encode_batch` (values verified equal), recounts memoized, per-row force-splits parallelized (GIL released in Rust). Pathological doc: 4 s instead of hours.
  - `chunk_index` logs SLOW docs (>60 s) for diagnosability.
- **Chunk store**: **6,730,304 chunks** (10.2/doc, matches PoC), 2.68 GiB, 0.75% literal fallbacks, 91 B/chunk recipes, 500/500 reconstructions hash-verified through the query path.

### Still running (not part of this PR's code)

The full embedding run over all 6.73M chunks is in progress locally (~13.5 days at 5.77 chunks/s, resumable). Remaining after it: FTS5 build and the full-corpus eval (BM25 vs vectors vs hybrid α=0.5). Tracked in `docs/full-corpus-build.md`.

## Test plan

- [x] Fresh 300-doc ingest smoke test: source column, `dof_1999` dict groups, round-trip, resume
- [x] Full corpus: 0 uncompressed rows, 300/300 sha256 vs raw tree
- [x] Chunker parity: 799/799 bit-identical outputs vs HEAD
- [x] Chunk store: 500/500 query-path reconstructions hash-verified
- [x] Pilot: storage/latency/bit-exactness/spot-MRR results in `poc/data/pilot_binary_results.json`
