### PR TITLE
feat(human-eval): support local llama-server agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,18 +154,32 @@ El corpus completo ya está construido: 657,867 documentos, 6.73 millones de chu
   ```
 
   Reporte en `reports/eval_v4_retrieval.md` y resultados deterministas versionados en `eval/cache/eval_v4_full_comparison.json`. Resultado final: la fusión híbrida supera a BM25 puro (MRR 0.339 contra 0.221; all-hop@20 0.595 contra 0.429).
-- Evaluación del agente completo: `uv run python scripts/eval_v4_agent.py --provider kimi-code --model kimi-for-coding`.
+- Evaluación del agente completo: `uv run python scripts/eval_v4_agent.py --provider kimi-code --model kimi-for-coding` (también `--provider llama-server --model <id>` contra un servidor local OpenAI-compatible, por defecto `http://127.0.0.1:8080/v1`).
 
 ## Sitio de evaluación humana
 
 Aplicación web (Air + Clerk) en `human_eval/` para que personas formulen preguntas reales al agente y evalúen las respuestas.
 
+El modo de recuperación por defecto es `hybrid` (índice vec0 + embeddings GGUF). Si solo quieres búsqueda léxica, usa `DOF_RETRIEVAL_MODE=lexical`.
+
 ```bash
 set -a; source .env; set +a  # CLERK_* y DOF_SESSION_SECRET (nunca imprimir valores)
 export DOF_AGENT_PROVIDER=kimi-code DOF_AGENT_MODEL=kimi-for-coding \
-  DOF_RETRIEVAL_MODE=lexical DOF_WEB_HOST=0.0.0.0 DOF_WEB_PORT=8765
+  DOF_RETRIEVAL_MODE=hybrid DOF_WEB_HOST=0.0.0.0 DOF_WEB_PORT=8765
 uv run python -m human_eval.app  # http://127.0.0.1:8765
 ```
+
+También se puede usar un modelo local a través de cualquier servidor OpenAI-compatible (llama.cpp `llama-server`, LM Studio, vLLM, ...). Por ejemplo, con `llama-server` sirviendo `qwen3.8` en `http://127.0.0.1:8080/` (verifica el id con `curl -s localhost:8080/v1/models`):
+
+```bash
+set -a; source .env; set +a
+export DOF_AGENT_PROVIDER=llama-server DOF_AGENT_MODEL=qwen3.8 \
+  DOF_RETRIEVAL_MODE=hybrid DOF_WEB_HOST=0.0.0.0 DOF_WEB_PORT=8765
+uv run python -m human_eval.app
+```
+
+- `DOF_AGENT_PROVIDER=llama-server` usa el endpoint de Chat Completions de `DOF_AGENT_BASE_URL` (por defecto `http://127.0.0.1:8080/v1`). No requiere API key; si la sirves con autenticación, pásala por `DOF_AGENT_API_KEY`.
+- El modelo de chat local (puerto 8080) es independiente del llama-server de embeddings que levanta el modo `hybrid` (`DOF_EMBED_PORT`, por defecto 8086): pueden correr a la vez.
 
 - Visitantes anónimos leen las respuestas publicadas. Con cuenta: 1 pregunta cada 24 h (`DOF_DAILY_QUESTION_LIMIT`) y hay que evaluar una respuesta publicada antes de cada pregunta, incluida la primera. Los administradores publican y despublican en `/admin/queue` (rol vía `public_metadata.role = "admin"` en el dashboard de Clerk).
 - Recuperación híbrida para preguntas en vivo: `DOF_RETRIEVAL_MODE=hybrid` (requiere el índice vec0 y `DOF_GGUF_MODEL`; el servidor de embeddings llama-server se levanta una sola vez por proceso, con `DOF_EMBED_PORT`, por defecto 8086).

--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ El corpus completo ya está construido: 657,867 documentos, 6.73 millones de chu
 
 Aplicación web (Air + Clerk) en `human_eval/` para que personas formulen preguntas reales al agente y evalúen las respuestas.
 
-El modo de recuperación por defecto es `hybrid` (índice vec0 + embeddings GGUF). Si solo quieres búsqueda léxica, usa `DOF_RETRIEVAL_MODE=lexical`.
+El modo de recuperación por defecto es `lexical`. Para usar el índice vec0 y
+embeddings GGUF, configura `DOF_RETRIEVAL_MODE=hybrid`.
 
 ```bash
 set -a; source .env; set +a  # CLERK_* y DOF_SESSION_SECRET (nunca imprimir valores)
@@ -169,17 +170,40 @@ export DOF_AGENT_PROVIDER=kimi-code DOF_AGENT_MODEL=kimi-for-coding \
 uv run python -m human_eval.app  # http://127.0.0.1:8765
 ```
 
