### PR TITLE
Admisión: separar espera en cola de procesamiento y registrar rechazos

### DIFF
--- a/docs/production-roadmap.md
+++ b/docs/production-roadmap.md
@@ -111,6 +111,18 @@ base suficiente. Lo siguiente es:
 - conservar una forma administrativa de pausar admisión sin apagar las páginas
   publicadas.
 
+**Avance del 26 de agosto de 2026.** Ya existían la capacidad de cola (20),
+la respuesta 503 al llenarse, una sola ejecución activa por usuario y la cuota
+diaria. Ahora cada respuesta terminada separa la espera en cola del tiempo de
+procesamiento usando las marcas de `run_events`, sin instrumentación nueva, y
+cada rechazo de admisión (cola llena o ejecución activa) queda registrado en
+el log con la profundidad de la cola. Decidimos posponer `Retry-After`, la
+posición en cola y la espera estimada: con la cuota de una pregunta por día y
+una audiencia pequeña, primero queremos observar en el log con qué frecuencia
+se rechazan admisiones antes de construir esa maquinaria. Quedan pendientes de
+este apartado los timeouts por turno y por corrida, la detección del modelo
+caído antes de admitir y la pausa administrativa de admisión.
+
 Leases, reclamo atómico entre procesos y una base distinta a SQLite serán
 necesarios si llegamos a operar varios workers. No hacen falta para la primera
 beta en una sola máquina.

--- a/human_eval/app.py
+++ b/human_eval/app.py
@@ -135,6 +135,38 @@ def _escape(value: Any) -> str:
     return html.escape("" if value is None else str(value), quote=True)
 
 
+def _seconds_between(start: Any, end: Any) -> float | None:
+    """Seconds between two ISO-8601 timestamps; None when unavailable."""
+    if not isinstance(start, str) or not isinstance(end, str):
+        return None
+    try:
+        began = datetime.fromisoformat(start.replace("Z", "+00:00"))
+        finished = datetime.fromisoformat(end.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return max(0.0, (finished - began).total_seconds())
+
+
+def _fmt_duration(seconds: float) -> str:
+    total = int(round(seconds))
+    minutes, secs = divmod(total, 60)
+    if minutes:
+        return f"{minutes} min {secs} s"
+    return f"{secs} s"
+
+
+def _timing_meta(run: dict[str, Any]) -> str:
+    """Split queue wait from processing time using run event timestamps."""
+    queue_wait = _seconds_between(run.get("created_at"), run.get("started_at"))
+    processing = _seconds_between(run.get("started_at"), run.get("completed_at"))
+    parts = []
+    if queue_wait is not None:
+        parts.append(f"Espera en cola: {_fmt_duration(queue_wait)}")
+    if processing is not None:
+        parts.append(f"Procesamiento: {_fmt_duration(processing)}")
+    return " · ".join(parts)
+
+
 def _csrf(request: Request) -> str:
     token = request.session.get("csrf_token")
     if not isinstance(token, str) or len(token) < 32:
@@ -685,10 +717,12 @@ data-last-event-id="{_escape(last_event_id)}" aria-live="polite">
         if csrf_token
         else ""
     )
