### PR TITLE
feat(agent): prefer recent sources for current-state questions

### DIFF
--- a/agent_tools/agent.py
+++ b/agent_tools/agent.py
@@ -262,6 +262,9 @@ Política de herramientas:
   entra a la evidencia (search_evidence, get_document_outline, read_chunks).
   La vigencia se verifica leyendo los documentos, no con más búsquedas.
   search_documents se desactiva después de unas pocas llamadas.
+- Cuando search_evidence muestre chunks de documentos recientes, incluye al
+  menos el mejor chunk de cada documento reciente en tu read_chunks antes de
+  descartarlo por su fragmento; el título del documento acompaña a cada chunk.
 - Usa get_document_outline sólo para estructura o referencias cruzadas, y
   list_publications cuando la fecha de publicación sea el dato de entrada.
 - El año sobre el que rige una norma o cantidad no implica que se publicara ese

--- a/agent_tools/agent.py
+++ b/agent_tools/agent.py
@@ -247,7 +247,9 @@ read_chunks y debes incluir al menos una cita válida. Si la evidencia es
 insuficiente, dilo. Marca una premisa como false únicamente cuando los chunks
 citados establezcan la corrección y exprésala de forma afirmativa. "No se encontró"
 no demuestra que una premisa sea falsa; si no puedes documentar la corrección,
-usa unclear. Mantén la respuesta concreta.
+usa unclear. Mantén la respuesta concreta. Indica la fecha de publicación de las
+fuentes que sostienen tu respuesta y, si la evidencia más reciente disponible es
+antigua, advierte que la regla o el programa pudo haber cambiado.
 Al terminar devuelve SOLO JSON con la forma
 {"answer":"...","citations":[123],"premise_status":"supported|false|unclear"}.
 
@@ -259,6 +261,11 @@ Política de herramientas:
   list_publications cuando la fecha de publicación sea el dato de entrada.
 - El año sobre el que rige una norma o cantidad no implica que se publicara ese
   año. No fijes date_from sólo a partir del año mencionado en la pregunta.
+- Si la pregunta trata sobre programas, apoyos, requisitos o reglas vigentes y
+  no fija una fecha histórica, usa prefer_recent=true en search_documents y
+  comprueba si el instrumento encontrado fue reformado, derogado o sustituido
+  con posterioridad antes de responder. No uses un date_from rígido que excluya
+  la ley o programa base todavía vigente.
 - Conserva todas las partes de la pregunta desde la primera búsqueda. En una
   comparación entre años, busca evidencia para ambos años antes de responder.
 """
@@ -604,6 +611,13 @@ class DofToolbox:
                     "query": {"type": "string", "minLength": 1, "maxLength": 1000},
                     "strategy": strategy,
                     **filters,
+                    "prefer_recent": _nullable("boolean")
+                    | {
+                        "description": (
+                            "true da prioridad a las publicaciones más recientes; "
+                            "úsalo para preguntas sobre la situación vigente."
+                        )
+                    },
                     "top_k": {"type": "integer", "minimum": 1, "maximum": 10},
                 }
             ),
@@ -643,7 +657,10 @@ class DofToolbox:
     def tool_definitions(self) -> list[dict[str, Any]]:
         descriptions = {
             "list_publications": "Lista publicaciones por fecha y sección sin buscar texto.",
-            "search_documents": "Encuentra documentos candidatos. No devuelve evidencia citable.",
+            "search_documents": (
+                "Encuentra documentos candidatos con su fecha de publicación. "
+                "No devuelve evidencia citable."
+            ),
             "search_evidence": "Busca chunks relevantes dentro de documentos candidatos.",
             "get_document_outline": "Muestra encabezados y chunks de un documento sin leer su texto.",
             "read_chunks": "Lee texto verificable. Sólo los IDs leídos pueden citarse al responder.",
@@ -736,6 +753,7 @@ class DofToolbox:
             bm25_depth=100,
             vector_k=300,
             top_k=arguments["top_k"],
+            prefer_recent=bool(arguments.get("prefer_recent")),
         )
         self._remember_documents(result.documents)
         return result.to_dict()

--- a/agent_tools/agent.py
+++ b/agent_tools/agent.py
@@ -263,9 +263,12 @@ Política de herramientas:
   año. No fijes date_from sólo a partir del año mencionado en la pregunta.
 - Si la pregunta trata sobre programas, apoyos, requisitos o reglas vigentes y
   no fija una fecha histórica, usa prefer_recent=true en search_documents y
-  comprueba si el instrumento encontrado fue reformado, derogado o sustituido
-  con posterioridad antes de responder. No uses un date_from rígido que excluya
-  la ley o programa base todavía vigente.
+  search_evidence, y comprueba si el instrumento encontrado fue reformado,
+  derogado o sustituido con posterioridad antes de responder. Lee evidencia de
+  los candidatos más recientes que traten el tema antes de cerrar con documentos
+  antiguos; si los documentos recientes no tratan el tema, dilo explícitamente.
+  No uses un date_from rígido que excluya la ley o programa base todavía
+  vigente.
 - Conserva todas las partes de la pregunta desde la primera búsqueda. En una
   comparación entre años, busca evidencia para ambos años antes de responder.
 """