-También se puede usar un modelo local a través de cualquier servidor OpenAI-compatible (llama.cpp `llama-server`, LM Studio, vLLM, ...). Por ejemplo, con `llama-server` sirviendo `qwen3.8` en `http://127.0.0.1:8080/` (verifica el id con `curl -s localhost:8080/v1/models`):
+También se puede usar un modelo local a través de cualquier servidor
+OpenAI-compatible (llama.cpp `llama-server`, LM Studio, vLLM, ...). Para
+Qwen3.8-27B en esta Mac, inicia un solo slot con 32K de contexto y conserva el
+razonamiento entre turnos de herramientas:
+
+```bash
+llama-server -hf unsloth/Qwen3.8-27B-GGUF:UD-Q4_K_M \
+  --jinja --alias qwen3.8 --reasoning-preserve -c 32768 -np 1
+```
+
+Qwen3.8 usa razonamiento `xhigh` por defecto. El agente envía
+`reasoning_effort=low` en cada petición para evitar sobre-razonamiento en el
+bucle de hasta ocho turnos; se puede cambiar con `DOF_REASONING_EFFORT` a
+`medium` o `xhigh`. Esta elección sigue la recomendación de empezar con
+razonamiento bajo de [Simon Willison](https://simonwillison.net/2026/Aug/16/qwen-38-27b/)
+y el soporte nativo descrito en la
+[ficha oficial de Qwen3.8-27B](https://huggingface.co/Qwen/Qwen3.8-27B).
+
+Con el servidor escuchando en `http://127.0.0.1:8080/` (verifica el id con
+`curl -s localhost:8080/v1/models`):
 
 ```bash
 set -a; source .env; set +a
 export DOF_AGENT_PROVIDER=llama-server DOF_AGENT_MODEL=qwen3.8 \
-  DOF_RETRIEVAL_MODE=hybrid DOF_WEB_HOST=0.0.0.0 DOF_WEB_PORT=8765
+  DOF_REASONING_EFFORT=low DOF_RETRIEVAL_MODE=hybrid \
+  DOF_WEB_HOST=0.0.0.0 DOF_WEB_PORT=8765
 uv run python -m human_eval.app
 ```
 
 - `DOF_AGENT_PROVIDER=llama-server` usa el endpoint de Chat Completions de `DOF_AGENT_BASE_URL` (por defecto `http://127.0.0.1:8080/v1`). No requiere API key; si la sirves con autenticación, pásala por `DOF_AGENT_API_KEY`.
-- El modelo de chat local (puerto 8080) es independiente del llama-server de embeddings que levanta el modo `hybrid` (`DOF_EMBED_PORT`, por defecto 8086): pueden correr a la vez.
+- El modelo de chat local usa el puerto 8080 y el servidor de embeddings del
+  modo `hybrid` usa `DOF_EMBED_PORT` (8086 por defecto). Pueden correr a la vez,
+  pero la aplicación rechaza configuraciones donde ambos intenten usar el mismo
+  puerto local.
 
 - Visitantes anónimos leen las respuestas publicadas. Con cuenta: 1 pregunta cada 24 h (`DOF_DAILY_QUESTION_LIMIT`) y hay que evaluar una respuesta publicada antes de cada pregunta, incluida la primera. Los administradores publican y despublican en `/admin/queue` (rol vía `public_metadata.role = "admin"` en el dashboard de Clerk).
 - Recuperación híbrida para preguntas en vivo: `DOF_RETRIEVAL_MODE=hybrid` (requiere el índice vec0 y `DOF_GGUF_MODEL`; el servidor de embeddings llama-server se levanta una sola vez por proceso, con `DOF_EMBED_PORT`, por defecto 8086).

--- a/README.md
+++ b/README.md
@@ -170,10 +170,10 @@ export DOF_AGENT_PROVIDER=kimi-code DOF_AGENT_MODEL=kimi-for-coding \
 uv run python -m human_eval.app  # http://127.0.0.1:8765
 ```
 
-También se puede usar un modelo local a través de cualquier servidor
-OpenAI-compatible (llama.cpp `llama-server`, LM Studio, vLLM, ...). Para
-Qwen3.8-27B en esta Mac, inicia un solo slot con 32K de contexto y conserva el
-razonamiento entre turnos de herramientas:
+También se puede usar un modelo local mediante un servidor compatible con la
+API de OpenAI. La configuración probada en Apple Silicon usa Qwen3.8-27B con
+llama.cpp `llama-server`: un solo slot, 32K de contexto y razonamiento
+conservado entre turnos de herramientas.
 
 ```bash
 llama-server -hf unsloth/Qwen3.8-27B-GGUF:UD-Q4_K_M \
@@ -187,6 +187,8 @@ bucle de hasta ocho turnos; se puede cambiar con `DOF_REASONING_EFFORT` a
 razonamiento bajo de [Simon Willison](https://simonwillison.net/2026/Aug/16/qwen-38-27b/)
 y el soporte nativo descrito en la
 [ficha oficial de Qwen3.8-27B](https://huggingface.co/Qwen/Qwen3.8-27B).
+Otros servidores compatibles pueden ignorar o rechazar ese parámetro; configura
+`DOF_REASONING_EFFORT=` para omitirlo.
 
 Con el servidor escuchando en `http://127.0.0.1:8080/` (verifica el id con
 `curl -s localhost:8080/v1/models`):

--- a/agent_tools/agent.py
+++ b/agent_tools/agent.py
@@ -944,6 +944,7 @@ class OpenAIChatCompletionsBackend:
         model: str,
         api_key: str,
         base_url: str,
+        reasoning_effort: str | None = None,
         max_output_tokens: int = 2400,
         client: Any = None,
     ):
@@ -953,6 +954,7 @@ class OpenAIChatCompletionsBackend:
             client = OpenAI(api_key=api_key, base_url=base_url)
         self.client = client
         self.model = model
+        self.reasoning_effort = reasoning_effort
         self.max_output_tokens = max_output_tokens
 
     @staticmethod
@@ -1015,6 +1017,8 @@ class OpenAIChatCompletionsBackend:
             "parallel_tool_calls": False,
             "max_tokens": self.max_output_tokens,
         }
+        if self.reasoning_effort:
+            kwargs["reasoning_effort"] = self.reasoning_effort
         if tools:
             kwargs["tools"] = self._chat_tools(tools)
             kwargs["tool_choice"] = "auto"

--- a/agent_tools/agent.py
+++ b/agent_tools/agent.py
@@ -396,6 +396,19 @@ def _object_schema(properties: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _normalize_nullable_literals(
+    schema: dict[str, Any], arguments: dict[str, Any]
+) -> dict[str, Any]:
+    """Tolerate local models that serialize JSON null as the string ``null``."""
+    normalized = dict(arguments)
+    properties = schema.get("properties", {})
+    for name, value in arguments.items():
+        expected = properties.get(name, {}).get("type")
+        if value == "null" and isinstance(expected, list) and "null" in expected:
+            normalized[name] = None
+    return normalized
+
+
 def _query_snippet(text: str, query: str, max_chars: int) -> tuple[str, bool]:
     if len(text) <= max_chars:
         return text, False
@@ -732,6 +745,7 @@ class DofToolbox:
                     "message": "arguments are not valid JSON",
                 },
             }
+        arguments = _normalize_nullable_literals(self._schemas[name], arguments)
         errors = sorted(
             Draft202012Validator(self._schemas[name]).iter_errors(arguments),
             key=lambda error: list(error.path),

--- a/agent_tools/retrieval.py
+++ b/agent_tools/retrieval.py
@@ -7,11 +7,13 @@ LLM. Public methods map directly to the small tools exposed to an agent, while
 
 from __future__ import annotations
 
+import atexit
 import hashlib
 import json
 import math
 import re
 import sqlite3
+import threading
 import unicodedata
 from collections import Counter
 from dataclasses import dataclass
@@ -206,20 +208,49 @@ class LlamaQueryEmbedder:
     """Keep one local llama-server alive for an interactive session."""
 
     def __init__(self, gguf: Path, *, port: int = 8086, ctx: int = 8192):
-        from corpus_store.embed import start_server
+        from corpus_store.embed import (
+            DIMS,
+            PREFIX_QUERY,
+            embed_batch,
+            start_server,
+            stop_server,
+        )
 
         self.port = port
-        self.process = start_server(gguf, ctx=ctx, port=port)
+        self._lock = threading.Lock()
+        self._closed = False
+        process = start_server(gguf, ctx=ctx, port=port)
+        try:
+            probe = embed_batch([PREFIX_QUERY + "probe"], port)
+            if probe.shape != (1, DIMS):
+                raise RuntimeError(
+                    f"embedding llama-server returned shape {probe.shape}; "
+                    f"expected (1, {DIMS})"
+                )
+        except BaseException:
+            stop_server(process)
+            raise
+        self.process = process
+        atexit.register(self.close)
 
     def embed_query(self, query: str) -> bytes:
         from corpus_store.embed import PREFIX_QUERY, embed_batch, pack_binary
 
+        with self._lock:
+            if self._closed:
+                raise RuntimeError("embedding llama-server is closed")
         vector = embed_batch([PREFIX_QUERY + query], self.port)[0]
         return pack_binary(vector)
 
     def close(self) -> None:
-        self.process.terminate()
-        self.process.wait()
+        from corpus_store.embed import stop_server
+
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            atexit.unregister(self.close)
+            stop_server(self.process)
 
     def __enter__(self) -> "LlamaQueryEmbedder":
         return self

--- a/agent_tools/retrieval.py
+++ b/agent_tools/retrieval.py
@@ -239,7 +239,7 @@ class LlamaQueryEmbedder:
         with self._lock:
             if self._closed:
                 raise RuntimeError("embedding llama-server is closed")
-        vector = embed_batch([PREFIX_QUERY + query], self.port)[0]
+            vector = embed_batch([PREFIX_QUERY + query], self.port)[0]
         return pack_binary(vector)
 
     def close(self) -> None:

--- a/corpus_store/embed.py
+++ b/corpus_store/embed.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import socket
 import sqlite3
 import subprocess
 import sys
@@ -42,9 +43,9 @@ from pathlib import Path
 
 import numpy as np
 
-from rag_poc.chunker import DocPattern
 from corpus_store.chunk_index import normalized_text, reconstruct
 from corpus_store.db import connect, fetch_document_text
+from rag_poc.chunker import DocPattern
 
 MODEL_ID = "jinaai/jina-embeddings-v5-text-small"
 PREFIX_DOCUMENT = "Document: "
@@ -63,23 +64,77 @@ CREATE TABLE IF NOT EXISTS vector_meta (key TEXT PRIMARY KEY, value TEXT NOT NUL
 INSERT_EVERY = 2048  # vectors per committed batch
 
 
-def start_server(gguf: Path, ctx: int, port: int) -> subprocess.Popen:
-    proc = subprocess.Popen(
-        [
-            "llama-server", "-m", str(gguf),
-            "--embedding", "--port", str(port),
-            "-c", str(ctx), "-b", "8192", "-ub", "4096",
-            "--log-disable",
-        ],
-        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-    )
-    for _ in range(180):
+def _assert_port_available(port: int) -> None:
+    if not 1 <= port <= 65535:
+        raise ValueError("llama-server port must be between 1 and 65535")
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         try:
-            urllib.request.urlopen(f"http://127.0.0.1:{port}/health", timeout=1)
-            return proc
-        except Exception:
+            probe.bind(("127.0.0.1", port))
+        except OSError as exc:
+            raise RuntimeError(
+                f"cannot start embedding llama-server: port {port} is already in use"
+            ) from exc
+
+
+def stop_server(proc: subprocess.Popen, *, timeout: float = 10.0) -> None:
+    """Terminate and reap an owned llama-server, escalating if it will not exit."""
+    if proc.poll() is not None:
+        proc.wait()
+        return
+    proc.terminate()
+    try:
+        proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+def start_server(gguf: Path, ctx: int, port: int) -> subprocess.Popen:
+    _assert_port_available(port)
+    proc: subprocess.Popen | None = None
+    try:
+        proc = subprocess.Popen(
+            [
+                "llama-server",
+                "-m",
+                str(gguf),
+                "--embedding",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(port),
+                "-c",
+                str(ctx),
+                "-b",
+                "8192",
+                "-ub",
+                "4096",
+                "--log-disable",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        for _ in range(180):
+            exit_code = proc.poll()
+            if exit_code is not None:
+                raise RuntimeError(
+                    f"embedding llama-server exited during startup with code {exit_code}"
+                )
+            try:
+                with urllib.request.urlopen(
+                    f"http://127.0.0.1:{port}/health", timeout=1
+                ) as response:
+                    if response.status == 200:
+                        return proc
+            except OSError:
+                pass
             time.sleep(1)
-    raise RuntimeError("llama-server did not become healthy")
+        raise RuntimeError("embedding llama-server did not become healthy")
+    except BaseException:
+        if proc is not None:
+            stop_server(proc)
+        raise
 
 
 def embed_batch(texts: list[str], port: int, retries: int = 6) -> np.ndarray:
@@ -111,6 +166,8 @@ def embed_batch(texts: list[str], port: int, retries: int = 6) -> np.ndarray:
 
 def pack_binary(emb: np.ndarray) -> bytes:
     """sign() quantization: (emb >= 0) packed to DIMS/8 bytes."""
+    if emb.shape != (DIMS,):
+        raise ValueError(f"embedding shape {emb.shape} does not match ({DIMS},)")
     return np.packbits(emb >= 0).tobytes()
 
 
@@ -230,8 +287,7 @@ def main() -> None:
               f"db size {size / 2**20:.1f} MiB "
               f"({size / max(n_done + last_id, 1):.0f} B/vec incl. overhead)")
     finally:
-        proc.terminate()
-        proc.wait()
+        stop_server(proc)
     vectors.close()
 
 

--- a/human_eval/agent_executor.py
+++ b/human_eval/agent_executor.py
@@ -47,8 +47,11 @@ class AgentExecutorConfig:
     def from_env(cls, repo_root: str | Path) -> "AgentExecutorConfig":
         root = Path(repo_root).resolve()
         provider = os.environ.get("DOF_AGENT_PROVIDER", "openai-responses")
-        if provider not in {"openai-responses", "kimi-code"}:
-            raise ValueError("DOF_AGENT_PROVIDER must be openai-responses or kimi-code")
+        if provider not in {"openai-responses", "kimi-code", "llama-server"}:
+            raise ValueError(
+                "DOF_AGENT_PROVIDER must be openai-responses, kimi-code, "
+                "or llama-server"
+            )
         model = os.environ.get("DOF_AGENT_MODEL", os.environ.get("OPENAI_MODEL", ""))
         if not model:
             raise ValueError("set DOF_AGENT_MODEL or OPENAI_MODEL")
@@ -222,6 +225,15 @@ class AgentRunExecutor:
         }
 
     def _backend(self) -> Any:
+        if self.config.provider == "llama-server":
+            # Any OpenAI-compatible local server (llama.cpp llama-server,
+            # LM Studio, vLLM, ...). The API key is ignored by llama-server;
+            # the placeholder only satisfies the OpenAI client.
+            return OpenAIChatCompletionsBackend(
+                model=self.config.model,
+                api_key=os.environ.get("DOF_AGENT_API_KEY", "llama-server"),
+                base_url=self.config.base_url or "http://127.0.0.1:8080/v1",
+            )
         if self.config.provider == "kimi-code":
             api_key = os.environ.get("KIMI_API_KEY", "")
             if not api_key:

--- a/human_eval/agent_executor.py
+++ b/human_eval/agent_executor.py
@@ -10,6 +10,7 @@ import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 from agent_tools.agent import (
     AgentRunner,
@@ -25,6 +26,21 @@ from .service import ProgressCallback, PublicExecutionError
 DEFAULT_GGUF_MODEL = "~/dof-gguf/jina-v5-small-retrieval-F16.gguf"
 DEFAULT_VEC0_DB = "dof_db/dof_vec0_jina_binary.sqlite"
 RETRIEVAL_MODES = frozenset({"lexical", "vector", "hybrid"})
+LOCAL_AGENT_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+
+
+def _endpoint_port(url: str) -> tuple[str | None, int | None]:
+    parsed = urlparse(url)
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError(f"invalid DOF_AGENT_BASE_URL: {exc}") from exc
+    if port is None:
+        if parsed.scheme == "https":
+            port = 443
+        elif parsed.scheme == "http":
+            port = 80
+    return parsed.hostname, port
 
 
 @dataclass(frozen=True)
@@ -81,6 +97,19 @@ class AgentExecutorConfig:
                     f"DOF_RETRIEVAL_MODE={retrieval_mode} requires an existing "
                     "GGUF embedding model (DOF_GGUF_MODEL)"
                 )
+        embed_port = int(os.environ.get("DOF_EMBED_PORT", "8086"))
+        if not 1 <= embed_port <= 65535:
+            raise ValueError("DOF_EMBED_PORT must be between 1 and 65535")
+        base_url = os.environ.get("DOF_AGENT_BASE_URL")
+        if provider == "llama-server" and retrieval_mode != "lexical":
+            host, agent_port = _endpoint_port(
+                base_url or "http://127.0.0.1:8080/v1"
+            )
+            if host in LOCAL_AGENT_HOSTS and agent_port == embed_port:
+                raise ValueError(
+                    "DOF_AGENT_BASE_URL and DOF_EMBED_PORT must use different "
+                    "local ports"
+                )
         return cls(
             repo_root=root,
             provider=provider,
@@ -93,12 +122,12 @@ class AgentExecutorConfig:
             ),
             vec0_db=vec0_db,
             gguf_model=gguf_model,
-            embed_port=int(os.environ.get("DOF_EMBED_PORT", "8086")),
+            embed_port=embed_port,
             reasoning_effort=os.environ.get("DOF_REASONING_EFFORT", "low") or None,
             max_model_turns=int(os.environ.get("DOF_MAX_MODEL_TURNS", "8")),
             max_tool_calls=int(os.environ.get("DOF_MAX_TOOL_CALLS", "8")),
             retrieval_mode=retrieval_mode,
-            base_url=os.environ.get("DOF_AGENT_BASE_URL"),
+            base_url=base_url,
         )
 
 
@@ -233,6 +262,7 @@ class AgentRunExecutor:
                 model=self.config.model,
                 api_key=os.environ.get("DOF_AGENT_API_KEY", "llama-server"),
                 base_url=self.config.base_url or "http://127.0.0.1:8080/v1",
+                reasoning_effort=self.config.reasoning_effort,
             )
         if self.config.provider == "kimi-code":
             api_key = os.environ.get("KIMI_API_KEY", "")
@@ -285,16 +315,21 @@ class AgentRunExecutor:
             raise
         except Exception as exc:
             name = type(exc).__name__
+            status_code = getattr(exc, "status_code", None)
             if name in {
                 "APIConnectionError",
                 "APITimeoutError",
+                "APIStatusError",
                 "AuthenticationError",
+                "BadRequestError",
+                "InternalServerError",
+                "NotFoundError",
                 "PermissionDeniedError",
                 "RateLimitError",
             }:
                 code = (
                     "rate_limited"
-                    if name == "RateLimitError"
+                    if name == "RateLimitError" or status_code == 429
                     else "provider_unavailable"
                 )
                 raise PublicExecutionError(

--- a/human_eval/service.py
+++ b/human_eval/service.py
@@ -278,6 +278,12 @@ class EvaluationService:
                             ),
                         )
                     except PublicExecutionError as exc:
