### PR TITLE
Compact model-facing tool results

### DIFF
--- a/agent_tools/agent.py
+++ b/agent_tools/agent.py
@@ -401,12 +401,15 @@ def _object_schema(properties: dict[str, Any]) -> dict[str, Any]:
 def _normalize_nullable_literals(
     schema: dict[str, Any], arguments: dict[str, Any]
 ) -> dict[str, Any]:
-    """Tolerate local models that serialize JSON null as the string ``null``."""
+    """Tolerate local models that serialize null as ``null`` or ``None``."""
     normalized = dict(arguments)
     properties = schema.get("properties", {})
     for name, value in arguments.items():
         expected = properties.get(name, {}).get("type")
-        if value == "null" and isinstance(expected, list) and "null" in expected:
+        is_string_null = (
+            isinstance(value, str) and value.strip().lower() in {"null", "none"}
+        )
+        if is_string_null and isinstance(expected, list) and "null" in expected:
             normalized[name] = None
     return normalized
 
@@ -1127,9 +1130,11 @@ def _parse_final_answer(
         raise CitationCoverageError(
             f"final answer requires citations from {required_hops} distinct documents"
         )
-    if data["premise_status"] == "false" and not _has_affirmative_premise_correction(
-        data["answer"]
-    ):
+    premise_status = data["premise_status"]
+    has_correction = _has_affirmative_premise_correction(data["answer"])
+    if premise_status == "unclear" and has_correction:
+        premise_status = "false"
+    if premise_status == "false" and not has_correction:
         raise PremiseCorrectionRequiredError(
             "false premise requires an affirmative correction, not only a failed search"
         )
@@ -1139,7 +1144,7 @@ def _parse_final_answer(
         invalid_citations=[
             citation for citation in proposed if citation not in allowed
         ],
-        premise_status=data["premise_status"],
+        premise_status=premise_status,
     )
 
 

--- a/agent_tools/agent.py
+++ b/agent_tools/agent.py
@@ -223,14 +223,14 @@ def _has_affirmative_premise_correction(answer: str) -> bool:
 
 
 def _has_explicit_premise_correction(answer: str) -> bool:
-    """Detect an explicit negation-plus-correction structure.
+    """Flag an explicit negation-plus-correction structure for review.
 
     Stricter than ``_has_affirmative_premise_correction``: that helper treats
     any clause with a verb like ``vigente`` or ``establece`` as a correction,
     which is safe only as validation after the model already chose ``false``.
-    Inferring ``false`` from an ``unclear`` status requires the answer to
-    negate the premise (``no ...`` or a ``sino`` contrast) and then state
-    affirmatively what holds instead.
+    This signal never changes an ``unclear`` status; it only requests review
+    when the answer appears to negate the premise (``no ...`` or a ``sino``
+    contrast) and then state affirmatively what holds instead.
     """
     clauses = [
         clause
@@ -373,15 +373,9 @@ class AgentAnswer:
     citations: list[int]
     invalid_citations: list[int]
     premise_status: str
-    # What the model wrote before any normalization; equal to premise_status
-    # unless an explicit correction upgraded an ``unclear`` status.
-    premise_status_reported: str = ""
 
     def to_dict(self) -> dict[str, Any]:
-        data = asdict(self)
-        if not data["premise_status_reported"]:
-            data["premise_status_reported"] = data["premise_status"]
-        return data
+        return asdict(self)
 
 
 class CitationRequiredError(ValueError):
@@ -1166,13 +1160,9 @@ def _parse_final_answer(
             f"final answer requires citations from {required_hops} distinct documents"
         )
     premise_status = data["premise_status"]
-    has_correction = _has_affirmative_premise_correction(data["answer"])
-    premise_status_reported = premise_status
-    if premise_status == "unclear" and _has_explicit_premise_correction(
+    if premise_status == "false" and not _has_affirmative_premise_correction(
         data["answer"]
     ):
-        premise_status = "false"
-    if premise_status == "false" and not has_correction:
         raise PremiseCorrectionRequiredError(
             "false premise requires an affirmative correction, not only a failed search"
         )
@@ -1183,7 +1173,6 @@ def _parse_final_answer(
             citation for citation in proposed if citation not in allowed
         ],
         premise_status=premise_status,
-        premise_status_reported=premise_status_reported,
     )
 
 
@@ -1216,6 +1205,10 @@ def _verification(
         ),
         "correction_supported_by_citations": (
             "human_review_required" if false_premise else "not_applicable"
+        ),
+        "premise_status_review_required": (
+            answer.premise_status == "unclear"
+            and _has_explicit_premise_correction(answer.answer)
         ),
     }
 

--- a/agent_tools/agent.py
+++ b/agent_tools/agent.py
@@ -222,6 +222,35 @@ def _has_affirmative_premise_correction(answer: str) -> bool:
     return False
 
 
+def _has_explicit_premise_correction(answer: str) -> bool:
+    """Detect an explicit negation-plus-correction structure.
+
+    Stricter than ``_has_affirmative_premise_correction``: that helper treats
+    any clause with a verb like ``vigente`` or ``establece`` as a correction,
+    which is safe only as validation after the model already chose ``false``.
+    Inferring ``false`` from an ``unclear`` status requires the answer to
+    negate the premise (``no ...`` or a ``sino`` contrast) and then state
+    affirmatively what holds instead.
+    """
+    clauses = [
+        clause
+        for clause in re.split(r"[.;]\s*", _fold_for_coverage(answer))
+        if clause
+    ]
+    premise_denied = False
+    for clause in clauses:
+        if " sino " in f" {clause} " and CORRECTION_ASSERTION_RE.search(clause):
+            return True
+        if SEARCH_FAILURE_RE.search(clause):
+            continue
+        if clause.startswith("no "):
+            premise_denied = True
+            continue
+        if premise_denied and CORRECTION_ASSERTION_RE.search(clause):
+            return True
+    return False
+
+
 FINAL_ANSWER_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
@@ -344,9 +373,15 @@ class AgentAnswer:
     citations: list[int]
     invalid_citations: list[int]
     premise_status: str
+    # What the model wrote before any normalization; equal to premise_status
+    # unless an explicit correction upgraded an ``unclear`` status.
+    premise_status_reported: str = ""
 
     def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+        data = asdict(self)
+        if not data["premise_status_reported"]:
+            data["premise_status_reported"] = data["premise_status"]
+        return data
 
 
 class CitationRequiredError(ValueError):
@@ -1132,7 +1167,10 @@ def _parse_final_answer(
         )
     premise_status = data["premise_status"]
     has_correction = _has_affirmative_premise_correction(data["answer"])
-    if premise_status == "unclear" and has_correction:
+    premise_status_reported = premise_status
+    if premise_status == "unclear" and _has_explicit_premise_correction(
+        data["answer"]
+    ):
         premise_status = "false"
     if premise_status == "false" and not has_correction:
         raise PremiseCorrectionRequiredError(
@@ -1145,6 +1183,7 @@ def _parse_final_answer(
             citation for citation in proposed if citation not in allowed
         ],
         premise_status=premise_status,
+        premise_status_reported=premise_status_reported,
     )
 
 

--- a/agent_tools/agent.py
+++ b/agent_tools/agent.py
@@ -321,6 +321,8 @@ class ToolTrace:
     arguments: dict[str, Any] | None
     output: dict[str, Any]
     elapsed_ms: float
+    full_output_bytes: int = 0
+    model_output_bytes: int = 0
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -1357,6 +1359,18 @@ class AgentRunner:
                         tool_started = perf_counter()
                         output = self.toolbox.call(call.name, call.arguments)
                         elapsed_ms = (perf_counter() - tool_started) * 1000.0
+                    model_output = _model_tool_output(call.name, output)
+                    model_output_text = json.dumps(
+                        model_output,
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                    )
+                    if call.name in available_names and len(traces) < self.max_tool_calls:
+                        full_output_bytes = len(
+                            json.dumps(
+                                output, ensure_ascii=False, separators=(",", ":")
+                            ).encode("utf-8")
+                        )
                         traces.append(
                             ToolTrace(
                                 sequence=len(traces) + 1,
@@ -1366,6 +1380,8 @@ class AgentRunner:
                                 arguments=call.arguments,
                                 output=output,
                                 elapsed_ms=elapsed_ms,
+                                full_output_bytes=full_output_bytes,
+                                model_output_bytes=len(model_output_text.encode("utf-8")),
                             )
                         )
                     _emit_progress(
@@ -1383,7 +1399,7 @@ class AgentRunner:
                         {
                             "type": "function_call_output",
                             "call_id": call.call_id,
-                            "output": json.dumps(output, ensure_ascii=False),
+                            "output": model_output_text,
                         }
                     )
                 continue
@@ -1640,6 +1656,121 @@ def _tool_reason(name: str) -> str:
         "get_document_outline": "La estructura ayuda a ubicar las secciones que conviene leer.",
         "read_chunks": "Sólo los chunks leídos pueden convertirse en evidencia y citas de la respuesta.",
     }.get(name, "Esta consulta aporta evidencia observable para el siguiente paso.")
+
+
+MODEL_EVIDENCE_SNIPPET_CHARS = 360
+
+
+def _present_fields(item: dict[str, Any], names: tuple[str, ...]) -> dict[str, Any]:
+    return {
+        name: item[name]
+        for name in names
+        if name in item and item[name] not in (None, [], "")
+    }
+
+
+def _model_tool_output(name: str, output: dict[str, Any]) -> dict[str, Any]:
+    """Return the smallest tool result the model needs for its next decision."""
+    if not output.get("ok"):
+        error = output.get("error", {})
+        return {
+            "ok": False,
+            "error": {
+                "type": error.get("type", "tool_error"),
+                "message": error.get("message", "La consulta falló."),
+            },
+        }
+
+    data = output.get("data", {})
+    compact: dict[str, Any] = {"ok": True}
+    if name in {"list_publications", "search_documents"}:
+        source_key = "publications" if name == "list_publications" else "documents"
+        items = data.get(source_key, [])
+        compact[source_key] = [
+            _present_fields(
+                item,
+                (
+                    "document_id",
+                    "publication_date",
+                    "section",
+                    "title",
+                    "institution",
+                    "rank",
+                ),
+            )
+            for item in items
+        ]
+        return compact
+
+    if name == "search_evidence":
+        query = str(data.get("query") or "")
+        evidence = []
+        for item in data.get("evidence", []):
+            snippet, narrowed = _query_snippet(
+                str(item.get("snippet") or ""),
+                query,
+                MODEL_EVIDENCE_SNIPPET_CHARS,
+            )
+            candidate = _present_fields(
+                item,
+                (
+                    "chunk_id",
+                    "document_id",
+                    "heading_path",
+                    "rank",
+                ),
+            )
+            candidate["snippet"] = snippet
+            if item.get("snippet_truncated") or narrowed:
+                candidate["snippet_truncated"] = True
+            evidence.append(candidate)
+        compact["evidence"] = evidence
+        return compact
+
+    if name == "get_document_outline":
+        compact.update(
+            _present_fields(
+                data,
+                (
+                    "document_id",
+                    "publication_date",
+                    "section",
+                    "title",
+                    "institution",
+                    "outline_truncated",
+                ),
+            )
+        )
+        compact["chunks"] = [
+            _present_fields(
+                item,
+                ("chunk_id", "chunk_index", "heading_path", "token_count"),
+            )
+            for item in data.get("chunks", [])
+        ]
+        return compact
+
+    if name == "read_chunks":
+        compact["chunks"] = [
+            _present_fields(
+                item,
+                (
+                    "chunk_id",
+                    "document_id",
+                    "publication_date",
+                    "section",
+                    "heading_path",
+                    "title",
+                    "text",
+                ),
+            )
+            for item in data.get("chunks", [])
+        ]
+        if "coverage" in data:
+            compact["coverage"] = data["coverage"]
+        return compact
+
+    return output
 
 
 def _public_tool_progress(

--- a/docs/production-roadmap.md
+++ b/docs/production-roadmap.md
@@ -82,6 +82,15 @@ herramientas ocuparon 16,825 bytes completos y 8,659 bytes frente al modelo.
 Es una medición de una sola pregunta y Qwen puede variar entre corridas, así que
 la tomamos como señal prometedora, no como cifra definitiva de capacidad.
 
+Después corrimos una pregunta de cada una de las siete categorías de eval-v4.
+Las siete terminaron con la evidencia esperada después de corregir dos
+incompatibilidades observadas en Qwen: también puede escribir `"None"` para un
+valor nulo y a veces marca como `unclear` una respuesta que ya contiene una
+corrección afirmativa de la premisa. La recuperación de citas fue completa y la
+precisión automática fue 0.86 por dos citas adicionales. El tiempo varió de 244
+a 1,136 segundos, con un promedio de 458; la cola larga importa mucho más que
+el promedio para decidir la capacidad inicial.
+
 ### 2. Construir una línea base que podamos repetir
 
 La siguiente medición debe incluir preguntas fáciles, multi-documento, de fecha

--- a/docs/production-roadmap.md
+++ b/docs/production-roadmap.md
@@ -83,10 +83,11 @@ Es una medición de una sola pregunta y Qwen puede variar entre corridas, así q
 la tomamos como señal prometedora, no como cifra definitiva de capacidad.
 
 Después corrimos una pregunta de cada una de las siete categorías de eval-v4.
-Las siete terminaron con la evidencia esperada después de corregir dos
-incompatibilidades observadas en Qwen: también puede escribir `"None"` para un
-valor nulo y a veces marca como `unclear` una respuesta que ya contiene una
-corrección afirmativa de la premisa. La recuperación de citas fue completa y la
+Las siete localizaron la evidencia esperada después de aceptar que Qwen también
+puede escribir `"None"` para un valor nulo. En el caso de premisa falsa, el
+modelo dejó el estado en `unclear` aunque el texto contenía una corrección
+afirmativa; conservamos ese estado y marcamos la respuesta para revisión, en vez
+de cambiarlo con una heurística. La recuperación de citas fue completa y la
 precisión automática fue 0.86 por dos citas adicionales. El tiempo varió de 244
 a 1,136 segundos, con un promedio de 458; la cola larga importa mucho más que
 el promedio para decidir la capacidad inicial.

--- a/docs/production-roadmap.md
+++ b/docs/production-roadmap.md
@@ -73,6 +73,15 @@ El primer paquete de cambios será:
 Cada reducción debe pasar eval-v4. No aceptaremos una mejora de latencia que
 empeore cobertura, uso de herramientas o precisión de citas.
 
+**Avance del 25 de agosto de 2026.** El agente ya separa el resultado completo,
+que permanece en la traza, de la versión compacta que recibe el modelo. En una
+repetición de SP-002 con la misma configuración, los tokens totales bajaron de
+24,410 a 12,590 y el tiempo de 403 a 259 segundos; ambos intentos terminaron con
+la cita correcta al chunk `1342011`. En la corrida nueva, los tres resultados de
+herramientas ocuparon 16,825 bytes completos y 8,659 bytes frente al modelo.
+Es una medición de una sola pregunta y Qwen puede variar entre corridas, así que
+la tomamos como señal prometedora, no como cifra definitiva de capacidad.
+
 ### 2. Construir una línea base que podamos repetir
 
 La siguiente medición debe incluir preguntas fáciles, multi-documento, de fecha
@@ -172,11 +181,11 @@ inferencia. Eso permite cambiar una pieza sin rehacer el proyecto.
 
 ## Próximos tres entregables
 
-1. Un reporte reproducible con 10 a 20 preguntas y métricas por turno.
-2. Resultados de herramientas compactos, con comparación antes/después en
-   tokens, latencia y calidad.
-3. Admisión con capacidad global, cola visible, `Retry-After` y métricas de
+1. Ampliar la comparación de resultados compactos a 10 o 20 preguntas, con
+   métricas por turno y revisión de calidad.
+2. Admisión con capacidad global, cola visible, `Retry-After` y métricas de
    espera.
+3. Una línea base de uno y dos slots para fijar la concurrencia inicial.
 
 Después de esos tres trabajos podremos fijar una concurrencia inicial y abrir
 una beta pequeña con datos, no con estimaciones.

--- a/docs/production-roadmap.md
+++ b/docs/production-roadmap.md
@@ -101,6 +101,21 @@ cuando el servidor lo soporte de forma estable, MTP o un modelo de borrador.
 Qwen3.8-27B es el primer candidato, no una obligación. Usaremos la misma muestra
 para comparar cuantizaciones, otros modelos y equipos Apple o NVIDIA.
 
+MTP merece una prueba distinta por plataforma. Qwen3.8 ya incluye la cabeza de
+predicción y `llama-server` puede activarla sin descargar otro modelo. Los
+resultados publicados hasta ahora son buenos en varias tarjetas NVIDIA, pero no
+se trasladan directamente a Metal: en Apple Silicon la verificación de lotes
+pequeños puede comerse el ahorro, sobre todo en prosa.
+
+En nuestro M3 Pro, SP-002 con `draft-mtp` y dos tokens de borrador conservó la
+cita correcta. La generación subió de unos 7.5 a entre 8.3 y 8.7 tokens por
+segundo, pero la corrida completa tardó 356 segundos, contra 259 sin MTP. El
+modelo también generó más razonamiento y procesó más contexto, así que no es una
+comparación controlada suficiente para atribuir toda la diferencia a MTP. Por
+ahora no será el valor predeterminado en Mac. Lo volveremos a medir con una
+muestra fija, varias repeticiones y un `llama.cpp` reciente; en NVIDIA tendrá su
+propio barrido de profundidad y memoria.
+
 ### 3. Poner admisión delante del modelo
 
 Con 403 segundos por una pregunta, un solo slot atendería como máximo unas nueve

--- a/human_eval/agent_executor.py
+++ b/human_eval/agent_executor.py
@@ -401,9 +401,8 @@ def _public_result(run: dict[str, Any]) -> dict[str, Any]:
         warnings.append("coverage_incomplete")
     if run["answer"].get("invalid_citations"):
         warnings.append("invalid_citations_removed")
-    premise_reported = run["answer"].get("premise_status_reported")
-    if premise_reported and premise_reported != run["answer"].get("premise_status"):
-        warnings.append("premise_status_normalized")
+    if run.get("verification", {}).get("premise_status_review_required"):
+        warnings.append("premise_status_review_required")
     if run["stop_reason"] != "completed":
         warnings.append(run["stop_reason"])
     return {

--- a/human_eval/agent_executor.py
+++ b/human_eval/agent_executor.py
@@ -401,6 +401,9 @@ def _public_result(run: dict[str, Any]) -> dict[str, Any]:
         warnings.append("coverage_incomplete")
     if run["answer"].get("invalid_citations"):
         warnings.append("invalid_citations_removed")
+    premise_reported = run["answer"].get("premise_status_reported")
+    if premise_reported and premise_reported != run["answer"].get("premise_status"):
+        warnings.append("premise_status_normalized")
     if run["stop_reason"] != "completed":
         warnings.append(run["stop_reason"])
     return {

--- a/scripts/eval_v4_agent.py
+++ b/scripts/eval_v4_agent.py
@@ -80,6 +80,7 @@ def calculate_metrics(results: list[dict[str, Any]]) -> dict[str, Any]:
     precisions: list[float] = []
     recalls: list[float] = []
     false_premise: list[bool] = []
+    false_premise_labeled: list[bool] = []
     tool_errors = 0
     totals = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
     for item in completed:
@@ -97,7 +98,15 @@ def calculate_metrics(results: list[dict[str, Any]]) -> dict[str, Any]:
         for key in totals:
             totals[key] += item["run"]["usage"].get(key, 0)
         if item["category"] == "negative_false_premise":
-            false_premise.append(item["run"]["answer"]["premise_status"] == "false")
+            # A run corrects the false premise when the model labels it false
+            # or when verification flags an explicit correction left as
+            # ``unclear``; the label-only rate measures self-labeling.
+            labeled_false = item["run"]["answer"]["premise_status"] == "false"
+            review_flagged = item["run"].get("verification", {}).get(
+                "premise_status_review_required", False
+            )
+            false_premise.append(labeled_false or review_flagged)
+            false_premise_labeled.append(labeled_false)
     n = len(completed)
     return {
         "n": len(results),
@@ -108,6 +117,11 @@ def calculate_metrics(results: list[dict[str, Any]]) -> dict[str, Any]:
         "citation_recall": sum(recalls) / n,
         "false_premise_correction_accuracy": (
             sum(false_premise) / len(false_premise) if false_premise else None
+        ),
+        "false_premise_label_accuracy": (
+            sum(false_premise_labeled) / len(false_premise_labeled)
+            if false_premise_labeled
+            else None
         ),
         "coverage_completion_rate": coverage_completion_rate,
         "tool_error_count": tool_errors,

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -1125,6 +1125,18 @@ class AgentToolsTests(unittest.TestCase):
             {4},
         )
         self.assertEqual(answer.premise_status, "false")
+        self.assertEqual(answer.to_dict()["premise_status_reported"], "unclear")
+
+    def test_unclear_with_a_plain_assertion_is_not_reclassified(self):
+        # A bare verb like "vigente" validates an already-false premise, but is
+        # not enough to infer one: the answer must negate and then correct.
+        answer = _parse_final_answer(
+            '{"answer":"La ley vigente es aplicable.","citations":[4],'
+            '"premise_status":"unclear"}',
+            {4},
+        )
+        self.assertEqual(answer.premise_status, "unclear")
+        self.assertEqual(answer.to_dict()["premise_status_reported"], "unclear")
 
     def test_false_premise_keeps_unclear_for_a_failed_search(self):
         answer = _parse_final_answer(

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -1117,26 +1117,24 @@ class AgentToolsTests(unittest.TestCase):
         self.assertEqual(answer.premise_status, "false")
         self.assertEqual(answer.citations, [4])
 
-    def test_false_premise_normalizes_unclear_with_an_affirmative_correction(self):
+    def test_false_premise_preserves_unclear_with_an_affirmative_correction(self):
         answer = _parse_final_answer(
             '{"answer":"No reformó el artículo 123; reformó los artículos 76 y 78 '
             'de la Ley Federal del Trabajo.","citations":[4],'
             '"premise_status":"unclear"}',
             {4},
         )
-        self.assertEqual(answer.premise_status, "false")
-        self.assertEqual(answer.to_dict()["premise_status_reported"], "unclear")
+        self.assertEqual(answer.premise_status, "unclear")
 
     def test_unclear_with_a_plain_assertion_is_not_reclassified(self):
         # A bare verb like "vigente" validates an already-false premise, but is
-        # not enough to infer one: the answer must negate and then correct.
+        # not enough to request review: the answer must negate and then correct.
         answer = _parse_final_answer(
             '{"answer":"La ley vigente es aplicable.","citations":[4],'
             '"premise_status":"unclear"}',
             {4},
         )
         self.assertEqual(answer.premise_status, "unclear")
-        self.assertEqual(answer.to_dict()["premise_status_reported"], "unclear")
 
     def test_false_premise_keeps_unclear_for_a_failed_search(self):
         answer = _parse_final_answer(

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 from agent_tools.agent import (
     FINAL_ANSWER_SCHEMA,
+    AgentAnswer,
     AgentRunner,
     DofToolbox,
     ModelTurn,
@@ -17,6 +18,7 @@ from agent_tools.agent import (
     _model_tool_output,
     _parse_final_answer,
     _query_snippet,
+    _verification,
 )
 from agent_tools.headers import extract_document_header
 from agent_tools.llm import _parse_json, answer_with_context
@@ -1127,14 +1129,45 @@ class AgentToolsTests(unittest.TestCase):
         self.assertEqual(answer.premise_status, "unclear")
 
     def test_unclear_with_a_plain_assertion_is_not_reclassified(self):
-        # A bare verb like "vigente" validates an already-false premise, but is
-        # not enough to request review: the answer must negate and then correct.
+        # Parsing preserves the reported status either way; a bare verb like
+        # "vigente" also does not trip the stricter review flag, which requires
+        # the answer to negate the premise and then correct it.
         answer = _parse_final_answer(
             '{"answer":"La ley vigente es aplicable.","citations":[4],'
             '"premise_status":"unclear"}',
             {4},
         )
         self.assertEqual(answer.premise_status, "unclear")
+
+    def test_verification_flags_only_explicit_corrections_left_unclear(self):
+        toolbox = SimpleNamespace(read_chunk_documents={}, missing_coverage=[])
+        explicit = AgentAnswer(
+            answer="No reformó el artículo 123; reformó los artículos 76 y 78.",
+            citations=[4],
+            invalid_citations=[],
+            premise_status="unclear",
+        )
+        self.assertTrue(
+            _verification(explicit, toolbox, 1)["premise_status_review_required"]
+        )
+        plain = AgentAnswer(
+            answer="La ley vigente es aplicable.",
+            citations=[4],
+            invalid_citations=[],
+            premise_status="unclear",
+        )
+        self.assertFalse(
+            _verification(plain, toolbox, 1)["premise_status_review_required"]
+        )
+        labeled = AgentAnswer(
+            answer=explicit.answer,
+            citations=[4],
+            invalid_citations=[],
+            premise_status="false",
+        )
+        self.assertFalse(
+            _verification(labeled, toolbox, 1)["premise_status_review_required"]
+        )
 
     def test_false_premise_keeps_unclear_for_a_failed_search(self):
         answer = _parse_final_answer(

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -305,7 +305,7 @@ class AgentToolsTests(unittest.TestCase):
         self.assertTrue(output["ok"])
         self.assertTrue(retriever.calls[0][1]["prefer_recent"])
 
-    def test_toolbox_normalizes_string_null_for_nullable_arguments(self):
+    def test_toolbox_normalizes_string_null_and_none_for_nullable_arguments(self):
         class RecordingRetriever(FakeRetriever):
             def __init__(self):
                 self.calls = []
@@ -327,10 +327,10 @@ class AgentToolsTests(unittest.TestCase):
             {
                 "query": "tipo de cambio",
                 "strategy": "lexical",
-                "as_of": "null",
+                "as_of": "None",
                 "date_from": "null",
-                "date_to": "null",
-                "section": "null",
+                "date_to": " NONE ",
+                "section": "none",
                 "prefer_recent": "null",
                 "top_k": 5,
             },
@@ -1116,6 +1116,23 @@ class AgentToolsTests(unittest.TestCase):
         )
         self.assertEqual(answer.premise_status, "false")
         self.assertEqual(answer.citations, [4])
+
+    def test_false_premise_normalizes_unclear_with_an_affirmative_correction(self):
+        answer = _parse_final_answer(
+            '{"answer":"No reformó el artículo 123; reformó los artículos 76 y 78 '
+            'de la Ley Federal del Trabajo.","citations":[4],'
+            '"premise_status":"unclear"}',
+            {4},
+        )
+        self.assertEqual(answer.premise_status, "false")
+
+    def test_false_premise_keeps_unclear_for_a_failed_search(self):
+        answer = _parse_final_answer(
+            '{"answer":"No se encontró el decreto en los chunks leídos.",'
+            '"citations":[4],"premise_status":"unclear"}',
+            {4},
+        )
+        self.assertEqual(answer.premise_status, "unclear")
 
     def test_agent_reports_missing_false_premise_correction(self):
         backend = ScriptedBackend(

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -14,6 +14,7 @@ from agent_tools.agent import (
     _coverage_requirements,
     _enumeration_requirements,
     _explicit_question_requirements,
+    _model_tool_output,
     _parse_final_answer,
     _query_snippet,
 )
@@ -342,6 +343,46 @@ class AgentToolsTests(unittest.TestCase):
             {"as_of": None, "date_from": None, "date_to": None, "section": None},
         )
         self.assertFalse(retriever.calls[0][1]["prefer_recent"])
+
+    def test_model_tool_output_removes_diagnostics_and_bounds_snippets(self):
+        snippet = "tipo de cambio " + ("texto " * 150)
+        output = {
+            "ok": True,
+            "data": {
+                "query": "tipo de cambio",
+                "strategy": "lexical",
+                "evidence": [
+                    {
+                        "chunk_id": 4,
+                        "document_id": 2,
+                        "path": "documento.md",
+                        "publication_date": "2025-01-01",
+                        "section": "MAT",
+                        "heading_path": ["Encabezado"],
+                        "score": 9.5,
+                        "source": "bm25_chunk",
+                        "rank": 1,
+                        "snippet": snippet,
+                        "snippet_truncated": False,
+                    }
+                ],
+                "versions": {"corpus_version": "test"},
+                "settings": {"bm25_depth": 100},
+            },
+        }
+
+        compact = _model_tool_output("search_evidence", output)
+
+        self.assertEqual(set(compact), {"ok", "evidence"})
+        candidate = compact["evidence"][0]
+        self.assertNotIn("path", candidate)
+        self.assertNotIn("score", candidate)
+        self.assertNotIn("source", candidate)
+        self.assertNotIn("publication_date", candidate)
+        self.assertNotIn("section", candidate)
+        self.assertLessEqual(len(candidate["snippet"]), 360)
+        self.assertTrue(candidate["snippet_truncated"])
+        self.assertEqual(output["data"]["evidence"][0]["snippet"], snippet)
 
     def test_recency_rerank_gives_recent_chunks_visibility_without_dominance(self):
         ranked = [10, 11, 12, 13, 14]
@@ -777,6 +818,23 @@ class AgentToolsTests(unittest.TestCase):
         self.assertEqual(run.answer.invalid_citations, [999])
         self.assertEqual(run.tool_calls, 3)
         self.assertEqual(run.stop_reason, "completed")
+        model_list_output = json.loads(
+            next(
+                item["output"]
+                for item in backend.calls[1]["input_items"]
+                if item.get("call_id") == "call-list"
+            )
+        )
+        self.assertEqual(set(model_list_output), {"ok", "publications"})
+        self.assertNotIn("path", model_list_output["publications"][0])
+        self.assertEqual(
+            run.traces[0].output["data"]["publications"][0]["path"],
+            "doc.md",
+        )
+        self.assertLess(
+            run.traces[0].model_output_bytes,
+            run.traces[0].full_output_bytes,
+        )
         self.assertEqual(backend.calls[-1]["tools"], [])
         self.assertEqual(
             {tool["name"] for tool in backend.calls[0]["tools"]},

--- a/tests/test_human_eval.py
+++ b/tests/test_human_eval.py
@@ -224,17 +224,16 @@ class AgentResultTests(unittest.TestCase):
         self.assertEqual(result["coverage"]["missing"], ["año 2025"])
         self.assertFalse(result["coverage"]["complete"])
         self.assertIn("invalid_citations_removed", result["warnings"])
-        self.assertNotIn("premise_status_normalized", result["warnings"])
+        self.assertNotIn("premise_status_review_required", result["warnings"])
 
-    def test_public_result_flags_a_normalized_premise_status(self):
+    def test_public_result_flags_a_premise_status_needing_review(self):
         result = _public_result(
             {
                 "answer": {
                     "answer": "No reformó el artículo 123; reformó el 76.",
                     "citations": [123],
                     "invalid_citations": [],
-                    "premise_status": "false",
-                    "premise_status_reported": "unclear",
+                    "premise_status": "unclear",
                 },
                 "traces": [
                     {
@@ -255,7 +254,7 @@ class AgentResultTests(unittest.TestCase):
                     },
                 ],
                 "coverage": {},
-                "verification": {},
+                "verification": {"premise_status_review_required": True},
                 "stop_reason": "completed",
                 "model_turns": 3,
                 "tool_calls": 1,
@@ -263,9 +262,8 @@ class AgentResultTests(unittest.TestCase):
                 "elapsed_ms": 12.5,
             }
         )
-        self.assertEqual(result["answer"]["premise_status"], "false")
-        self.assertIn("premise_status_normalized", result["warnings"])
-        self.assertNotIn("premise_status_reported", result["answer"])
+        self.assertEqual(result["answer"]["premise_status"], "unclear")
+        self.assertIn("premise_status_review_required", result["warnings"])
 
     def test_provenance_distinguishes_available_from_used_vector_index(self):
         with tempfile.TemporaryDirectory() as tempdir:

--- a/tests/test_human_eval.py
+++ b/tests/test_human_eval.py
@@ -224,6 +224,48 @@ class AgentResultTests(unittest.TestCase):
         self.assertEqual(result["coverage"]["missing"], ["año 2025"])
         self.assertFalse(result["coverage"]["complete"])
         self.assertIn("invalid_citations_removed", result["warnings"])
+        self.assertNotIn("premise_status_normalized", result["warnings"])
+
+    def test_public_result_flags_a_normalized_premise_status(self):
+        result = _public_result(
+            {
+                "answer": {
+                    "answer": "No reformó el artículo 123; reformó el 76.",
+                    "citations": [123],
+                    "invalid_citations": [],
+                    "premise_status": "false",
+                    "premise_status_reported": "unclear",
+                },
+                "traces": [
+                    {
+                        "name": "read_chunks",
+                        "output": {
+                            "ok": True,
+                            "data": {
+                                "chunks": [
+                                    {
+                                        "chunk_id": 123,
+                                        "document_id": 45,
+                                        "path": "2026/documento.md",
+                                        "text": "Pasaje verificable.",
+                                    }
+                                ]
+                            },
+                        },
+                    },
+                ],
+                "coverage": {},
+                "verification": {},
+                "stop_reason": "completed",
+                "model_turns": 3,
+                "tool_calls": 1,
+                "usage": {"total_tokens": 100},
+                "elapsed_ms": 12.5,
+            }
+        )
+        self.assertEqual(result["answer"]["premise_status"], "false")
+        self.assertIn("premise_status_normalized", result["warnings"])
+        self.assertNotIn("premise_status_reported", result["answer"])
 
     def test_provenance_distinguishes_available_from_used_vector_index(self):
         with tempfile.TemporaryDirectory() as tempdir:


### PR DESCRIPTION
## Qué cambia

- separa el resultado completo de cada herramienta de la versión compacta que recibe el modelo;
- conserva la salida íntegra en las trazas para auditoría y diagnóstico;
- elimina del contexto rutas, scores, configuración del ranking y metadatos repetidos;
- acota los snippets de búsqueda antes de que el agente lea los chunks elegidos;
- registra bytes completos y bytes enviados al modelo por llamada;
- documenta la primera medición local y las observaciones sobre MTP en Apple Silicon.

## Primera medición

Usamos Qwen3.8-27B `UD-Q4_K_M`, `llama-server`, contexto de 32K, un slot, razonamiento `low` y recuperación léxica en una MacBook Pro M3 Pro con 36 GB.

En SP-002, la corrida compacta conservó la respuesta y la cita correcta al chunk `1342011`:

| | Antes | Compacto | Cambio |
| --- | ---: | ---: | ---: |
| Tokens de entrada | 23,275 | 11,706 | -49.7% |
| Tokens totales | 24,410 | 12,590 | -48.4% |
| Tiempo total | 403 s | 259 s | -35.6% |

Es una sola pregunta y el modelo no es determinista, por lo que estas cifras son una señal inicial, no un benchmark definitivo.

También probamos MTP con dos tokens de borrador. La generación subió de aproximadamente 7.5 a 8.3–8.7 tokens por segundo, pero la corrida completa tardó 356 segundos y produjo más razonamiento. Por ahora no se propone como valor predeterminado en Apple Silicon.

## Una pregunta por categoría

Corrimos una muestra compacta con recuperación léxica y una pregunta de cada categoría de eval-v4:

| Caso | Categoría | Tiempo | Herramientas | Resultado |
| --- | --- | ---: | ---: | --- |
| SP-003 | `single_passage` | 307 s | 3 | Completo |
| LI-004 | `list_enumeration` | 344 s | 3 | Completo |
| TE-004 | `temporal_transitorio` | 244 s | 3 | Completo |
| CR-003 | `cross_reference` | 340 s | 3 | Completo |
| MD-002 | `multi_document` | 572 s | 6 | Completo, dos documentos |
| MO-002 | `monitoring` | 266 s | 3 | Completo, tres citas |
| NE-003 | `negative_false_premise` | 1,136 s | 5 | Corrección afirmativa; estado `unclear` marcado para revisión |

Resultado agregado: 7/7 completadas, recuperación de citas 1.00, precisión automática de citas 0.86 y cobertura 1.00. Dos respuestas incluyeron un chunk vecino válido que no está marcado como gold. Los resultados completos de herramientas sumaron 185,581 bytes y las versiones dirigidas al modelo 118,319 bytes (-36.2%). El tiempo medio fue 458 segundos, pero el rango de 244 a 1,136 segundos es más útil para dimensionar la cola.

La primera pasada descubrió dos comportamientos reales de Qwen local: además de `"null"`, puede serializar valores opcionales como `"None"`; y puede escribir una corrección afirmativa mientras deja `premise_status` en `unclear`. Este PR normaliza el valor nulo. El estado de premisa se conserva tal como lo reportó el modelo y la discrepancia sólo genera una advertencia para revisión humana.

## Validación

- [x] 139 pruebas unitarias
- [x] Ruff en los archivos modificados
- [x] `git diff --check`
- [x] SP-002 termina con la cita correcta usando Qwen local
- [x] Una pregunta por cada categoría de eval-v4

La muestra usada fue: `SP-003`, `LI-004`, `TE-004`, `CR-003`, `MD-002`, `MO-002` y `NE-003`.