@@ -631,6 +634,13 @@ class DofToolbox:
                         "maxItems": 10,
                     },
                     "strategy": strategy,
+                    "prefer_recent": _nullable("boolean")
+                    | {
+                        "description": (
+                            "true da visibilidad a chunks de documentos más "
+                            "recientes dentro de los candidatos."
+                        )
+                    },
                     "top_k": {"type": "integer", "minimum": 1, "maximum": 10},
                 }
             ),
@@ -773,6 +783,7 @@ class DofToolbox:
             top_k=arguments["top_k"],
             candidate_depth=300,
             vector_k=300,
+            prefer_recent=bool(arguments.get("prefer_recent")),
         )
         self.visible_chunk_ids.update(result.evidence_ids)
         data = result.to_dict()

--- a/agent_tools/agent.py
+++ b/agent_tools/agent.py
@@ -23,6 +23,8 @@ from .retrieval import DofRetriever, QueryEmbedder
 
 LOGGER = logging.getLogger(__name__)
 
+MAX_DOCUMENT_SEARCH_CALLS = 3
+
 YEAR_RE = re.compile(r"\b(?:19|20)\d{2}\b")
 YEAR_COMPARISON_RE = re.compile(
     r"\b(?:de\s+((?:19|20)\d{2})\s+a|entre\s+((?:19|20)\d{2})\s+y)\s+"
@@ -256,7 +258,10 @@ Al terminar devuelve SOLO JSON con la forma
 Política de herramientas:
 - Haz una sola llamada por turno y usa la ruta más corta: search_documents,
   search_evidence, read_chunks y respuesta.
-- No repitas la misma búsqueda con variaciones menores.
+- No repitas búsquedas con variaciones menores: tras una o dos search_documents
+  entra a la evidencia (search_evidence, get_document_outline, read_chunks).
+  La vigencia se verifica leyendo los documentos, no con más búsquedas.
+  search_documents se desactiva después de unas pocas llamadas.
 - Usa get_document_outline sólo para estructura o referencias cruzadas, y
   list_publications cuando la fecha de publicación sea el dato de entrada.
 - El año sobre el que rige una norma o cantidad no implica que se publicara ese
@@ -442,6 +447,7 @@ class DofToolbox:
         self.coverage_requirements: set[str] = set()
         self.covered_requirements: set[str] = set()
         self.required_hops = 1
+        self.search_document_calls = 0
         self._vector_cache: dict[str, bytes] = {}
         self._schemas = self._build_schemas()
 
@@ -471,6 +477,7 @@ class DofToolbox:
         self.coverage_requirements = set(coverage_requirements or [])
         self.covered_requirements.clear()
         self.required_hops = required_hops
+        self.search_document_calls = 0
         self._vector_cache.clear()
 
     @property
@@ -753,6 +760,7 @@ class DofToolbox:
         }
 
     def _call_search_documents(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        self.search_document_calls += 1
         strategy = arguments["strategy"]
         filters = self._filters(arguments)
         result = self.retriever.search_documents(
@@ -1170,21 +1178,17 @@ class AgentRunner:
         if self.toolbox.read_chunk_ids and not self.toolbox.missing_coverage:
             return []
         if self.toolbox.read_chunk_ids:
-            return [
-                definitions[name]
-                for name in ("search_documents", "search_evidence", "read_chunks")
-            ]
+            names = ["search_evidence", "read_chunks"]
+            if self.toolbox.search_document_calls < MAX_DOCUMENT_SEARCH_CALLS:
+                names.insert(0, "search_documents")
+            return [definitions[name] for name in names]
         if self.toolbox.visible_chunk_ids:
             return [definitions["read_chunks"]]
         if self.toolbox.visible_document_ids:
-            return [
-                definitions[name]
-                for name in (
-                    "search_documents",
-                    "search_evidence",
-                    "get_document_outline",
-                )
-            ]
+            names = ["search_evidence", "get_document_outline"]
+            if self.toolbox.search_document_calls < MAX_DOCUMENT_SEARCH_CALLS:
+                names.insert(0, "search_documents")
+            return [definitions[name] for name in names]
         return [definitions[name] for name in ("list_publications", "search_documents")]
 
     def run(
@@ -1264,6 +1268,7 @@ class AgentRunner:
                     "available_tools": [tool["name"] for tool in available_tools],
                 },
             )
+            available_names = {tool["name"] for tool in available_tools}
             turn = self.backend.create_turn(
                 input_items=turn_input,
                 tools=available_tools,
@@ -1311,6 +1316,19 @@ class AgentRunner:
                             "error": {
                                 "type": "tool_limit",
                                 "message": f"maximum {self.max_tool_calls} tool calls reached",
+                            },
+                        }
+                        elapsed_ms = 0.0
+                    elif call.name not in available_names:
+                        output = {
+                            "ok": False,
+                            "error": {
+                                "type": "tool_unavailable",
+                                "message": (
+                                    f"{call.name} no está disponible en este turno; "
+                                    "usa una de: "
+                                    + ", ".join(sorted(available_names))
+                                ),
                             },
                         }
                         elapsed_ms = 0.0

--- a/agent_tools/models.py
+++ b/agent_tools/models.py
@@ -88,6 +88,7 @@ class DocumentHit:
     title: str | None = None
     institution: str | None = None
     title_boost: float = 0.0
+    recency_boost: float = 0.0
 
 
 @dataclass(frozen=True)

--- a/agent_tools/models.py
+++ b/agent_tools/models.py
@@ -104,6 +104,7 @@ class EvidenceHit:
     score: float
     source: str
     rank: int = 0
+    title: str | None = None
 
 
 @dataclass(frozen=True)

--- a/agent_tools/retrieval.py
+++ b/agent_tools/retrieval.py
@@ -160,6 +160,27 @@ def _apply_recency_to_ranked(
     )
 
 
+FRAGMENT_TITLE_RE = re.compile(
+    r"^(?:[IVXLCDM]{1,6}\.|[A-Z]\.|secci[oó]n\b|cap[ií]tulo\b|apartado\b|"
+    r"numeral\b|transitorio)",
+    re.I,
+)
+
+
+def _title_is_fragment(title: str | None) -> bool:
+    """Detect fast heading-based titles that are document-body fragments.
+
+    The fast header path takes the first chunk heading as the title, which for
+    many documents yields meaningless fragments like "II. DEL PROGRAMA" or
+    "II. Se deroga;". Those hide the instrument name from the agent, so the
+    caller should fall back to full header extraction.
+    """
+    if title is None:
+        return True
+    stripped = title.strip()
+    return len(stripped) < 20 or bool(FRAGMENT_TITLE_RE.match(stripped))
+
+
 def _document_name_phrases(query: str) -> list[str]:
     """Extract explicit legal-instrument names for an exact-phrase lookup."""
     phrases: list[str] = []
@@ -782,6 +803,8 @@ class DofRetriever:
             (document_id,),
         ).fetchall()
         header = self._document_header(document_id)
