### PR TITLE
Style 404 pages instead of blank plain-text responses

### DIFF
--- a/human_eval/app.py
+++ b/human_eval/app.py
@@ -934,6 +934,27 @@ visitante. Revisa cada pregunta antes de publicarla: se vuelve contenido públic
     )
 
 
+def _not_found_page(
+    title: str,
+    lede: str,
+    *,
+    user: User | None = None,
+    csrf_token: str = "",
+    page_scripts: Callable[[User | None], str] | None = None,
+) -> str:
+    body = f"""<section class="panel">
+<p class="eyebrow">Error 404</p><h2>{_escape(title)}</h2>
+<p class="lede">{_escape(lede)}</p>
+<p><a class="button secondary" href="/">← Ir a la portada</a></p></section>"""
+    return _page(
+        title,
+        body,
+        user=user,
+        csrf_token=csrf_token,
+        page_scripts=page_scripts,
+    )
+
+
 def _sanitize_login_next(raw: str | None) -> str:
     """Allow only same-origin absolute paths (open-redirect guard)."""
     if not raw:
@@ -1217,7 +1238,17 @@ def create_app(
                 admin=bool(user and user.is_admin),
             )
         except KeyError:
-            return HTMLResponse("Respuesta no encontrada.", status_code=404)
+            return HTMLResponse(
+                _not_found_page(
+                    "Respuesta no encontrada",
+                    "La respuesta que buscas no existe, fue retirada de la "
+                    "vista pública o todavía no se ha publicado.",
+                    user=user,
+                    csrf_token=_csrf(request) if user is not None else "",
+                    page_scripts=page_scripts,
+                ),
+                status_code=404,
+            )
         if run["status"] != "succeeded" or run.get("published_at") is None:
             # Owners/admins looking at their private run belong on /runs/.
             return RedirectResponse(f"/runs/{run_id}", status_code=303)
@@ -1254,7 +1285,16 @@ Publicada: {_escape(run.get("published_at"))}</p></section>
         try:
             run = service.public_run(run_id, user_id=user.id, admin=True)
         except KeyError:
-            return HTMLResponse("Ejecución no encontrada.", status_code=404)
+            return HTMLResponse(
+                _not_found_page(
+                    "Ejecución no encontrada",
+                    "La ejecución que buscas no existe o fue eliminada.",
+                    user=user,
+                    csrf_token=_csrf(request),
+                    page_scripts=page_scripts,
+                ),
+                status_code=404,
+            )
         csrf_token = _csrf(request)
         feedback_recorded = request.query_params.get("feedback") == "recorded"
         fragment = _status_fragment(
@@ -1492,6 +1532,28 @@ Publicada: {_escape(run.get("published_at"))}</p></section>
                     "active_runs_per_user": 1,
                 },
             }
+        )
+
+    @app.exception_handler(404)
+    async def not_found_handler(request: Request, exc: Exception) -> Response:
+        # Air registers its own default status-code handlers, which take
+        # precedence over class handlers, so 404 is customized by code.
+        # Browser paths get a styled page; the API keeps JSON responses.
+        detail = getattr(exc, "detail", "Not Found")
+        headers = getattr(exc, "headers", None)
+        if request.url.path.startswith("/api/"):
+            return JSONResponse({"detail": detail}, status_code=404, headers=headers)
+        user = await current_user(request)
+        return HTMLResponse(
+            _not_found_page(
+                "Página no encontrada",
+                "La dirección que buscas no corresponde a ninguna página del piloto.",
+                user=user,
+                csrf_token=_csrf(request) if user is not None else "",
+                page_scripts=page_scripts,
+            ),
+            status_code=404,
+            headers=headers,
         )
 
     return app

--- a/tests/test_human_eval.py
+++ b/tests/test_human_eval.py
@@ -1446,6 +1446,42 @@ class AirAppTests(AirAppTestCase):
         self.assertEqual(response.status_code, 303)
         self.assertEqual(response.headers["location"], "/admin")
 
+    def test_unknown_page_renders_styled_404(self):
+        response = self.client.get("/pagina-inexistente")
+        self.assertEqual(response.status_code, 404)
+        self.assertIn("text/html", response.headers["content-type"])
+        self.assertIn("Página no encontrada", response.text)
+        self.assertIn("Error 404", response.text)
+        self.assertIn("Agente del Diario", response.text)
+        self.assertIn('href="/"', response.text)
+
+    def test_unknown_answer_renders_styled_404(self):
+        response = self.client.get("/answers/no-existe")
+        self.assertEqual(response.status_code, 404)
+        self.assertIn("Respuesta no encontrada", response.text)
+        self.assertIn("Agente del Diario", response.text)
+        self.assertIn('href="/"', response.text)
+
+    def test_unknown_run_renders_styled_404_for_admin(self):
+        # Non-owners are redirected to /answers/; only owners and admins
+        # reach the run page itself.
+        self.as_user("root", admin=True)
+        response = self.client.get("/runs/no-existe")
+        self.assertEqual(response.status_code, 404)
+        self.assertIn("Ejecución no encontrada", response.text)
+        self.assertIn("Agente del Diario", response.text)
+        self.assertIn('<a href="/admin">admin</a>', response.text)
+
+    def test_unknown_api_route_returns_json_404(self):
+        response = self.client.get("/api/v1/inexistente")
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json(), {"detail": "Not Found"})
+
+    def test_method_not_allowed_keeps_plain_text_response(self):
+        response = self.client.post("/api/v1/health")
+        self.assertEqual(response.status_code, 405)
+        self.assertNotIn("text/html", response.headers["content-type"])
+
     def test_health_and_capabilities_are_public_but_reveal_no_paths(self):
         health = self.client.get("/api/v1/health")
         self.assertEqual(health.json(), {"status": "ok"})


### PR DESCRIPTION
## Problem

Not-found pages were blank plain-text responses outside the app's design:

- `/answers/{unknown-id}` → blank page with `Respuesta no encontrada.`
- `/{unknown-path}` → Air's default mvp.css 404 page ("The requested resource was not found on this server.")

## Changes

- **New `_not_found_page()`** renders 404s with the app's own layout: `Error 404` eyebrow, heading, explanation text, a "← Ir a la portada" button, and the normal header (session area included when signed in).
- **`/answers/{run_id}`** and **`/runs/{run_id}`** now use it ("Respuesta no encontrada" / "Ejecución no encontrada").
- **Global 404 handler** for unmatched routes, registered by status code because Air's default handlers (`DEFAULT_EXCEPTION_HANDLERS`) take precedence over class-based handlers:
  - browser paths → styled HTML page;
  - `/api/` paths → machine-readable JSON (`{"detail": "Not Found"}`).
- Machine-facing endpoints (SSE stream, status fragments, POST actions) keep their existing plain responses.

## Validation

- `uv run python -m unittest discover -s tests` — **111 tests OK** (new: styled 404 for unknown page/answer/run, JSON 404 for unknown API route, 405 stays plain text).
- `ruff check` / `ruff format --check` clean.
- Verified live (local + Tailscale): `/pagina-inexistente` and `/answers/no-existe` render the styled page.
