### PR TITLE
Add admin dashboard with question deletion

### DIFF
--- a/human_eval/app.py
+++ b/human_eval/app.py
@@ -210,6 +210,8 @@ button,.button { display:inline-block; border:0; border-radius:3px; color:white;
   cursor:pointer; font-weight:750; padding:.72rem 1rem; text-decoration:none; }
 button:hover,.button:hover { background:var(--accent-dark); }
 .secondary { background:transparent; border:1px solid var(--line); color:var(--ink); }
+.danger { background:var(--warn); }
+.danger:hover { background:#6d3013; }
 .status { border-left:5px solid var(--accent); }
 .status[data-state="failed"],.warning { border-left-color:var(--warn); }
 .meta { color:var(--muted); font-size:.86rem; }
@@ -472,7 +474,7 @@ def _page(
     if user is not None:
         session_area = (
             f'<span class="meta">{_escape(user.email or user.id)}'
-            f"{' · admin' if user.is_admin else ''}</span>"
+            f"{' · <a href="/admin">admin</a>' if user.is_admin else ''}</span>"
             f'<form method="post" action="/logout"><input type="hidden" name="csrf_token" '
             f'value="{_escape(csrf_token)}"><button class="secondary" type="submit">Salir</button></form>'
         )
@@ -811,26 +813,83 @@ No cambia esta respuesta ni el conjunto v4.</p>
 <button type="submit">Guardar evaluación</button></form></section>"""
 
 
+def _delete_run_form(run_id: str, csrf_token: str, *, next_url: str) -> str:
+    return f"""<form method="post" action="/admin/runs/{_escape(run_id)}/delete" style="margin-top:.4rem"
+onsubmit="return confirm('¿Eliminar esta pregunta y todos sus datos? Esta acción no se puede deshacer.');">
+<input type="hidden" name="csrf_token" value="{_escape(csrf_token)}">
+<input type="hidden" name="next" value="{_escape(next_url)}">
+<button class="danger" type="submit">Eliminar pregunta y datos</button></form>"""
+
+
 def _admin_panel(run: dict[str, Any], csrf_token: str) -> str:
     run_id = _escape(run["run_id"])
     published_at = run.get("published_at")
     next_url = _escape(f"/runs/{run['run_id']}")
+    delete_form = _delete_run_form(run["run_id"], csrf_token, next_url="/admin")
     if published_at:
         return f"""<section class="panel"><h2>Moderación</h2>
 <p class="meta">Publicada {_escape(published_at)} por {_escape(run.get("published_by") or "admin")}.</p>
 <form method="post" action="/admin/runs/{run_id}/unpublish">
 <input type="hidden" name="csrf_token" value="{_escape(csrf_token)}">
 <input type="hidden" name="next" value="{next_url}">
-<button class="secondary" type="submit">Retirar de la vista pública</button></form></section>"""
-    if run["status"] != "succeeded":
+<button class="secondary" type="submit">Retirar de la vista pública</button></form>
+{delete_form}</section>"""
+    if run["status"] not in ("succeeded", "failed"):
         return ""
+    if run["status"] == "failed":
+        return f"""<section class="panel"><h2>Moderación</h2>
+<p class="meta">La ejecución falló; solo puede eliminarse.</p>
+{delete_form}</section>"""
     return f"""<section class="panel"><h2>Moderación</h2>
 <p class="lede">Publicar hace visible la pregunta y la respuesta para cualquier visitante.
 Revisa que la pregunta no contenga datos personales antes de publicar.</p>
 <form method="post" action="/admin/runs/{run_id}/publish">
 <input type="hidden" name="csrf_token" value="{_escape(csrf_token)}">
 <input type="hidden" name="next" value="{next_url}">
-<button type="submit">Publicar respuesta</button></form></section>"""
+<button type="submit">Publicar respuesta</button></form>
+{delete_form}</section>"""
+
+
+def _admin_dashboard_page(
+    runs: list[dict[str, Any]],
+    *,
+    user: User,
+    csrf_token: str,
+    page_scripts: Callable[[User | None], str] | None = None,
+) -> str:
+    rows = []
+    for run in runs:
+        state = _escape(STATUS_LABELS.get(run["status"], run["status"]))
+        if run["published_at"]:
+            state += f" · Publicada {_escape(run['published_at'])}"
+        delete = ""
+        if run["status"] not in ("queued", "running"):
+            delete = _delete_run_form(run["run_id"], csrf_token, next_url="/admin")
+        rows.append(
+            f"""<li><a href="/runs/{_escape(run["run_id"])}">{_escape(run["question"])}</a>
+<span class="meta">{state} · {_escape(run["created_at"])} · {_escape(run["user_id"])}</span>{delete}</li>"""
+        )
+    items = (
+        "".join(rows)
+        or '<li><span class="meta">No hay preguntas registradas.</span></li>'
+    )
+    body = f"""<p><a href="/">← Portada</a></p><section><p class="eyebrow">Administración</p>
+<h1>Panel de administración</h1><p class="lede">Acciones editoriales del piloto.
+Las cuentas y los roles se gestionan en Clerk.</p></section>
+<section class="panel"><h2>Moderación</h2>
+<p class="meta">Publica o retira respuestas de la vista pública.</p>
+<p><a href="/admin/queue">Cola de publicación →</a></p></section>
+<section class="panel"><h2>Preguntas</h2>
+<p class="meta">Eliminar borra la pregunta, la respuesta, la evidencia registrada y las
+evaluaciones asociadas. Las ejecuciones en curso no pueden eliminarse. Esta acción no se puede deshacer.</p>
+<ul class="run-list">{items}</ul></section>"""
+    return _page(
+        "Administración",
+        body,
+        user=user,
+        csrf_token=csrf_token,
+        page_scripts=page_scripts,
+    )
 
 
 def _moderation_page(
@@ -862,7 +921,7 @@ def _moderation_page(
         "".join(rows)
         or '<li><span class="meta">No hay respuestas por moderar.</span></li>'
     )
-    body = f"""<p><a href="/">← Portada</a></p><section><p class="eyebrow">Moderación</p>
+    body = f"""<p><a href="/admin">← Panel de administración</a></p><section><p class="eyebrow">Moderación</p>
 <h1>Cola de publicación</h1><p class="lede">Las respuestas publicadas son visibles para cualquier
 visitante. Revisa cada pregunta antes de publicarla: se vuelve contenido público.</p></section>
 <section class="panel"><ul class="run-list">{items}</ul></section>"""
@@ -1326,6 +1385,22 @@ Publicada: {_escape(run.get("published_at"))}</p></section>
             f"{next_url}{separator}feedback=recorded", status_code=303
         )
 
+    @app.get("/admin", response_class=HTMLResponse)
+    async def admin_dashboard(request: Request) -> Response:
+        user = await current_user(request)
+        if user is None:
+            return login_redirect(request)
+        if not user.is_admin:
+            return HTMLResponse("Solo administradores.", status_code=403)
+        return HTMLResponse(
+            _admin_dashboard_page(
+                service.store.admin_runs(),
+                user=user,
+                csrf_token=_csrf(request),
+                page_scripts=page_scripts,
+            )
+        )
+
     @app.get("/admin/queue", response_class=HTMLResponse)
     async def moderation_queue(request: Request) -> Response:
         user = await current_user(request)
@@ -1369,6 +1444,27 @@ Publicada: {_escape(run.get("published_at"))}</p></section>
         except ValueError as exc:
             return HTMLResponse(_escape(str(exc)), status_code=422)
         next_url = _safe_next(form.get("next"), "/admin/queue")
+        return RedirectResponse(next_url, status_code=303)
+
+    @app.post("/admin/runs/{run_id}/delete")
+    async def delete_run(request: Request, run_id: str) -> Response:
+        user = await current_user(request)
+        if user is None:
+            return login_redirect(request)
+        if not user.is_admin:
+            return HTMLResponse("Solo administradores.", status_code=403)
+        form = await _form(request)
+        if not _csrf_valid(request, form.get("csrf_token")):
+            return HTMLResponse("La sesión del formulario venció.", status_code=403)
+        try:
+            service.delete_run(run_id)
+        except KeyError:
+            return HTMLResponse("Ejecución no encontrada.", status_code=404)
+        except ValueError as exc:
+            return HTMLResponse(_escape(str(exc)), status_code=422)
+        next_url = _safe_next(form.get("next"), "/admin")
+        if next_url in {f"/runs/{run_id}", f"/answers/{run_id}"}:
+            next_url = "/admin"
         return RedirectResponse(next_url, status_code=303)
 
     @app.get("/api/v1/health")

--- a/human_eval/service.py
+++ b/human_eval/service.py
@@ -253,6 +253,10 @@ class EvaluationService:
     def unpublish(self, run_id: str) -> None:
         self.store.unpublish_run(run_id)
 
+    def delete_run(self, run_id: str) -> None:
+        """Delete a terminal run and all its data (admin-only action)."""
+        self.store.delete_run(run_id)
+
     def _worker_loop(self) -> None:
         try:
             while not self._closing.is_set():

--- a/human_eval/store.py
+++ b/human_eval/store.py
@@ -386,6 +386,56 @@ class EvaluationStore:
             if cursor.rowcount == 0:
                 raise KeyError(run_id)
 
+    def admin_runs(self, *, limit: int = 200) -> list[dict[str, Any]]:
+        """All runs for the admin dashboard, newest first, with latest status."""
+        if not 1 <= limit <= 500:
+            raise ValueError("limit must be between 1 and 500")
+        with self._connect() as connection:
+            rows = connection.execute(
+                "SELECT r.run_id, r.question, r.created_at, r.published_at, "
+                "e.event_type, r.user_id "
+                "FROM runs r JOIN run_events e ON e.run_id = r.run_id "
+                "AND e.sequence = (SELECT MAX(e2.sequence) FROM run_events e2 "
+                "WHERE e2.run_id = r.run_id) "
+                "ORDER BY r.created_at DESC, r.run_id DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
+        return [
+            {
+                "run_id": row[0],
+                "question": row[1],
+                "created_at": row[2],
+                "published_at": row[3],
+                "status": "running" if row[4] == "started" else row[4],
+                "user_id": row[5],
+            }
+            for row in rows
+        ]
+
+    def delete_run(self, run_id: str) -> None:
+        """Delete a terminal run with its events, progress, and feedback.
+
+        Active runs (queued/running) are refused: the worker may still be
+        writing events for them, and the foreign keys to ``runs`` would make
+        those writes fail.
+        """
+        with self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            exists = connection.execute(
+                "SELECT 1 FROM runs WHERE run_id = ?", (run_id,)
+            ).fetchone()
+            if exists is None:
+                raise KeyError(run_id)
+            latest = connection.execute(
+                "SELECT event_type FROM run_events WHERE run_id = ? "
+                "ORDER BY sequence DESC LIMIT 1",
+                (run_id,),
+            ).fetchone()
+            if latest is not None and latest[0] in ("queued", "started"):
+                raise ValueError("active runs cannot be deleted")
+            for table in ("run_progress", "run_events", "feedback", "runs"):
+                connection.execute(f"DELETE FROM {table} WHERE run_id = ?", (run_id,))
+
     def check_health(self) -> bool:
         try:
             with self._connect() as connection:

--- a/tests/test_human_eval.py
+++ b/tests/test_human_eval.py
@@ -594,6 +594,72 @@ class StoreTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.store.delete_seed_run(second["run_id"], user_prefix="evaluator")
 
+    def test_delete_run_removes_run_and_related_data(self):
+        run, _ = self.store.create_run(
+            RunRequest("pregunta a borrar"), user_id="evaluator", provenance=PROVENANCE
+        )
+        self.store.append_event(run["run_id"], "started")
+        self.store.append_progress(
+            run["run_id"], "agent_started", {"message": "inicio"}
+        )
+        self.store.append_event(run["run_id"], "succeeded", {"answer": {}})
+        self.store.add_feedback(
+            run["run_id"], FeedbackRequest("helpful", (), ""), user_id="evaluator"
+        )
+
+        self.store.delete_run(run["run_id"])
+
+        self.assertIsNone(self.store.get_run(run["run_id"]))
+        self.assertEqual(self.store.progress_for_run(run["run_id"]), [])
+        self.assertEqual(self.store.feedback_for_run(run["run_id"]), [])
+        with sqlite3.connect(self.path) as connection:
+            for table in ("runs", "run_events", "run_progress", "feedback"):
+                count = connection.execute(
+                    f"SELECT COUNT(*) FROM {table} WHERE run_id = ?",
+                    (run["run_id"],),
+                ).fetchone()[0]
+                self.assertEqual(count, 0, table)
+        with self.assertRaises(KeyError):
+            self.store.delete_run(run["run_id"])
+
+    def test_delete_run_refuses_active_runs(self):
+        run, _ = self.store.create_run(
+            RunRequest("pregunta en curso"), user_id="evaluator", provenance=PROVENANCE
+        )
+        with self.assertRaises(ValueError):
+            self.store.delete_run(run["run_id"])  # queued
+        self.store.append_event(run["run_id"], "started")
+        with self.assertRaises(ValueError):
+            self.store.delete_run(run["run_id"])  # running
+        self.assertIsNotNone(self.store.get_run(run["run_id"]))
+
+        self.store.append_event(run["run_id"], "failed", {"code": "x", "message": "y"})
+        self.store.delete_run(run["run_id"])
+        self.assertIsNone(self.store.get_run(run["run_id"]))
+
+    def test_admin_runs_lists_all_runs_with_status(self):
+        first, _ = self.store.create_run(
+            RunRequest("primera pregunta"), user_id="evaluator", provenance=PROVENANCE
+        )
+        second, _ = self.store.create_run(
+            RunRequest("segunda pregunta"), user_id="otra", provenance=PROVENANCE
+        )
+        self.store.append_event(first["run_id"], "started")
+        self.store.append_event(first["run_id"], "succeeded", {"answer": {}})
+        self.store.publish_run(first["run_id"], publisher_id="root")
+
+        runs = self.store.admin_runs()
+        self.assertEqual(
+            [run["run_id"] for run in runs], [second["run_id"], first["run_id"]]
+        )
+        self.assertEqual(runs[0]["status"], "queued")
+        self.assertEqual(runs[0]["user_id"], "otra")
+        self.assertIsNone(runs[0]["published_at"])
+        self.assertEqual(runs[1]["status"], "succeeded")
+        self.assertIsNotNone(runs[1]["published_at"])
+        with self.assertRaises(ValueError):
+            self.store.admin_runs(limit=0)
+
     def test_failed_seed_run_is_retried_on_the_next_attempt(self):
         class FlakySeedExecutor:
             def __init__(self):
@@ -1302,6 +1368,83 @@ class AirAppTests(AirAppTestCase):
         self.assertEqual(unpublished.status_code, 303)
         self.as_anonymous()
         self.assertEqual(self.client.get(f"/answers/{run_id}").status_code, 404)
+
+    def test_admin_dashboard_and_delete_question(self):
+        self.as_user("root", admin=True)
+        run_id = self.create_run("pregunta que se eliminará")
+        wait_for_terminal(self.service, run_id)
+        self.assertEqual(self.publish(run_id).status_code, 303)
+
+        # Anonymous visitors see the published answer but not the dashboard.
+        self.as_anonymous()
+        self.assertEqual(self.client.get(f"/answers/{run_id}").status_code, 200)
+        anon = self.client.get("/admin", follow_redirects=False)
+        self.assertEqual(anon.status_code, 303)
+
+        # Non-admins cannot see the dashboard nor delete.
+        self.as_user("bob")
+        home = self.client.get("/")
+        self.assertNotIn('<a href="/admin">admin</a>', home.text)
+        self.assertEqual(self.client.get("/admin").status_code, 403)
+        denied = self.client.post(
+            f"/admin/runs/{run_id}/delete",
+            data={"csrf_token": self.csrf(), "next": "/admin"},
+            follow_redirects=False,
+        )
+        self.assertEqual(denied.status_code, 403)
+        self.assertIsNotNone(self.service.store.get_run(run_id))
+
+        # Admins get a header link and the dashboard lists the run.
+        self.as_user("root", admin=True)
+        home = self.client.get("/")
+        self.assertIn('<a href="/admin">admin</a>', home.text)
+        dashboard = self.client.get("/admin")
+        self.assertEqual(dashboard.status_code, 200)
+        self.assertIn("Panel de administración", dashboard.text)
+        self.assertIn("pregunta que se eliminará", dashboard.text)
+        self.assertIn("/admin/queue", dashboard.text)
+
+        # CSRF is enforced.
+        rejected = self.client.post(
+            f"/admin/runs/{run_id}/delete",
+            data={"csrf_token": "wrong", "next": "/admin"},
+            follow_redirects=False,
+        )
+        self.assertEqual(rejected.status_code, 403)
+        self.assertIsNotNone(self.service.store.get_run(run_id))
+
+        # Deletion removes the run and its public answer.
+        deleted = self.client.post(
+            f"/admin/runs/{run_id}/delete",
+            data={"csrf_token": self.csrf(), "next": "/admin"},
+            follow_redirects=False,
+        )
+        self.assertEqual(deleted.status_code, 303)
+        self.assertEqual(deleted.headers["location"], "/admin")
+        self.assertIsNone(self.service.store.get_run(run_id))
+        self.as_anonymous()
+        self.assertEqual(self.client.get(f"/answers/{run_id}").status_code, 404)
+
+    def test_delete_unknown_or_missing_run(self):
+        self.as_user("root", admin=True)
+        missing = self.client.post(
+            "/admin/runs/no-existe/delete",
+            data={"csrf_token": self.csrf(), "next": "/admin"},
+            follow_redirects=False,
+        )
+        self.assertEqual(missing.status_code, 404)
+
+    def test_delete_redirects_away_from_removed_run_page(self):
+        self.as_user("root", admin=True)
+        run_id = self.create_run("pregunta efímera")
+        wait_for_terminal(self.service, run_id)
+        response = self.client.post(
+            f"/admin/runs/{run_id}/delete",
+            data={"csrf_token": self.csrf(), "next": f"/runs/{run_id}"},
+            follow_redirects=False,
+        )
+        self.assertEqual(response.status_code, 303)
+        self.assertEqual(response.headers["location"], "/admin")
 
     def test_health_and_capabilities_are_public_but_reveal_no_paths(self):
         health = self.client.get("/api/v1/health")


### PR DESCRIPTION
## What

- The `admin` label in the header now links to a new **`/admin` dashboard**.
- `/admin` links to the existing publication queue (`/admin/queue`) and lists **every run** (newest first: status, publication state, date, author) with a per-run **Eliminar** action.
- New `POST /admin/runs/{run_id}/delete` endpoint: deletes the run **and** its events, progress, and feedback; published answers disappear from the public view.
- The run-page moderation panel gains the same delete action, and now also appears for **failed** runs (previously they had no admin actions at all).

## Safety

- Admin-only, POST + CSRF enforced (same pattern as publish/unpublish).
- **Active runs (queued/running) are refused** (`ValueError`, HTTP 422) so the worker never loses a run mid-flight (FK constraints would break its writes).
- Delete forms ask for JS confirmation; redirect targets pointing at the deleted run page are rewritten to `/admin`; `next` still goes through the open-redirect guard.
- Unknown runs return 404.

## Store/service

- `EvaluationStore.admin_runs()` — dashboard listing with latest status.
- `EvaluationStore.delete_run()` — transactional delete across `run_progress`, `run_events`, `feedback`, `runs`; `KeyError` on unknown, `ValueError` on active.
- `EvaluationService.delete_run()` — thin wrapper, consistent with `publish`/`unpublish`.

## Validation

- `uv run python -m unittest discover -s tests` — **106 tests OK** (new store tests for delete/listing/refusals; new app tests for dashboard access control, header link, CSRF, deletion removing the public answer, and redirect guards).
- `ruff check` and `ruff format --check` clean.
- Verified live on the running instance (local + Tailscale URL).