+        if _title_is_fragment(header.title):
+            header = self._document_header(document_id, full=True)
         return DocumentOutline(
             document_id=int(row[0]),
             path=row[1],
@@ -986,7 +1009,7 @@ class DofRetriever:
             if doc_id not in doc_info:
                 continue
             header = headers[doc_id]
-            if header.title is None:
+            if _title_is_fragment(header.title):
                 header = self._document_header(doc_id, full=True)
             documents.append(
                 DocumentHit(

--- a/agent_tools/retrieval.py
+++ b/agent_tools/retrieval.py
@@ -823,6 +823,19 @@ class DofRetriever:
             institution=header.institution,
         )
 
+    def _evidence_titles(
+        self, document_ids: list[int]
+    ) -> dict[int, str | None]:
+        """Resolve readable titles for evidence hits (full header on fragments)."""
+        headers = self._document_headers(document_ids)
+        titles: dict[int, str | None] = {}
+        for document_id in document_ids:
+            header = headers[document_id]
+            if _title_is_fragment(header.title):
+                header = self._document_header(document_id, full=True)
+            titles[document_id] = header.title
+        return titles
+
     def read_chunks(
         self, chunk_ids: list[int], *, neighbor_window: int = 0
     ) -> list[EvidenceHit]:
@@ -858,6 +871,9 @@ class DofRetriever:
         ordered = sorted(
             records.values(), key=lambda item: (item.document_id, item.chunk_index)
         )
+        titles = self._evidence_titles(
+            list({record.document_id for record in ordered})
+        )
         return [
             EvidenceHit(
                 chunk_id=record.chunk_id,
@@ -871,6 +887,7 @@ class DofRetriever:
                 score=0.0,
                 source="read",
                 rank=rank,
+                title=titles.get(record.document_id),
             )
             for rank, (record, text) in enumerate(self._reconstruct_records(ordered), 1)
         ]
@@ -1127,6 +1144,7 @@ class DofRetriever:
             )
         ranked_ids = ranked_ids[:top_k]
 
+        titles = self._evidence_titles(document_ids)
         evidence: list[EvidenceHit] = []
         for rank, chunk_id in enumerate(ranked_ids, 1):
             item = by_id.get(chunk_id)
@@ -1151,6 +1169,7 @@ class DofRetriever:
                     score=score_by_id.get(chunk_id, vector_score.get(chunk_id, 0.0)),
                     source=source,
                     rank=rank,
+                    title=titles.get(record.document_id),
                 )
             )
         return EvidenceSearchResult(

--- a/agent_tools/retrieval.py
+++ b/agent_tools/retrieval.py
@@ -108,6 +108,27 @@ def _normative_title_boost(query: str, title: str | None) -> float:
     return boost
 
 
+def _recency_boosts(
+    candidates: list[tuple[int, str | None]], weight: float
+) -> dict[int, float]:
+    """Rank-based recency bonus: the newest dated candidate gets ``weight``.
+
+    Boosts decay linearly by recency rank so relevance still dominates, and
+    undated documents receive no bonus. Ordering by ``(-date, document_id)``
+    keeps the result deterministic for a static corpus.
+    """
+    dated = sorted(
+        ((date, document_id) for document_id, date in candidates if date),
+        key=lambda item: (item[0], -item[1]),
+        reverse=True,
+    )
+    n = len(dated)
+    return {
+        document_id: weight * (n - rank) / n
+        for rank, (_, document_id) in enumerate(dated)
+    }
+
+
 def _document_name_phrases(query: str) -> list[str]:
     """Extract explicit legal-instrument names for an exact-phrase lookup."""
     phrases: list[str] = []
@@ -811,6 +832,8 @@ class DofRetriever:
         vector_k: int = 200,
         top_k: int = 20,
         bm25_weight: float = 0.75,
+        prefer_recent: bool = False,
+        recency_weight: float = 0.15,
     ) -> DocumentSearchResult:
         """Find candidate documents using lexical, vector, or hybrid ranking."""
         started = perf_counter()
