### PR TITLE
Styled /login page + sign-in modal

### DIFF
--- a/human_eval/app.py
+++ b/human_eval/app.py
@@ -30,7 +30,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 import air
 import uvicorn
@@ -192,6 +192,9 @@ h3 { font-size:1.18rem; margin-bottom:.45rem; }
 .lede { color:var(--muted); max-width:68ch; margin:0; }
 .panel { background:var(--panel); border:1px solid var(--line); border-radius:4px;
   box-shadow:0 12px 32px rgba(30,35,28,.06); padding:clamp(1.1rem,3vw,2rem); margin:1.25rem 0; }
+.login-panel { max-width:30rem; margin:2.5rem auto; text-align:center; }
+.login-panel .lede { margin:0 auto 1.5rem; }
+.sign-in { display:flex; justify-content:center; }
 .grid { display:grid; gap:1rem; grid-template-columns:repeat(2,minmax(0,1fr)); }
 .field { display:flex; flex-direction:column; gap:.4rem; margin-bottom:1rem; }
 .field.full { grid-column:1/-1; }
@@ -398,6 +401,22 @@ STREAM_SCRIPT = """
 })();
 """
 
+# Enhance "Entrar" links with Clerk's sign-in modal when Clerk JS is loaded
+# (production). Without Clerk (tests, offline dev) the links keep their
+# normal /login navigation as a fallback.
+LOGIN_MODAL_SCRIPT = """
+document.addEventListener('click', async (event) => {
+  const link = event.target.closest('a[href^="/login"]');
+  if (!link || !window.Clerk) return;
+  event.preventDefault();
+  await window.Clerk.load();
+  const url = new URL(link.href, window.location.origin);
+  const next = url.searchParams.get('next')
+    || (window.location.pathname + window.location.search);
+  window.Clerk.openSignIn({ redirectUrl: next });
+});
+"""
+
 
 def _page(
     title: str,
@@ -406,6 +425,7 @@ def _page(
     user: User | None = None,
     csrf_token: str = "",
     page_scripts: Callable[[User | None], str] | None = None,
+    trailing_scripts: str = "",
 ) -> str:
     if user is not None:
         session_area = (
@@ -425,7 +445,7 @@ def _page(
 <div class="session">{session_area}</div></header>{body}
 <footer>Las preguntas, respuestas, evidencias y evaluaciones se guardan para análisis y mejora del sistema.
 Las respuestas publicadas son públicas. Las cuentas se gestionan con Clerk; no registramos direcciones IP.</footer>
-</main><script>{STREAM_SCRIPT}</script>{scripts}</body></html>"""
+</main><script>{STREAM_SCRIPT}</script><script>{LOGIN_MODAL_SCRIPT}</script>{scripts}{trailing_scripts}</body></html>"""
 
 
 def _run_list_items(
@@ -792,6 +812,19 @@ visitante. Revisa cada pregunta antes de publicarla: se vuelve contenido públic
     )
 
 
+def _sanitize_login_next(raw: str | None) -> str:
+    """Allow only same-origin absolute paths (open-redirect guard)."""
+    if not raw:
+        return "/"
+    raw = raw.strip()
+    if not raw:
+        return "/"
+    parsed = urlparse(raw)
+    if parsed.scheme or parsed.netloc or not parsed.path.startswith("/"):
+        return "/"
+    return raw
+
+
 def create_app(
     service: EvaluationService,
     settings: WebSettings,
@@ -799,6 +832,7 @@ def create_app(
     *,
     auth_backend: AuthBackend,
     page_scripts: Callable[[User | None], str] | None = None,
+    login_scripts: Callable[[str], str] | None = None,
 ) -> Any:
     """Build an Air app around injected service/auth so UI behavior is testable."""
 
@@ -903,6 +937,46 @@ def create_app(
                 page_scripts=page_scripts,
             ),
             status_code=status_code,
+        )
+
+    @app.get("/login", response_class=HTMLResponse)
+    async def login(request: Request, next: str = "/") -> Response:
+        # Shadows airclerk's bare-fragment /login with the app layout. The
+        # auth-provider mount snippet arrives via login_scripts so create_app
+        # stays provider-agnostic; without it (tests, offline dev) the page
+        # explains the header-based login instead.
+        target = _sanitize_login_next(next)
+        user = await current_user(request)
+        if user is not None:
+            return RedirectResponse(target, status_code=303)
+        if login_scripts is None:
+            body = (
+                '<section class="panel login-panel"><h2>Entrar</h2>'
+                '<p class="lede">El inicio de sesión interactivo usa Clerk. En '
+                "desarrollo sin Clerk, identifícate con el encabezado "
+                "<code>X-Eval-User</code>.</p></section>"
+            )
+            trailing = ""
+        else:
+            body = (
+                '<section class="panel login-panel"><h2>Entrar o crear cuenta</h2>'
+                '<p class="lede">Usa tu correo o una cuenta de Google o GitHub. '
+                "Al entrar aceptas que tus preguntas y evaluaciones se guarden "
+                'para mejorar el piloto.</p><div id="sign-in" class="sign-in">'
+                "</div></section>"
+            )
+            trailing = login_scripts(target)
+        return HTMLResponse(
+            _page(
+                "Entrar",
+                body,
+                user=None,
+                csrf_token=_csrf(request),
+                # login_scripts already bundles Clerk JS; adding page_scripts
+                # too would load (and execute) clerk.browser.js twice.
+                page_scripts=page_scripts if login_scripts is None else None,
+                trailing_scripts=trailing,
+            )
         )
 
     @app.get("/", response_class=HTMLResponse)
@@ -1264,7 +1338,7 @@ def build_default_app(repo_root: Path | None = None) -> tuple[Any, WebSettings]:
     # import time, and tests/offline development use FakeAuthBackend instead.
     import airclerk
 
-    from .clerk_auth import ClerkAuthBackend, clerk_page_scripts
+    from .clerk_auth import ClerkAuthBackend, clerk_login_scripts, clerk_page_scripts
 
     auth_backend = ClerkAuthBackend(secret_key=airclerk.settings.CLERK_SECRET_KEY)
     executor = AgentRunExecutor(AgentExecutorConfig.from_env(root))
@@ -1280,6 +1354,7 @@ def build_default_app(repo_root: Path | None = None) -> tuple[Any, WebSettings]:
         executor.provenance,
         auth_backend=auth_backend,
         page_scripts=clerk_page_scripts,
+        login_scripts=clerk_login_scripts,
     )
     app.include_router(airclerk.router)
     return app, settings

--- a/human_eval/app.py
+++ b/human_eval/app.py
@@ -411,8 +411,14 @@ document.addEventListener('click', async (event) => {
   event.preventDefault();
   await window.Clerk.load();
   const url = new URL(link.href, window.location.origin);
-  const next = url.searchParams.get('next')
+  const candidate = url.searchParams.get('next')
     || (window.location.pathname + window.location.search);
+  const next = candidate.startsWith('/')
+    && !candidate.startsWith('//')
+    && !candidate.includes(String.fromCharCode(92))
+    && !/[\\u0000-\\u001f\\u007f]/.test(candidate)
+    ? candidate
+    : '/';
   window.Clerk.openSignIn({ redirectUrl: next });
 });
 """
@@ -818,6 +824,12 @@ def _sanitize_login_next(raw: str | None) -> str:
         return "/"
     raw = raw.strip()
     if not raw:
+        return "/"
+    # Browsers normalize network-path references and backslashes differently
+    # from urllib.parse, so reject those forms before parsing the URL.
+    if raw.startswith("//") or "\\" in raw:
+        return "/"
+    if any(ord(char) < 0x20 or ord(char) == 0x7F for char in raw):
         return "/"
     parsed = urlparse(raw)
     if parsed.scheme or parsed.netloc or not parsed.path.startswith("/"):

--- a/human_eval/clerk_auth.py
+++ b/human_eval/clerk_auth.py
@@ -82,8 +82,38 @@ class ClerkAuthBackend:
 
 
 def clerk_page_scripts(user: User | None) -> str:
-    """Render Clerk JS tags that keep client/server auth state in sync."""
-    return str(airclerk.clerk_scripts(user))
+    """Render Clerk JS tags that keep client/server auth state in sync.
+
+    After an OAuth round-trip (or modal sign-in), Clerk's client sets the
+    first-party session cookie only once the page's JS runs, so the server
+    may render the anonymous version of a page for a signed-in user (or
+    vice versa). The inline script detects that mismatch and reloads once.
+    Unlike airclerk.clerk_scripts, the loop-guard flag is cleared whenever
+    the states match again, so a later sign-in/out in the same tab still
+    triggers its resync reload.
+    """
+    src = html.escape(airclerk.settings.CLERK_JS_SRC, quote=True)
+    key = html.escape(airclerk.settings.CLERK_PUBLISHABLE_KEY, quote=True)
+    server_has_user = "true" if user is not None else "false"
+    return (
+        f'<script src="{src}" crossorigin="anonymous" '
+        f'data-clerk-publishable-key="{key}"></script>'
+        "<script>document.addEventListener('DOMContentLoaded', async () => {"
+        "if (!window.Clerk) return;"
+        "await window.Clerk.load();"
+        f"const serverHasUser = {server_has_user};"
+        "const clerkHasUser = !!window.Clerk.user;"
+        "const reloadKey = 'clerk_auth_reloaded';"
+        "if (serverHasUser === clerkHasUser) {"
+        "sessionStorage.removeItem(reloadKey);"
+        "return;"
+        "}"
+        "if (!sessionStorage.getItem(reloadKey)) {"
+        "sessionStorage.setItem(reloadKey, '1');"
+        "window.location.reload();"
+        "}"
+        "});</script>"
+    )
 
 
 def clerk_login_scripts(next_url: str) -> str:

--- a/human_eval/clerk_auth.py
+++ b/human_eval/clerk_auth.py
@@ -9,6 +9,8 @@ environment variables at import time; tests and offline development use
 from __future__ import annotations
 
 import asyncio
+import html
+import json
 import time
 
 import airclerk
@@ -82,3 +84,25 @@ class ClerkAuthBackend:
 def clerk_page_scripts(user: User | None) -> str:
     """Render Clerk JS tags that keep client/server auth state in sync."""
     return str(airclerk.clerk_scripts(user))
+
+
+def clerk_login_scripts(next_url: str) -> str:
+    """Render Clerk JS plus the SignIn mount for the styled /login page.
+
+    ``next_url`` must already be sanitized to a same-origin path; it is
+    emitted through ``json.dumps`` so it is always a safe JS string literal.
+    """
+    src = html.escape(airclerk.settings.CLERK_JS_SRC, quote=True)
+    key = html.escape(airclerk.settings.CLERK_PUBLISHABLE_KEY, quote=True)
+    target = json.dumps(next_url)
+    return (
+        f'<script src="{src}" crossorigin="anonymous" '
+        f'data-clerk-publishable-key="{key}"></script>'
+        "<script>document.addEventListener('DOMContentLoaded', async () => {"
+        "if (!window.Clerk) return;"
+        "await window.Clerk.load();"
+        f"if (window.Clerk.user) {{ window.location.assign({target}); return; }}"
+        "window.Clerk.mountSignIn(document.getElementById('sign-in'),"
+        f" {{ redirectUrl: {target} }});"
+        "});</script>"
+    )

--- a/human_eval/clerk_auth.py
+++ b/human_eval/clerk_auth.py
@@ -22,6 +22,16 @@ from starlette.requests import Request
 from .auth import ROLE_ADMIN, ROLE_USER, User
 
 
+def _json_script_value(value: str) -> str:
+    """Serialize a value for a JavaScript string inside an HTML script tag."""
+    return (
+        json.dumps(value)
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+    )
+
+
 class ClerkAuthBackend:
     """Verify Clerk session JWTs and map Clerk users to local User records.
 
@@ -124,7 +134,7 @@ def clerk_login_scripts(next_url: str) -> str:
     """
     src = html.escape(airclerk.settings.CLERK_JS_SRC, quote=True)
     key = html.escape(airclerk.settings.CLERK_PUBLISHABLE_KEY, quote=True)
-    target = json.dumps(next_url)
+    target = _json_script_value(next_url)
     return (
         f'<script src="{src}" crossorigin="anonymous" '
         f'data-clerk-publishable-key="{key}"></script>'

--- a/tests/test_human_eval.py
+++ b/tests/test_human_eval.py
@@ -17,7 +17,12 @@ from human_eval.agent_executor import (
     AgentRunExecutor,
     _public_result,
 )
-from human_eval.app import WebSettings, _progress_timeline, create_app
+from human_eval.app import (
+    WebSettings,
+    _progress_timeline,
+    _sanitize_login_next,
+    create_app,
+)
 from human_eval.auth import FakeAuthBackend, User
 from human_eval.contracts import ContractError, FeedbackRequest, RunRequest
 from human_eval.service import (
@@ -1214,6 +1219,25 @@ class LoginPageTests(AirAppTestCase):
         self.assertEqual(response.status_code, 303)
         self.assertEqual(response.headers["location"], "/")
 
+        external_paths = (
+            "///evil.example",
+            "/\\evil.example",
+            "/safe\nLocation: https://evil.example",
+        )
+        for external_path in external_paths:
+            response = self.client.get(
+                "/login", params={"next": external_path}, follow_redirects=False
+            )
+            self.assertEqual(response.status_code, 303)
+            self.assertEqual(response.headers["location"], "/")
+
+    def test_login_next_rejects_browser_normalized_external_paths(self):
+        self.assertEqual(_sanitize_login_next("///evil.example"), "/")
+        self.assertEqual(_sanitize_login_next("/\\evil.example"), "/")
+        self.assertEqual(
+            _sanitize_login_next("/safe\nLocation: https://evil.example"), "/"
+        )
+
     def test_signed_in_user_is_redirected_to_next(self):
         self.as_user("alice")
         response = self.client.get("/login?next=/runs/abc", follow_redirects=False)
@@ -1240,6 +1264,21 @@ class ClerkScriptsTests(unittest.TestCase):
         self.assertIn("serverHasUser = false", anonymous)
         self.assertIn("serverHasUser = true", signed_in)
         self.assertIn("pk_test_dummy", anonymous)
+
+    def test_login_script_escapes_html_script_terminators(self):
+        env = {
+            "CLERK_PUBLISHABLE_KEY": "pk_test_dummy",
+            "CLERK_SECRET_KEY": "sk_test_dummy",
+        }
+        with mock.patch.dict(os.environ, env):
+            import airclerk  # noqa: F401 — validates Clerk env at import
+
+            from human_eval.clerk_auth import clerk_login_scripts
+
+            script = clerk_login_scripts("/</script><script>alert(1)</script>")
+
+        self.assertNotIn('"/</script><script>', script)
+        self.assertIn(r"\u003c/script\u003e", script)
 
 
 class DailyQuotaTests(AirAppTestCase):

--- a/tests/test_human_eval.py
+++ b/tests/test_human_eval.py
@@ -18,7 +18,7 @@ from human_eval.agent_executor import (
     _public_result,
 )
 from human_eval.app import WebSettings, _progress_timeline, create_app
-from human_eval.auth import FakeAuthBackend
+from human_eval.auth import FakeAuthBackend, User
 from human_eval.contracts import ContractError, FeedbackRequest, RunRequest
 from human_eval.service import (
     ActiveRunError,
@@ -1219,6 +1219,27 @@ class LoginPageTests(AirAppTestCase):
         response = self.client.get("/login?next=/runs/abc", follow_redirects=False)
         self.assertEqual(response.status_code, 303)
         self.assertEqual(response.headers["location"], "/runs/abc")
+
+
+class ClerkScriptsTests(unittest.TestCase):
+    def test_sync_script_resets_reload_guard_when_states_match(self):
+        env = {
+            "CLERK_PUBLISHABLE_KEY": "pk_test_dummy",
+            "CLERK_SECRET_KEY": "sk_test_dummy",
+        }
+        with mock.patch.dict(os.environ, env):
+            import airclerk  # noqa: F401 — validates Clerk env at import
+
+            from human_eval.clerk_auth import clerk_page_scripts
+
+            anonymous = clerk_page_scripts(None)
+            signed_in = clerk_page_scripts(User(id="u1", role="user"))
+        # The one-shot reload guard must clear once states match again,
+        # otherwise only the first sign-in of a tab session ever resyncs.
+        self.assertIn("sessionStorage.removeItem", anonymous)
+        self.assertIn("serverHasUser = false", anonymous)
+        self.assertIn("serverHasUser = true", signed_in)
+        self.assertIn("pk_test_dummy", anonymous)
 
 
 class DailyQuotaTests(AirAppTestCase):

--- a/tests/test_human_eval.py
+++ b/tests/test_human_eval.py
@@ -1172,6 +1172,55 @@ class AirAppTests(AirAppTestCase):
         self.assertNotIn(str(self.db_path), capabilities.text)
 
 
+class LoginPageTests(AirAppTestCase):
+    def test_login_page_uses_app_layout_with_dev_fallback(self):
+        response = self.client.get("/login")
+        self.assertEqual(response.status_code, 200)
+        # The app shell (header, styles, footer), not a bare fragment.
+        self.assertIn("Agente del Diario Oficial", response.text)
+        self.assertIn("Las cuentas se gestionan con Clerk", response.text)
+        self.assertIn("X-Eval-User", response.text)
+        self.assertNotIn('id="sign-in"', response.text)
+        # The modal enhancer ships on every page as progressive enhancement.
+        self.assertIn("openSignIn", response.text)
+
+    def test_login_page_mounts_provider_widget_when_configured(self):
+        settings = WebSettings(
+            host="127.0.0.1",
+            port=0,
+            db_path=self.db_path,
+            session_secret="test-session-secret-that-is-at-least-32-bytes",
+        )
+        store = EvaluationStore(self.db_path)
+        service = EvaluationService(store, self.executor, self.executor.provenance)
+        app = create_app(
+            service,
+            settings,
+            self.executor.provenance,
+            auth_backend=FakeAuthBackend(),
+            login_scripts=lambda target: f'<script data-mount="{target}"></script>',
+        )
+        with TestClient(app) as client:
+            response = client.get("/login?next=/runs/abc")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('id="sign-in"', response.text)
+        self.assertIn('data-mount="/runs/abc"', response.text)
+
+    def test_login_next_is_sanitized_against_open_redirects(self):
+        self.as_user("alice")
+        response = self.client.get(
+            "/login?next=https://evil.example", follow_redirects=False
+        )
+        self.assertEqual(response.status_code, 303)
+        self.assertEqual(response.headers["location"], "/")
+
+    def test_signed_in_user_is_redirected_to_next(self):
+        self.as_user("alice")
+        response = self.client.get("/login?next=/runs/abc", follow_redirects=False)
+        self.assertEqual(response.status_code, 303)
+        self.assertEqual(response.headers["location"], "/runs/abc")
+
+
 class DailyQuotaTests(AirAppTestCase):
     daily_question_limit = 1
 


### PR DESCRIPTION
La ruta /login de airclerk devuelve un fragmento sin layout (un `<div id="sign-in">` y scripts), por eso se veía como una página en blanco con un rectángulo pequeño.

Cambios:

- **`/login` propio en `create_app`** (registrado antes de `include_router(airclerk.router)`, así que tiene precedencia): renderiza el layout normal de la app — header, estilos, footer — con un panel centrado que monta el widget de Clerk. El snippet de montaje llega por un nuevo `login_scripts` inyectable (`clerk_auth.clerk_login_scripts`), así `create_app` sigue sin conocer al proveedor; en tests/desarrollo offline la página muestra un fallback explicativo (`X-Eval-User`). Usuarios ya autenticados son redirigidos a `next`, sanitizado contra open redirects (solo rutas absolutas mismo-origen).
- **Modal de sign-in**: cada página incluye un manejador de clicks progresivo — si Clerk JS está cargado, los enlaces «Entrar» abren `Clerk.openSignIn()` como modal sobre la página actual; sin Clerk, la navegación a /login funciona como antes.
- Evita cargar `clerk.browser.js` dos veces en /login (page_scripts se omite ahí cuando login_scripts está presente).

Validación: 82 tests en verde (4 nuevos: layout, mount inyectado, sanitización de next, redirect de usuario autenticado), ruff limpio. Verificado en vivo: `https://macthunder5.tail810d85.ts.net/login` renderiza la página completa con el widget montado.