+    timing = _timing_meta(run)
+    timing_html = f" · {_escape(timing)}" if timing else ""
     return f"""<section id="run-status" data-state="succeeded" aria-live="polite">
 <section class="panel status"><p class="eyebrow">Respuesta terminada</p><h2>Respuesta</h2>{warning_html}
 <div class="answer">{_escape(answer.get("text", ""))}</div><p><strong>Citas:</strong> {citation_links}</p>
-<p class="meta">Premisa: {_escape(answer.get("premise_status", "unknown"))} · {_escape(result.get("elapsed_ms"))} ms</p></section>
+<p class="meta">Premisa: {_escape(answer.get("premise_status", "unknown"))}{timing_html}</p></section>
 <section class="panel"><h2>Proceso de investigación</h2>
 <p class="lede">El registro de decisiones y evidencia permanece disponible después de generar la respuesta.</p>
 {_completed_process(run.get("progress", []))}</section>

--- a/human_eval/service.py
+++ b/human_eval/service.py
@@ -154,6 +154,9 @@ class EvaluationService:
             if existing is not None:
                 return existing
             if self.store.has_active_run(user_id):
+                LOGGER.warning(
+                    "admission rejected: user %s already has an active run", user_id
+                )
                 raise ActiveRunError("user already has an active run")
             if not admin:
                 if not self.store.has_review_since_last_submission(user_id):
@@ -172,6 +175,11 @@ class EvaluationService:
                     ):
                         raise QuotaExceededError("daily question limit reached")
             if self.queue.full():
+                LOGGER.warning(
+                    "admission rejected: queue full (depth=%s, capacity=%s)",
+                    self.queue.qsize(),
+                    self.queue.maxsize,
+                )
                 raise QueueFullError("execution queue is full")
             prepare_executor = getattr(self.executor, "prepare", None)
             if callable(prepare_executor):
@@ -185,6 +193,13 @@ class EvaluationService:
                 try:
                     self.queue.put_nowait(run["run_id"])
                 except queue.Full:
+                    LOGGER.warning(
+                        "admission rejected after persisting run %s: queue full "
+                        "(depth=%s, capacity=%s)",
+                        run["run_id"],
+                        self.queue.qsize(),
+                        self.queue.maxsize,
+                    )
                     self.store.append_event(
                         run["run_id"],
                         "failed",

--- a/human_eval/service.py
+++ b/human_eval/service.py
@@ -155,7 +155,10 @@ class EvaluationService:
                 return existing
             if self.store.has_active_run(user_id):
                 LOGGER.warning(
-                    "admission rejected: user %s already has an active run", user_id
+                    "admission rejected: active run exists "
+                    "(depth=%s, capacity=%s)",
+                    self.queue.qsize(),
+                    self.queue.maxsize,
                 )
                 raise ActiveRunError("user already has an active run")
             if not admin:

--- a/tests/test_human_eval.py
+++ b/tests/test_human_eval.py
@@ -925,6 +925,35 @@ class ServiceTests(unittest.TestCase):
             executor.release.set()
             service.close()
 
+    def test_active_run_rejection_is_logged_without_user_id(self):
+        executor = BlockingExecutor()
+        service = EvaluationService(
+            self.store, executor, executor.provenance, queue_capacity=2
+        )
+        service.start()
+        try:
+            service.submit(
+                RunRequest("primera", client_request_id="active-1"),
+                user_id="sensitive-user-id",
+                admin=True,
+            )
+            self.assertTrue(executor.started.wait(timeout=3))
+            with self.assertLogs("human_eval.service", level="WARNING") as captured:
+                with self.assertRaises(ActiveRunError):
+                    service.submit(
+                        RunRequest("segunda", client_request_id="active-2"),
+                        user_id="sensitive-user-id",
+                        admin=True,
+                    )
+            message = captured.output[0]
+            self.assertIn("active run exists", message)
+            self.assertIn("depth=0", message)
+            self.assertIn("capacity=2", message)
+            self.assertNotIn("sensitive-user-id", message)
+        finally:
+            executor.release.set()
+            service.close()
+
     def test_close_runs_the_executor_shutdown_hook(self):
         class ClosingExecutor(FakeExecutor):
             def __init__(self):

--- a/tests/test_human_eval.py
+++ b/tests/test_human_eval.py
@@ -33,6 +33,7 @@ from human_eval.service import (
     EvaluationService,
     IdempotencyConflictError,
     PublicExecutionError,
+    QueueFullError,
 )
 from human_eval.store import SCHEMA_VERSION, EvaluationStore
 from scripts.seed_human_eval_v4_hybrid import SEED_USER, seed_live_run
@@ -893,6 +894,37 @@ class ServiceTests(unittest.TestCase):
             executor.release.set()
             service.close()
 
+    def test_queue_full_rejection_is_logged(self):
+        executor = BlockingExecutor()
+        service = EvaluationService(
+            self.store, executor, executor.provenance, queue_capacity=1
+        )
+        service.start()
+        try:
+            service.submit(
+                RunRequest("primera", client_request_id="q1"),
+                user_id="u1",
+                admin=True,
+            )
+            self.assertTrue(executor.started.wait(timeout=3))
+            service.submit(
+                RunRequest("segunda", client_request_id="q2"),
+                user_id="u2",
+                admin=True,
+            )
+            with self.assertLogs("human_eval.service", level="WARNING") as captured:
+                with self.assertRaises(QueueFullError):
+                    service.submit(
+                        RunRequest("tercera", client_request_id="q3"),
+                        user_id="u3",
+                        admin=True,
+                    )
+            self.assertIn("queue full", captured.output[0])
+            self.assertIn("capacity=1", captured.output[0])
+        finally:
+            executor.release.set()
+            service.close()
+
     def test_close_runs_the_executor_shutdown_hook(self):
         class ClosingExecutor(FakeExecutor):
             def __init__(self):
@@ -1262,6 +1294,15 @@ class AirAppTests(AirAppTestCase):
         feedback = self.service.store.feedback_for_run(run_id)
         self.assertEqual(feedback[0]["rating"], "partially_helpful")
         self.assertEqual(feedback[0]["user_id"], "alice")
+
+    def test_finished_run_splits_queue_wait_from_processing(self):
+        self.seed_and_unlock("alice")
+        run_id = self.create_run()
+        wait_for_terminal(self.service, run_id)
+        page = self.client.get(f"/runs/{run_id}")
+        self.assertEqual(page.status_code, 200)
+        self.assertIn("Espera en cola:", page.text)
+        self.assertIn("Procesamiento:", page.text)
 
     def test_progress_timeline_shows_decisions_and_expandable_chunks(self):
         rendered = _progress_timeline(


### PR DESCRIPTION
## Qué cambia

Primera entrega, deliberadamente pequeña, del apartado 3 del roadmap (poner admisión delante del modelo):

- cada respuesta terminada separa **espera en cola** (`queued` → `started`) de **procesamiento** (`started` → terminal) usando las marcas de `run_events`, sin instrumentación nueva;
- cada rechazo de admisión (cola llena o ejecución activa por usuario) queda registrado en el log con la profundidad y capacidad de la cola.

## Por qué no `Retry-After` ni posición en cola todavía

Con la cuota de una pregunta por día por usuario y una audiencia beta pequeña, llenar una cola de 20 requeriría unas 20 personas distintas en el lapso de una sola corrida: todavía no hemos observado un solo rechazo por cola llena. Preferimos **registrar los rechazos primero** y construir `Retry-After`, posición en cola y espera estimada cuando el log muestre con qué frecuencia aparecen.

## Lo que queda del apartado 3

- timeouts por turno y por corrida completa (una corrida abandonada hoy puede ocupar el único slot indefinidamente);
- detectar el modelo caído antes de admitir trabajo (hoy `/api/v1/health` sólo verifica SQLite);
- pausa administrativa de admisión sin apagar las páginas publicadas;
- `Retry-After`, posición en cola y espera estimada, cuando los logs lo justifiquen.

## Validación

- [x] 140 pruebas unitarias (nuevas: separación cola/procesamiento en la respuesta y registro del rechazo por cola llena con `assertLogs`)
- [x] Ruff en `human_eval` y `tests`
- [x] `git diff --check`