@@ -906,7 +929,20 @@ class DofRetriever:
                     fused_rank,
                 )
             )
-        reranked.sort(key=lambda row: (-(row[1] + row[4]), row[5], row[0]))
+        recency = (
+            _recency_boosts(
+                [
+                    (row[0], doc_info.get(row[0], (None, None, None))[1])
+                    for row in reranked
+                ],
+                recency_weight * max((row[1] for row in reranked), default=0.0),
+            )
+            if prefer_recent and reranked
+            else {}
+        )
+        reranked.sort(
+            key=lambda row: (-(row[1] + row[4] + recency.get(row[0], 0.0)), row[5], row[0])
+        )
         documents = []
         for rank, (
             doc_id,
@@ -927,13 +963,14 @@ class DofRetriever:
                     path=doc_info[doc_id][0],
                     publication_date=doc_info[doc_id][1],
                     section=doc_info[doc_id][2],
-                    score=score + title_boost,
+                    score=score + title_boost + recency.get(doc_id, 0.0),
                     bm25_score=bm25_score,
                     vector_score=vector_score,
                     rank=rank,
                     title=header.title or headers[doc_id].title,
                     institution=header.institution,
                     title_boost=title_boost,
+                    recency_boost=recency.get(doc_id, 0.0),
                 )
             )
         return DocumentSearchResult(
@@ -953,6 +990,8 @@ class DofRetriever:
                 "normative_title_rerank": True,
                 "dated_heading_candidates": bool(heading_titles),
                 "exact_title_candidates": bool(exact_titles),
+                "prefer_recent": prefer_recent,
+                "recency_weight": recency_weight if prefer_recent else 0.0,
             },
         )
 

