### PR TITLE
Seed script: preseed web app with eval-v4 agent answers

### DIFF
--- a/scripts/seed_human_eval_v4.py
+++ b/scripts/seed_human_eval_v4.py
@@ -1,0 +1,113 @@
+"""Seed the human-evaluation web app with answers from an agent eval run.
+
+Reads an agent-eval results file (e.g. eval/cache/eval_v4_agent_all_*.json,
+whose ``results[].run`` entries carry the raw agent output) and registers
+each question as a completed run in the human-evaluation store, owned by the
+``seed:eval-v4`` system user and published by default so anonymous visitors
+can read — and signed-in users can review — the answers immediately.
+
+Idempotent: each seed run uses ``client_request_id = "eval-v4:<question id>"``,
+so rerunning the script skips questions that are already seeded.
+
+Usage:
+    uv run python scripts/seed_human_eval_v4.py \
+        --agent-results eval/cache/eval_v4_agent_all_kimi_k27_v9.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from human_eval.agent_executor import _public_result
+from human_eval.contracts import RunRequest
+from human_eval.store import EvaluationStore
+
+SEED_USER = "seed:eval-v4"
+
+
+def seed_run(store: EvaluationStore, item: dict, *, publish: bool) -> str:
+    """Create one seeded run; returns 'created', 'skipped', or 'failed'."""
+    question_id = item["id"]
+    run = item.get("run") or {}
+    request = RunRequest(
+        question=item["question"],
+        as_of=item.get("as_of"),
+        required_hops=max(1, min(5, int(item.get("required_hops") or 1))),
+        client_request_id=f"eval-v4:{question_id}",
+    )
+    provenance = {
+        "seeded_from": "eval_v4_agent_results",
+        "source_eval_id": question_id,
+        "category": item.get("category"),
+        "corpus_version": "dof-full-v1",
+        "chunker_version": "dof-chunker-v1",
+        "model": run.get("model"),
+        "configuration": {
+            "retrieval_mode": "lexical",
+            "max_model_turns": run.get("model_turns"),
+            "max_tool_calls": run.get("tool_calls"),
+        },
+    }
+    record, created = store.create_run(
+        request, user_id=SEED_USER, provenance=provenance
+    )
+    if not created:
+        return "skipped"
+    store.append_event(record["run_id"], "started")
+    if run.get("answer", {}).get("answer"):
+        store.append_event(record["run_id"], "succeeded", _public_result(run))
+        if publish:
+            store.publish_run(record["run_id"], publisher_id=SEED_USER)
+        return "created"
+    store.append_event(
+        record["run_id"],
+        "failed",
+        {
+            "code": "seeded_incomplete_run",
+            "message": "La ejecución original no produjo respuesta.",
+        },
+    )
+    return "failed"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--agent-results", type=Path, required=True)
+    parser.add_argument(
+        "--db",
+        type=Path,
+        default=Path("var/human_evaluation.sqlite"),
+    )
+    parser.add_argument(
+        "--no-publish",
+        action="store_true",
+        help="create the runs but leave them unpublished",
+    )
+    args = parser.parse_args()
+
+    data = json.loads(args.agent_results.read_text())
+    results = data.get("results")
+    if not isinstance(results, list):
+        raise SystemExit(f"{args.agent_results}: no 'results' list found")
+
+    store = EvaluationStore(args.db)
+    store.initialize()
+    counts = {"created": 0, "skipped": 0, "failed": 0}
+    for item in results:
+        outcome = seed_run(store, item, publish=not args.no_publish)
+        counts[outcome] += 1
+        print(f"{item['id']}: {outcome}")
+    print(
+        f"done: {counts['created']} created, {counts['skipped']} already "
+        f"present, {counts['failed']} without answer"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Resumen

`scripts/seed_human_eval_v4.py` convierte un archivo de resultados del agente (p. ej. `eval/cache/eval_v4_agent_all_kimi_k27_v9.json`, las 42 preguntas de eval v4) en ejecuciones completadas y **publicadas** del store de evaluación humana:

- Cada pregunta se crea con `client_request_id = "eval-v4:<id>"` → reruns son no-ops (idempotente).
- El payload público se construye con el mismo `_public_result` del executor, así que las páginas públicas renderizan respuesta, evidencia y traza igual que una ejecución real.
- Las ejecuciones quedan a nombre del usuario de sistema `seed:eval-v4` y se publican por defecto (`--no-publish` para dejarlas en borrador); las que no produjeron respuesta se registran como fallidas y nunca se publican.
- La provenance registra el origen (`seeded_from`, id de eval, modelo) para distinguirlas de ejecuciones interactivas.

Ya corrido contra `var/human_evaluation.sqlite` (con backup previo en `var/human_evaluation.sqlite.bak-v2`): 42/42 creadas y publicadas; la migración v2→v3 del esquema se verificó en vivo sobre los 5 runs del piloto anterior, que quedaron intactos. App reiniciada con el stack nuevo (Python 3.14 + Clerk): home anónimo lista las 42 respuestas, `/answers/{id}` renderiza completo, POST /runs anónimo redirige a /login.

🤖 Generated with [Pi](https://github.com/earendil-works/pi)