+                        if exc.__cause__ is not None:
+                            LOGGER.exception(
+                                "human-evaluation run %s failed with %s",
+                                run_id,
+                                exc.code,
+                            )
                         self._append_event_if_open(
                             run_id,
                             "failed",

--- a/scripts/eval_v4_agent.py
+++ b/scripts/eval_v4_agent.py
@@ -158,7 +158,7 @@ def main() -> int:
     parser.add_argument("--queries", default="eval/dof_queries_v4.jsonl")
     parser.add_argument(
         "--provider",
-        choices=["openai-responses", "kimi-code"],
+        choices=["openai-responses", "kimi-code", "llama-server"],
         default="openai-responses",
     )
     selection = parser.add_mutually_exclusive_group()
@@ -220,7 +220,13 @@ def main() -> int:
         )
         return payload
 
-    if args.provider == "kimi-code":
+    if args.provider == "llama-server":
+        backend = OpenAIChatCompletionsBackend(
+            model=args.model,
+            api_key=os.environ.get("DOF_AGENT_API_KEY", "llama-server"),
+            base_url=args.base_url or "http://127.0.0.1:8080/v1",
+        )
+    elif args.provider == "kimi-code":
         api_key = os.environ.get("KIMI_API_KEY", "")
         if not api_key:
             parser.error("kimi-code provider requires KIMI_API_KEY")