--- a/agent_tools/retrieval.py
+++ b/agent_tools/retrieval.py
@@ -129,6 +129,37 @@ def _recency_boosts(
     }
 
 
+def _apply_recency_to_ranked(
+    ranked_ids: list[int],
+    dates: dict[int, str | None],
+    weight: float,
+) -> list[int]:
+    """Blend rank-based relevance with document recency.
+
+    The goal is visibility, not dominance: the best chunk from a recent
+    document should reach the top-k so the agent can judge it, without
+    pushing irrelevant recent chunks above highly relevant older ones.
+    """
+    n = len(ranked_ids)
+    if not n or weight <= 0.0:
+        return ranked_ids
+    relevance = {chunk_id: (n - rank) / n for rank, chunk_id in enumerate(ranked_ids)}
+    recency = _recency_boosts(
+        [(chunk_id, dates.get(chunk_id)) for chunk_id in ranked_ids], 1.0
+    )
+    return sorted(
+        ranked_ids,
+        key=lambda chunk_id: (
+            -(
+                (1.0 - weight) * relevance[chunk_id]
+                + weight * recency.get(chunk_id, 0.0)
+            ),
+            -relevance[chunk_id],
+            chunk_id,
+        ),
+    )
+
+
 def _document_name_phrases(query: str) -> list[str]:
     """Extract explicit legal-instrument names for an exact-phrase lookup."""
     phrases: list[str] = []
@@ -1005,6 +1036,8 @@ class DofRetriever:
         top_k: int = 20,
         candidate_depth: int = 200,
         vector_k: int = 200,