--- a/scripts/eval_v4_agent.py
+++ b/scripts/eval_v4_agent.py
@@ -225,6 +225,7 @@ def main() -> int:
             model=args.model,
             api_key=os.environ.get("DOF_AGENT_API_KEY", "llama-server"),
             base_url=args.base_url or "http://127.0.0.1:8080/v1",
+            reasoning_effort=args.reasoning_effort or None,
         )
     elif args.provider == "kimi-code":
         api_key = os.environ.get("KIMI_API_KEY", "")

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -304,6 +304,45 @@ class AgentToolsTests(unittest.TestCase):
         self.assertTrue(output["ok"])
         self.assertTrue(retriever.calls[0][1]["prefer_recent"])
 
+    def test_toolbox_normalizes_string_null_for_nullable_arguments(self):
+        class RecordingRetriever(FakeRetriever):
+            def __init__(self):
+                self.calls = []
+
+            def search_documents(self, query, **kwargs):
+                self.calls.append((query, kwargs))
+                return DocumentSearchResult(
+                    query=query,
+                    strategy=RetrievalStrategy(kwargs["strategy"]),
+                    filters=kwargs["filters"],
+                    versions=self.versions,
+                )
+
+        retriever = RecordingRetriever()
+        toolbox = DofToolbox(retriever)
+        toolbox.begin(as_of=None)
+        output = toolbox.call(
+            "search_documents",
+            {
+                "query": "tipo de cambio",
+                "strategy": "lexical",
+                "as_of": "null",
+                "date_from": "null",
+                "date_to": "null",
+                "section": "null",
+                "prefer_recent": "null",
+                "top_k": 5,
+            },
+        )
+
+        self.assertTrue(output["ok"])
+        filters = retriever.calls[0][1]["filters"]
+        self.assertEqual(
+            filters.to_dict(),
+            {"as_of": None, "date_from": None, "date_to": None, "section": None},
+        )
+        self.assertFalse(retriever.calls[0][1]["prefer_recent"])
+
     def test_recency_rerank_gives_recent_chunks_visibility_without_dominance(self):
         ranked = [10, 11, 12, 13, 14]
         dates = {

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -1161,6 +1161,27 @@ class AgentToolsTests(unittest.TestCase):
         self.assertEqual(turn.output_items[0]["reasoning_content"], "reasoning")
         self.assertEqual(client.kwargs["messages"][-1]["role"], "tool")
         self.assertEqual(client.kwargs["tools"][0]["function"]["name"], "read_chunks")
+        self.assertNotIn("reasoning_effort", client.kwargs)
         backend.create_turn(input_items=[], tools=[], instructions="final")
         self.assertEqual(client.kwargs["tool_choice"], "none")
         self.assertNotIn("tools", client.kwargs)
+
+    def test_chat_adapter_sends_configured_reasoning_effort(self):
+        message = DumpableItem(role="assistant", content="answer", tool_calls=[])
+        response = SimpleNamespace(
+            id="chat-1",
+            choices=[SimpleNamespace(message=message)],
+            usage=None,
+        )
+        client = ChatCompletionsClient(response)
+        backend = OpenAIChatCompletionsBackend(
+            model="qwen3.8",
+            api_key="test",
+            base_url="http://127.0.0.1:8080/v1",
+            reasoning_effort="low",
+            client=client,
+        )
+
+        backend.create_turn(input_items=[], tools=[], instructions="test")
+
+        self.assertEqual(client.kwargs["reasoning_effort"], "low")

--- a/tests/test_embedding_server.py
+++ b/tests/test_embedding_server.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import subprocess
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import numpy as np
+
+from agent_tools.retrieval import LlamaQueryEmbedder
+from corpus_store.embed import DIMS, pack_binary, start_server, stop_server
+
+
+class EmbeddingServerTests(unittest.TestCase):
+    def test_pack_binary_rejects_wrong_dimension(self):
+        with self.assertRaisesRegex(ValueError, "embedding shape"):
+            pack_binary(np.zeros(DIMS + 1, dtype=np.float32))
+
+    def test_start_server_rejects_an_occupied_port_before_spawning(self):
+        with (
+            mock.patch(
+                "corpus_store.embed._assert_port_available",
+                side_effect=RuntimeError("occupied"),
+            ),
+            mock.patch("corpus_store.embed.subprocess.Popen") as popen,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "occupied"):
+                start_server(Path("model.gguf"), ctx=8192, port=8086)
+        popen.assert_not_called()
+
+    def test_start_server_reaps_a_child_that_exits_during_startup(self):
+        process = mock.Mock()
+        process.poll.return_value = 9
+        with (
+            mock.patch("corpus_store.embed._assert_port_available"),
+            mock.patch("corpus_store.embed.subprocess.Popen", return_value=process),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "code 9"):
+                start_server(Path("model.gguf"), ctx=8192, port=8086)
+        process.wait.assert_called_once_with()
+
+    def test_stop_server_kills_a_child_that_ignores_terminate(self):
+        process = mock.Mock()
+        process.poll.return_value = None
+        process.wait.side_effect = [subprocess.TimeoutExpired("llama-server", 0.1), 0]
+
+        stop_server(process, timeout=0.1)
+
+        process.terminate.assert_called_once_with()
+        process.kill.assert_called_once_with()
+
+    def test_query_embedder_probes_and_closes_once(self):
+        process = mock.Mock()
+        process.poll.return_value = None
+        with (
+            mock.patch("corpus_store.embed.start_server", return_value=process),
+            mock.patch(
+                "corpus_store.embed.embed_batch",
+                return_value=np.zeros((1, DIMS), dtype=np.float32),
+            ) as embed_batch,
+            mock.patch("corpus_store.embed.stop_server") as stop,
+            mock.patch("agent_tools.retrieval.atexit.register") as register,
+            mock.patch("agent_tools.retrieval.atexit.unregister") as unregister,
+        ):
+            embedder = LlamaQueryEmbedder(Path("model.gguf"))
+            embedder.close()
+            embedder.close()
+
+        embed_batch.assert_called_once_with(["Query: probe"], 8086)
+        register.assert_called_once()
+        unregister.assert_called_once()
+        stop.assert_called_once_with(process)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_embedding_server.py
+++ b/tests/test_embedding_server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import subprocess
+import threading
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -69,6 +70,61 @@ class EmbeddingServerTests(unittest.TestCase):
         embed_batch.assert_called_once_with(["Query: probe"], 8086)
         register.assert_called_once()
         unregister.assert_called_once()
+        stop.assert_called_once_with(process)
+
+    def test_close_waits_for_an_in_flight_embedding(self):
+        process = mock.Mock()
+        process.poll.return_value = None
+        query_started = threading.Event()
+        release_query = threading.Event()
+        close_started = threading.Event()
+        errors: list[BaseException] = []
+
+        def embed_batch(texts, port):
+            if texts == ["Query: probe"]:
+                return np.zeros((1, DIMS), dtype=np.float32)
+            query_started.set()
+            if not release_query.wait(timeout=1):
+                raise TimeoutError("test did not release the embedding request")
+            return np.zeros((1, DIMS), dtype=np.float32)
+
+        with (
+            mock.patch("corpus_store.embed.start_server", return_value=process),
+            mock.patch("corpus_store.embed.embed_batch", side_effect=embed_batch),
+            mock.patch("corpus_store.embed.stop_server") as stop,
+            mock.patch("agent_tools.retrieval.atexit.register"),
+            mock.patch("agent_tools.retrieval.atexit.unregister"),
+        ):
+            embedder = LlamaQueryEmbedder(Path("model.gguf"))
+
+            def run_query():
+                try:
+                    embedder.embed_query("consulta")
+                except BaseException as exc:
+                    errors.append(exc)
+
+            def run_close():
+                close_started.set()
+                embedder.close()
+
+            query_thread = threading.Thread(target=run_query)
+            close_thread = threading.Thread(target=run_close)
+            query_thread.start()
+            self.assertTrue(query_started.wait(timeout=1))
+            close_thread.start()
+            self.assertTrue(close_started.wait(timeout=1))
+            close_thread.join(timeout=0.05)
+
+            self.assertTrue(close_thread.is_alive())
+            stop.assert_not_called()
+
+            release_query.set()
+            query_thread.join(timeout=1)
+            close_thread.join(timeout=1)
+
+        self.assertFalse(query_thread.is_alive())
+        self.assertFalse(close_thread.is_alive())
+        self.assertEqual(errors, [])
         stop.assert_called_once_with(process)
 
 

--- a/tests/test_human_eval.py
+++ b/tests/test_human_eval.py
@@ -317,6 +317,7 @@ class AgentExecutorConfigTests(unittest.TestCase):
         self.assertEqual(
             str(backend.client.base_url), "http://127.0.0.1:8080/v1/"
         )
+        self.assertEqual(backend.reasoning_effort, "low")
 
     def test_llama_server_backend_honors_base_url_override(self):
         executor = AgentRunExecutor(
@@ -362,6 +363,25 @@ class AgentExecutorConfigTests(unittest.TestCase):
         self.assertEqual(config.vec0_db, vec0)
         self.assertEqual(config.gguf_model, gguf)
         self.assertEqual(config.embed_port, 9999)
+
+    def test_rejects_invalid_embedding_port(self):
+        with self.assertRaisesRegex(ValueError, "DOF_EMBED_PORT"):
+            self._config(DOF_EMBED_PORT="0")
+
+    def test_rejects_shared_local_chat_and_embedding_port(self):
+        vec0_dir = self.root.resolve() / "dof_db"
+        vec0_dir.mkdir()
+        (vec0_dir / "dof_vec0_jina_binary.sqlite").touch()
+        gguf = self.root / "model.gguf"
+        gguf.touch()
+        with self.assertRaisesRegex(ValueError, "different local ports"):
+            self._config(
+                DOF_AGENT_PROVIDER="llama-server",
+                DOF_RETRIEVAL_MODE="hybrid",
+                DOF_GGUF_MODEL=str(gguf),
+                DOF_AGENT_BASE_URL="http://127.0.0.1:8080/v1",
+                DOF_EMBED_PORT="8080",
+            )
 
 
 class AgentExecutorEmbedderTests(unittest.TestCase):

--- a/tests/test_human_eval.py
+++ b/tests/test_human_eval.py
@@ -293,6 +293,46 @@ class AgentExecutorConfigTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             self._config(DOF_RETRIEVAL_MODE="weird")
 
+    def test_accepts_llama_server_provider(self):
+        config = self._config(DOF_AGENT_PROVIDER="llama-server")
+        self.assertEqual(config.provider, "llama-server")
+
+    def test_rejects_unknown_provider(self):
+        with self.assertRaisesRegex(ValueError, "DOF_AGENT_PROVIDER"):
+            self._config(DOF_AGENT_PROVIDER="weird")
+
+    def test_llama_server_backend_uses_local_openai_compatible_endpoint(self):
+        executor = AgentRunExecutor(
+            AgentExecutorConfig(
+                repo_root=self.root,
+                provider="llama-server",
+                model="ornith",
+                corpus_db=self.root / "missing-corpus.sqlite",
+                chunks_db=self.root / "missing-chunks.sqlite",
+            )
+        )
+        with mock.patch.dict(os.environ, {}, clear=True):
+            backend = executor._backend()
+        self.assertEqual(backend.model, "ornith")
+        self.assertEqual(
+            str(backend.client.base_url), "http://127.0.0.1:8080/v1/"
+        )
+
+    def test_llama_server_backend_honors_base_url_override(self):
+        executor = AgentRunExecutor(
+            AgentExecutorConfig(
+                repo_root=self.root,
+                provider="llama-server",
+                model="ornith",
+                corpus_db=self.root / "missing-corpus.sqlite",
+                chunks_db=self.root / "missing-chunks.sqlite",
+                base_url="http://127.0.0.1:9999/v1/",
+            )
+        )
+        with mock.patch.dict(os.environ, {}, clear=True):
+            backend = executor._backend()
+        self.assertEqual(str(backend.client.base_url), "http://127.0.0.1:9999/v1/")
+
     def test_non_lexical_mode_requires_existing_vector_index(self):
         with self.assertRaisesRegex(ValueError, "vector index"):
             self._config(DOF_RETRIEVAL_MODE="hybrid")

--- a/tests/test_human_eval.py
+++ b/tests/test_human_eval.py
@@ -334,6 +334,12 @@ class AgentExecutorConfigTests(unittest.TestCase):
             backend = executor._backend()
         self.assertEqual(str(backend.client.base_url), "http://127.0.0.1:9999/v1/")
 
+    def test_empty_reasoning_effort_disables_the_optional_field(self):
+        config = self._config(
+            DOF_AGENT_PROVIDER="llama-server", DOF_REASONING_EFFORT=""
+        )
+        self.assertIsNone(config.reasoning_effort)
+
     def test_non_lexical_mode_requires_existing_vector_index(self):
         with self.assertRaisesRegex(ValueError, "vector index"):
             self._config(DOF_RETRIEVAL_MODE="hybrid")
@@ -809,6 +815,36 @@ class ServiceTests(unittest.TestCase):
                 )
         finally:
             service.close()
+
+    def test_worker_logs_the_private_cause_of_a_public_failure(self):
+        class FailingExecutor(FakeExecutor):
+            def execute(self, request, *, on_progress=None):
+                try:
+                    raise RuntimeError("private provider detail")
+                except RuntimeError as exc:
+                    raise PublicExecutionError(
+                        "provider_unavailable", "El proveedor no está disponible."
+                    ) from exc
+
+        executor = FailingExecutor()
+        service = EvaluationService(self.store, executor, executor.provenance)
+        with mock.patch("human_eval.service.LOGGER.exception") as log_exception:
+            service.start()
+            try:
+                created = service.submit(
+                    RunRequest("pregunta válida"), user_id="evaluator", admin=True
+                )
+                finished = wait_for_terminal(service, created["run_id"])
+            finally:
+                service.close()
+
+        self.assertEqual(finished["status"], "failed")
+        self.assertEqual(finished["error"]["code"], "provider_unavailable")
+        log_exception.assert_called_once_with(
+            "human-evaluation run %s failed with %s",
+            created["run_id"],
+            "provider_unavailable",
+        )
 
     def test_submit_prepares_executor_before_snapshotting_provenance(self):
         class PreparingExecutor(FakeExecutor):


### PR DESCRIPTION
## Qué hace

Permite que el agente del sitio de evaluación humana (`human_eval/`) y el script de evaluación del agente corran contra un servidor local compatible con la API de OpenAI, además de `openai-responses` y `kimi-code`. La configuración validada usa Qwen3.8-27B con `llama.cpp llama-server`.

### Nuevo provider `llama-server`

- `DOF_AGENT_PROVIDER=llama-server` usa el backend de Chat Completions contra `DOF_AGENT_BASE_URL` (por defecto `http://127.0.0.1:8080/v1`). No requiere API key; si el servidor autentica, se pasa por `DOF_AGENT_API_KEY`.
- `scripts/eval_v4_agent.py` acepta `--provider llama-server` para el mismo endpoint local.
- El agente envía `reasoning_effort=low` por defecto para Qwen3.8. Se puede cambiar o eliminar con `DOF_REASONING_EFFORT=` si otro endpoint no acepta ese parámetro.

### Endurecimiento de la ejecución local

- `corpus_store/embed.py`: `start_server` verifica que el puerto esté libre y recoge correctamente un proceso que falla durante el arranque.
- `LlamaQueryEmbedder`: verifica la forma `(1, DIMS)` al arrancar, cierra de forma idempotente con `atexit` y espera a que terminen embeddings activos antes de detener el servidor.
- `human_eval/agent_executor.py`: valida que el puerto del agente local y `DOF_EMBED_PORT` no colisionen, pasa `reasoning_effort` al backend de chat y convierte fallas conocidas del proveedor en errores públicos seguros.
- El worker registra la causa privada y el `run_id` de esos errores sin exponer detalles internos a la interfaz.
- Los argumentos opcionales que modelos locales serializan como la cadena `"null"` se normalizan a JSON `null` antes de validar y ejecutar herramientas.

### Docs

- README y AGENTS.md documentan el provider local, el modo léxico predeterminado y `hybrid` como opción cuando están disponibles el índice vec0 y el GGUF de embeddings.
- El servidor de chat local usa el puerto 8080 y el de embeddings `DOF_EMBED_PORT` (8086 por defecto); la aplicación rechaza configuraciones donde ambos colisionan.

## Pruebas

- 134 tests en verde (`uv run python -m unittest discover -s tests -q`).
- `ruff` limpio en las rutas tocadas y `git diff --check` sin errores.
- Smoke test real con `unsloth/Qwen3.8-27B-GGUF:UD-Q4_K_M`, `llama-server`, `reasoning_effort=low` y recuperación léxica: SP-002 terminó en cuatro turnos, hizo tres llamadas de herramienta, citó el chunk correcto `1342011` y obtuvo precisión/recall de citas de 1.0. En una MacBook Pro M3 Pro tardó aproximadamente 403 segundos.
- App levantada con `DOF_AGENT_PROVIDER=llama-server DOF_AGENT_MODEL=qwen3.8 DOF_RETRIEVAL_MODE=hybrid`: `/api/v1/capabilities` reporta `model: qwen3.8`, `retrieval_mode: hybrid`, `vector_available: true`.

Nota: el fix de Clerk `redirectUrl` → `forceRedirectUrl` en `human_eval/app.py` / `clerk_auth.py` queda fuera de este PR por no estar relacionado.