+        prefer_recent: bool = False,
+        recency_weight: float = 0.25,
     ) -> EvidenceSearchResult:
         """Search deeply for citable chunks inside candidate documents."""
         started = perf_counter()
@@ -1059,6 +1092,16 @@ class DofRetriever:
             ranked_ids = vector_ids
         else:
             ranked_ids = _rrf([lexical_ids, vector_ids])
+        if prefer_recent:
+            ranked_ids = _apply_recency_to_ranked(
+                ranked_ids,
+                {
+                    chunk_id: by_id[chunk_id][0].publication_date
+                    for chunk_id in ranked_ids
+                    if chunk_id in by_id
+                },
+                recency_weight,
+            )
         ranked_ids = ranked_ids[:top_k]
 
         evidence: list[EvidenceHit] = []
@@ -1101,6 +1144,8 @@ class DofRetriever:
                 "vector_k": vector_k,
                 "vector_filtering": "post_filter",
                 "lexical_ranker": "bounded_bm25",
+                "prefer_recent": prefer_recent,
+                "recency_weight": recency_weight if prefer_recent else 0.0,
             },
         )
 

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -21,6 +21,7 @@ from agent_tools.headers import extract_document_header
 from agent_tools.llm import _parse_json, answer_with_context
 from agent_tools.models import (
     DocumentOutline,
+    DocumentSearchResult,
     EvidenceHit,
     EvidenceSearchResult,
     IndexVersions,
@@ -35,6 +36,7 @@ from agent_tools.retrieval import (
     _document_name_phrases,
     _fuse_documents,
     _normative_title_boost,
+    _recency_boosts,
     _rrf,
 )
 from scripts.eval_v4_agent import (
@@ -242,6 +244,60 @@ class AgentToolsTests(unittest.TestCase):
             ),
             ["Ley General de Aguas"],
         )
+
+    def test_recency_boosts_favor_newest_and_skip_undated(self):
+        boosts = _recency_boosts(
+            [(1, "2009-06-01"), (2, "2024-03-15"), (3, None), (4, "2018-11-30")],
+            0.3,
+        )
+        self.assertNotIn(3, boosts)
+        self.assertAlmostEqual(boosts[2], 0.3)
+        self.assertGreater(boosts[2], boosts[4])
+        self.assertGreater(boosts[4], boosts[1])
+        self.assertEqual(boosts, _recency_boosts([(4, "2018-11-30"), (3, None), (2, "2024-03-15"), (1, "2009-06-01")], 0.3))
+
+    def test_search_documents_tool_exposes_prefer_recent(self):
+        toolbox = DofToolbox(FakeRetriever())
+        search = next(
+            tool
+            for tool in toolbox.tool_definitions()
+            if tool["name"] == "search_documents"
+        )
+        prefer_recent = search["parameters"]["properties"]["prefer_recent"]
+        self.assertEqual(prefer_recent["type"], ["boolean", "null"])
+
+    def test_toolbox_passes_prefer_recent_to_the_retriever(self):
+        class RecordingRetriever(FakeRetriever):
+            def __init__(self):
+                self.calls = []
+
+            def search_documents(self, query, **kwargs):
+                self.calls.append((query, kwargs))
+                return DocumentSearchResult(
+                    query=query,
+                    strategy=RetrievalStrategy(kwargs["strategy"]),
+                    filters=kwargs["filters"],
+                    versions=self.versions,
+                )
+
+        retriever = RecordingRetriever()
+        toolbox = DofToolbox(retriever)
+        toolbox.begin(as_of=None)
+        output = toolbox.call(
+            "search_documents",
+            {
+                "query": "apoyos para desempleo",
+                "strategy": "lexical",
+                "as_of": None,
+                "date_from": None,
+                "date_to": None,
+                "section": None,
+                "prefer_recent": True,
+                "top_k": 5,
+            },
+        )
+        self.assertTrue(output["ok"])
+        self.assertTrue(retriever.calls[0][1]["prefer_recent"])
 
     def test_comparison_years_are_explicit_coverage_requirements(self):
         self.assertEqual(

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -32,6 +32,7 @@ from agent_tools.models import (
     SearchResult,
 )
 from agent_tools.retrieval import (
+    _apply_recency_to_ranked,
     _bm25_chunk_scores,
     _document_name_phrases,
     _fuse_documents,
@@ -111,6 +112,8 @@ class MultiDocumentFakeRetriever(FakeRetriever):
         top_k=10,
         candidate_depth=300,
         vector_k=300,
+        prefer_recent=False,
+        recency_weight=0.25,
     ):
         hits = [
             EvidenceHit(
@@ -298,6 +301,31 @@ class AgentToolsTests(unittest.TestCase):
         )
         self.assertTrue(output["ok"])
         self.assertTrue(retriever.calls[0][1]["prefer_recent"])
+
+    def test_recency_rerank_gives_recent_chunks_visibility_without_dominance(self):
+        ranked = [10, 11, 12, 13, 14]
+        dates = {
+            10: "2009-12-29",
+            11: "2009-12-29",
+            12: "2009-12-29",
+            13: "2008-07-04",
+            14: "2021-03-19",
+        }
+        reordered = _apply_recency_to_ranked(ranked, dates, 0.25)
+        self.assertEqual(reordered[0], 10)
+        self.assertLess(reordered.index(14), reordered.index(13))
+        self.assertEqual(ranked, [10, 11, 12, 13, 14])
+        self.assertEqual(_apply_recency_to_ranked(ranked, dates, 0.0), ranked)
+
+    def test_search_evidence_tool_exposes_prefer_recent(self):
+        toolbox = DofToolbox(FakeRetriever())
+        search = next(
+            tool
+            for tool in toolbox.tool_definitions()
+            if tool["name"] == "search_evidence"
+        )
+        prefer_recent = search["parameters"]["properties"]["prefer_recent"]
+        self.assertEqual(prefer_recent["type"], ["boolean", "null"])
 
     def test_comparison_years_are_explicit_coverage_requirements(self):
         self.assertEqual(
@@ -870,6 +898,7 @@ class AgentToolsTests(unittest.TestCase):
                                 "query": "evidencia",
                                 "document_ids": [2, 3],
                                 "strategy": "lexical",
+                                "prefer_recent": None,
                                 "top_k": 5,
                             },
                         )

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -20,6 +20,7 @@ from agent_tools.agent import (
 from agent_tools.headers import extract_document_header
 from agent_tools.llm import _parse_json, answer_with_context
 from agent_tools.models import (
+    DocumentHit,
     DocumentOutline,
     DocumentSearchResult,
     EvidenceHit,
@@ -336,6 +337,55 @@ class AgentToolsTests(unittest.TestCase):
             "ACUERDO por el que se modifica el diverso",
         ):
             self.assertFalse(_title_is_fragment(real), real)
+
+    def test_agent_document_search_budget_forces_drill_down(self):
+        class SearchingRetriever(FakeRetriever):
+            def search_documents(self, query, **kwargs):
+                return DocumentSearchResult(
+                    query=query,
+                    strategy=RetrievalStrategy(kwargs["strategy"]),
+                    filters=kwargs["filters"],
+                    documents=[
+                        DocumentHit(
+                            document_id=2,
+                            path="doc.md",
+                            publication_date="2025-01-01",
+                            section="MAT",
+                            score=1.0,
+                            title="Documento",
+                        )
+                    ],
+                    versions=self.versions,
+                )
+
+        search_call = ToolCall(
+            call_id="call-search",
+            name="search_documents",
+            arguments={
+                "query": "apoyos desempleo",
+                "strategy": "lexical",
+                "as_of": None,
+                "date_from": None,
+                "date_to": None,
+                "section": None,
+                "prefer_recent": True,
+                "top_k": 5,
+            },
+        )
+        backend = ScriptedBackend(
+            [
+                ModelTurn(response_id=str(i), output_items=[], tool_calls=[search_call])
+                for i in range(4)
+            ]
+            + [ModelTurn(response_id="final", output_items=[], final_text="{}")]
+        )
+        toolbox = DofToolbox(SearchingRetriever())
+        run = AgentRunner(backend, toolbox, max_model_turns=5).run("pregunta")
+        self.assertEqual(toolbox.search_document_calls, 3)
+        self.assertEqual(run.tool_calls, 3)
+        fourth_turn_tools = {tool["name"] for tool in backend.calls[3]["tools"]}
+        self.assertNotIn("search_documents", fourth_turn_tools)
+        self.assertIn("search_evidence", fourth_turn_tools)
 
     def test_comparison_years_are_explicit_coverage_requirements(self):
         self.assertEqual(

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -39,6 +39,7 @@ from agent_tools.retrieval import (
     _normative_title_boost,
     _recency_boosts,
     _rrf,
+    _title_is_fragment,
 )
 from scripts.eval_v4_agent import (
     calculate_metrics,
@@ -326,6 +327,15 @@ class AgentToolsTests(unittest.TestCase):
         )
         prefer_recent = search["parameters"]["properties"]["prefer_recent"]
         self.assertEqual(prefer_recent["type"], ["boolean", "null"])
+
+    def test_fragment_titles_trigger_full_header_extraction(self):
+        for fragment in (None, "II. DEL PROGRAMA", "II. Se deroga;", "B. DOCUMENTACIÓN", "corto"):
+            self.assertTrue(_title_is_fragment(fragment), fragment)
+        for real in (
+            "REGLAS DE OPERACION DEL PROGRAMA DE APOYO AL EMPLEO",
+            "ACUERDO por el que se modifica el diverso",
+        ):
+            self.assertFalse(_title_is_fragment(real), real)
 
     def test_comparison_years_are_explicit_coverage_requirements(self):
         self.assertEqual(


### PR DESCRIPTION
## Problem

Answers didn't favor source recency. For example, *"¿Qué apoyos existen para desempleo en México y qué requisitos tienen?"* surfaced documents from 2009/2014 that are most likely no longer applicable, with no warning about their age.

## Changes

**Retrieval (`agent_tools/retrieval.py`, `models.py`)**
- New `_recency_boosts()` helper: deterministic, rank-based bonus (newest dated candidate gets the full weight, decays linearly; undated documents get none).
- `search_documents()` gains opt-in `prefer_recent` / `recency_weight` params. The boost is scaled to the candidate score range so it reorders close matches but never dominates relevance or the normative-title rerank. Recorded per hit (`DocumentHit.recency_boost`) and in result `settings`.

**Agent (`agent_tools/agent.py`)**
- `search_documents` tool schema exposes `prefer_recent` (nullable boolean, strict-schema compliant); the toolbox passes it through.
- `AGENT_INSTRUCTIONS` recency/vigencia policy: for questions about current programs/requirements with no historical date, use `prefer_recent=true`, verify the instrument wasn't later reformed/derogated, avoid rigid `date_from` filters that would exclude a still-in-force base law, and disclose source publication dates in the answer (warning when the newest available evidence is old).

## Why opt-in

Recency is wrong for questions targeting a specific date or instrument ("reforma de 2013", "NOM-035"), so the model decides per question under prompt guidance. Default behavior is unchanged, keeping eval baselines reproducible.

## Verification

- 114 tests pass; `ruff check human_eval tests agent_tools` clean; 3 new tests (boost ordering/determinism, schema exposure, toolbox pass-through).
- Smoke test on the real corpus with the example question: with `prefer_recent=True` the 2013 Programa Sectorial de Trabajo and a 2016 document move into the top ranks and the 2009 REGLAS DE OPERACION drop out, while the top-relevance 2021 document stays first.