### PR TITLE
Automate incremental DOF corpus updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ dof_word/
 
 > **NOTA**: El script descarga un archivo .doc por cada documento legal individual (no por edición completa).
 
+### Actualización diaria en macOS
+
+El servidor macOS usa un job de `launchd` para descargar, convertir e indexar
+automáticamente los documentos nuevos, incluyendo FTS5, chunks, embeddings y
+vec0. El pipeline es reanudable y se pone al corriente desde la fecha más
+reciente confirmada antes de cambiar a una ventana diaria de siete días.
+Consulta [`docs/daily-updates.md`](docs/daily-updates.md) para instalación,
+pruebas, logs y operación.
+
 ## Extraer markdown
 
 Hay dos métodos de extracción dependiendo del tipo de archivo:

--- a/README.md
+++ b/README.md
@@ -60,14 +60,15 @@ dof_word/
 
 > **NOTA**: El script descarga un archivo .doc por cada documento legal individual (no por edición completa).
 
-### Actualización diaria en macOS
+### Actualización diaria
 
-El servidor macOS usa un job de `launchd` para descargar, convertir e indexar
-automáticamente los documentos nuevos, incluyendo FTS5, chunks, embeddings y
-vec0. El pipeline es reanudable y se pone al corriente desde la fecha más
-reciente confirmada antes de cambiar a una ventana diaria de siete días.
-Consulta [`docs/daily-updates.md`](docs/daily-updates.md) para instalación,
-pruebas, logs y operación.
+El servidor de producción descarga, convierte e indexa automáticamente los
+documentos nuevos, incluyendo FTS5, chunks, embeddings y vec0 — vía `launchd`
+en macOS o un *user timer* de `systemd` en Linux. El pipeline es reanudable y
+se pone al corriente desde la fecha más reciente confirmada antes de cambiar
+a una ventana diaria de siete días. Consulta
+[`docs/daily-updates.md`](docs/daily-updates.md) para instalación, pruebas,
+logs y operación.
 
 ## Extraer markdown
 

--- a/convert_doc_to_md.py
+++ b/convert_doc_to_md.py
@@ -17,6 +17,7 @@ Usage:
     python convert_doc_to_md.py                          # Convert all years
     python convert_doc_to_md.py --years 2020 2021 2022   # Specific years
     python convert_doc_to_md.py --workers 4              # Limit parallelism
+    python convert_doc_to_md.py --start-date 2026-08-24 --end-date 2026-08-27
     python convert_doc_to_md.py --dry-run                # Just count files
     python convert_doc_to_md.py --retry-failed           # Retry only failed files
     python convert_doc_to_md.py --input-dir /path/to/docs --output-dir /path/to/md
@@ -30,6 +31,7 @@ import subprocess
 import tempfile
 import time
 from concurrent.futures import ProcessPoolExecutor, as_completed
+from datetime import date, datetime
 from pathlib import Path
 
 # Configuration
@@ -235,8 +237,20 @@ def get_output_path(doc_path: Path) -> Path:
     return OUTPUT_DIR / rel.with_suffix(".md")
 
 
-def find_doc_files(years=None):
-    """Find all .doc files, optionally filtered by years."""
+def publication_date_from_path(path: Path) -> date | None:
+    """Read YYYY/MM/DDMMYYYY from a canonical dof_word path."""
+    try:
+        parts = path.relative_to(INPUT_DIR).parts
+        if len(parts) < 3:
+            return None
+        return datetime.strptime(parts[2], "%d%m%Y").date()
+    except (ValueError, OSError):
+        return None
+
+
+def find_doc_files(years=None, start_date: date | None = None,
+                   end_date: date | None = None):
+    """Find .doc files, optionally filtered by years and publication date."""
     files = []
     if years:
         for year in years:
@@ -248,6 +262,25 @@ def find_doc_files(years=None):
     else:
         files = sorted(INPUT_DIR.rglob("*.doc"))
         log.info(f"Total: {len(files)} .doc files")
+    if start_date or end_date:
+        selected = []
+        for path in files:
+            publication_date = publication_date_from_path(path)
+            if publication_date is None:
+                log.warning(f"Ignoring .doc outside canonical date layout: {path}")
+                continue
+            if start_date and publication_date < start_date:
+                continue
+            if end_date and publication_date > end_date:
+                continue
+            selected.append(path)
+        files = selected
+        log.info(
+            "Date window %s..%s: %d .doc files",
+            start_date or "unbounded",
+            end_date or "unbounded",
+            len(files),
+        )
     return files
 
 
@@ -270,7 +303,14 @@ def main():
                         help="Input directory with .doc files (default: ./dof_word)")
     parser.add_argument("--output-dir", type=str, default="./dof_md",
                         help="Output directory for .md files (default: ./dof_md)")
+    parser.add_argument("--start-date", type=date.fromisoformat,
+                        help="Only convert files on/after YYYY-MM-DD")
+    parser.add_argument("--end-date", type=date.fromisoformat,
+                        help="Only convert files on/before YYYY-MM-DD")
     args = parser.parse_args()
+
+    if args.start_date and args.end_date and args.start_date > args.end_date:
+        parser.error("--start-date must not be after --end-date")
 
     global INPUT_DIR, OUTPUT_DIR, FAILED_DIR
     INPUT_DIR = Path(args.input_dir)
@@ -289,7 +329,7 @@ def main():
         log.info("Years: ALL")
     log.info("=" * 60)
 
-    files = find_doc_files(args.years)
+    files = find_doc_files(args.years, args.start_date, args.end_date)
     if not files:
         log.warning("No .doc files found!")
         return

--- a/convert_doc_to_md.py
+++ b/convert_doc_to_md.py
@@ -27,7 +27,6 @@ import logging
 import re
 import shutil
 import subprocess
-import sys
 import tempfile
 import time
 from concurrent.futures import ProcessPoolExecutor, as_completed
@@ -80,6 +79,13 @@ def convert_single_doc(doc_path: Path, output_md_path: Path, worker_id: int = 0)
 
     if output_md_path.exists() and output_md_path.stat().st_size > 0:
         result["status"] = "skipped"
+        return result
+
+    with doc_path.open("rb") as stream:
+        prefix = stream.read(512).lstrip().lower()
+    if prefix.startswith((b"<!doctype html", b"<html")):
+        result["status"] = "invalid_download"
+        result["error"] = "HTML error page stored with a .doc extension"
         return result
 
     output_md_path.parent.mkdir(parents=True, exist_ok=True)
@@ -360,7 +366,8 @@ def main():
             else:
                 failed += 1
                 failed_paths.append(result["doc_path"])
-                log.warning(f"FAILED [{status}]: {result['doc_path']}")
+                detail = f" — {result['error']}" if result.get("error") else ""
+                log.warning(f"FAILED [{status}]: {result['doc_path']}{detail}")
 
             if i % 1000 == 0 or i == len(work_items):
                 elapsed = time.time() - start_time
@@ -396,6 +403,8 @@ def main():
         if profile.exists():
             shutil.rmtree(profile, ignore_errors=True)
 
+    return 1 if failed_paths else 0
+
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/convert_doc_to_md.py
+++ b/convert_doc_to_md.py
@@ -34,6 +34,8 @@ from concurrent.futures import ProcessPoolExecutor, as_completed
 from datetime import date, datetime
 from pathlib import Path
 
+from word_validation import is_valid_word_file
+
 # Configuration
 PANDOC_FILTER = Path(__file__).parent / "pandoc_filters" / "dof_headers.lua"
 LOG_FILE = Path(__file__).parent / "convert_doc_to_md.log"
@@ -83,9 +85,7 @@ def convert_single_doc(doc_path: Path, output_md_path: Path, worker_id: int = 0)
         result["status"] = "skipped"
         return result
 
-    with doc_path.open("rb") as stream:
-        prefix = stream.read(512).lstrip().lower()
-    if prefix.startswith((b"<!doctype html", b"<html")):
+    if not is_valid_word_file(doc_path):
         # Quarantine so this run's failure does not repeat forever: the
         # .invalid suffix is invisible to the *.doc scan here and to the
         # *_<note_id>.doc resume glob in get_word_dof, so the downloader
@@ -94,7 +94,7 @@ def convert_single_doc(doc_path: Path, output_md_path: Path, worker_id: int = 0)
         doc_path.replace(quarantine)
         result["status"] = "invalid_download"
         result["error"] = (
-            "HTML error page stored with a .doc extension; "
+            "invalid Word payload stored with a .doc extension; "
             f"quarantined to {quarantine.name}"
         )
         return result

--- a/convert_doc_to_md.py
+++ b/convert_doc_to_md.py
@@ -84,8 +84,17 @@ def convert_single_doc(doc_path: Path, output_md_path: Path, worker_id: int = 0)
     with doc_path.open("rb") as stream:
         prefix = stream.read(512).lstrip().lower()
     if prefix.startswith((b"<!doctype html", b"<html")):
+        # Quarantine so this run's failure does not repeat forever: the
+        # .invalid suffix is invisible to the *.doc scan here and to the
+        # *_<note_id>.doc resume glob in get_word_dof, so the downloader
+        # re-fetches the notice on its next pass.
+        quarantine = doc_path.with_name(doc_path.name + ".invalid")
+        doc_path.replace(quarantine)
         result["status"] = "invalid_download"
-        result["error"] = "HTML error page stored with a .doc extension"
+        result["error"] = (
+            "HTML error page stored with a .doc extension; "
+            f"quarantined to {quarantine.name}"
+        )
         return result
 
     output_md_path.parent.mkdir(parents=True, exist_ok=True)

--- a/corpus_store/chunk_index.py
+++ b/corpus_store/chunk_index.py
@@ -262,9 +262,12 @@ def main() -> None:
 
     # Both stores are append-only and each document is committed only after
     # all of its chunks have been built. Avoid decompressing the full corpus
-    # on every daily incremental run.
+    # on every daily incremental run. The checkpoint is keyed by chunker
+    # version so bumping CHUNKER_VERSION re-chunks the full corpus instead
+    # of silently skipping every previously chunked document.
     last_document_id = chunks.execute(
         "SELECT COALESCE(MAX(document_id), 0) FROM chunks"
+        " WHERE chunker_version = ?", (CHUNKER_VERSION,)
     ).fetchone()[0]
 
     t0 = time.time()

--- a/corpus_store/chunk_index.py
+++ b/corpus_store/chunk_index.py
@@ -34,7 +34,6 @@ import time
 from pathlib import Path
 
 from corpus_store.db import connect
-from corpus_store.ingest import REPAIRS_DDL
 from rag_poc.chunker import (
     BOILERPLATE_H,
     H2_RE,
@@ -65,10 +64,6 @@ CREATE TABLE IF NOT EXISTS chunks (
 );
 CREATE INDEX IF NOT EXISTS chunks_document_idx ON chunks(document_id);
 CREATE INDEX IF NOT EXISTS chunks_chunker_idx ON chunks(chunker_version);
-CREATE TABLE IF NOT EXISTS chunk_vector_invalidations (
-    chunk_id INTEGER PRIMARY KEY,
-    invalidated_at TEXT NOT NULL DEFAULT (datetime('now'))
-);
 """
 
 ANCHOR = 24
@@ -237,22 +232,11 @@ def reconstruct(recipe: list, c: str) -> str:
 def iter_documents(
     conn: sqlite3.Connection,
     after_document_id: int = 0,
-    include_document_ids: set[int] | None = None,
 ):
     from corpus_store.db import fetch_document_text
-    include_document_ids = include_document_ids or set()
-    if include_document_ids:
-        placeholders = ",".join("?" for _ in include_document_ids)
-        cur = conn.execute(
-            "SELECT document_id, path, markdown FROM documents"
-            f" WHERE document_id > ? OR document_id IN ({placeholders})"
-            " ORDER BY document_id",
-            [after_document_id, *sorted(include_document_ids)],
-        )
-    else:
-        cur = conn.execute(
-            "SELECT document_id, path, markdown FROM documents"
-            " WHERE document_id > ? ORDER BY document_id", (after_document_id,))
+    cur = conn.execute(
+        "SELECT document_id, path, markdown FROM documents"
+        " WHERE document_id > ? ORDER BY document_id", (after_document_id,))
     for doc_id, path, text in cur:
         if text:
             yield doc_id, path, text
@@ -262,17 +246,13 @@ def iter_documents(
 
 def require_current_chunker_version(chunks: sqlite3.Connection) -> None:
     """Refuse to append a new chunk format to an existing versioned store."""
-    versions = {
-        row[0]
-        for row in chunks.execute(
-            "SELECT DISTINCT chunker_version FROM chunks"
-        )
-    }
-    unexpected = versions - {CHUNKER_VERSION}
+    unexpected = chunks.execute(
+        "SELECT chunker_version FROM chunks WHERE chunker_version != ? LIMIT 1",
+        (CHUNKER_VERSION,),
+    ).fetchone()
     if unexpected:
-        found = ", ".join(sorted(unexpected))
         raise RuntimeError(
-            f"chunk store contains incompatible version(s): {found}; "
+            f"chunk store contains incompatible version {unexpected[0]}; "
             f"expected {CHUNKER_VERSION}. Rebuild the chunk, vector, and vec0 "
             "stores together instead of mixing versions."
         )
@@ -300,17 +280,8 @@ def main() -> None:
         raise
 
     corpus = connect(args.corpus_db)
-    corpus.executescript(REPAIRS_DDL)
-    corpus.commit()
     corpus_version = corpus.execute(
         "SELECT value FROM corpus_meta WHERE key = 'corpus_version'").fetchone()[0]
-    repair_ids = {
-        int(row[0])
-        for row in corpus.execute(
-            "SELECT document_id FROM document_repairs"
-            " WHERE chunks_pending = 1 ORDER BY document_id"
-        )
-    }
 
     # Both stores are append-only and each document is committed only after
     # all of its chunks have been built. Avoid decompressing the full corpus
@@ -336,14 +307,12 @@ def main() -> None:
                 " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", batch)
         batch.clear()
 
-    for doc_id, path, raw in iter_documents(
-        corpus, last_document_id, repair_ids
-    ):
+    for doc_id, path, raw in iter_documents(corpus, last_document_id):
         doc_t0 = time.time()
         done = chunks.execute(
             "SELECT 1 FROM chunks WHERE document_id = ? AND chunker_version = ?"
             " LIMIT 1", (doc_id, CHUNKER_VERSION)).fetchone()
-        if done and doc_id not in repair_ids:
+        if done:
             continue  # resume
         doc_chunks = split_text(raw, len(raw.encode("utf-8")), Path(path).stem)
         c = normalized_text(raw, doc_chunks[0].pattern) if doc_chunks else ""
@@ -352,7 +321,6 @@ def main() -> None:
         cursor = 0
         lo = 0
         prev_len = 0
-        doc_batch: list[tuple] = []
         for ch in doc_chunks:
             pat = ch.pattern.value
             recipe = None
@@ -384,7 +352,7 @@ def main() -> None:
                 first = 0
                 n_fallback += 1
             n_recipe_bytes += len(json.dumps(recipe))
-            doc_batch.append((
+            batch.append((
                 doc_id, path, ch.chunk_index, pat,
                 recipe[0][0] if isinstance(recipe[0], list) else 0,
                 recipe[-1][1] if isinstance(recipe[-1], list) else 0,
@@ -396,49 +364,6 @@ def main() -> None:
             ))
             n_chunks += 1
             stats_by_pattern[pat] = stats_by_pattern.get(pat, 0) + 1
-        if doc_id in repair_ids:
-            # A repair commits rows with this document_id immediately. Flush
-            # earlier new documents first so a crash cannot advance the
-            # MAX(document_id) checkpoint past chunks that only exist in batch.
-            flush_batch()
-            old_chunk_ids = [
-                int(row[0])
-                for row in chunks.execute(
-                    "SELECT chunk_id FROM chunks WHERE document_id = ?",
-                    (doc_id,),
-                )
-            ]
-            next_chunk_id = chunks.execute(
-                "SELECT COALESCE(MAX(chunk_id), 0) + 1 FROM chunks"
-            ).fetchone()[0]
-            repair_rows = [
-                (next_chunk_id + offset, *row)
-                for offset, row in enumerate(doc_batch)
-            ]
-            with chunks:
-                chunks.executemany(
-                    "INSERT OR IGNORE INTO chunk_vector_invalidations(chunk_id)"
-                    " VALUES (?)",
-                    [(chunk_id,) for chunk_id in old_chunk_ids],
-                )
-                chunks.execute(
-                    "DELETE FROM chunks WHERE document_id = ?", (doc_id,)
-                )
-                chunks.executemany(
-                    "INSERT INTO chunks (chunk_id, document_id, path, chunk_index,"
-                    " pattern, start_offset, end_offset, spans_json, token_count,"
-                    " heading_path, chunk_hash, chunker_version, corpus_version)"
-                    " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                    repair_rows,
-                )
-            with corpus:
-                corpus.execute(
-                    "UPDATE document_repairs SET chunks_pending = 0"
-                    " WHERE document_id = ?",
-                    (doc_id,),
-                )
-        else:
-            batch.extend(doc_batch)
         n_docs += 1
         doc_dt = time.time() - doc_t0
         if doc_dt > 60:

--- a/corpus_store/chunk_index.py
+++ b/corpus_store/chunk_index.py
@@ -247,9 +247,14 @@ def iter_documents(
 def require_current_chunker_version(chunks: sqlite3.Connection) -> None:
     """Refuse to append a new chunk format to an existing versioned store."""
     unexpected = chunks.execute(
-        "SELECT chunker_version FROM chunks WHERE chunker_version != ? LIMIT 1",
+        "SELECT chunker_version FROM chunks WHERE chunker_version < ? LIMIT 1",
         (CHUNKER_VERSION,),
     ).fetchone()
+    if unexpected is None:
+        unexpected = chunks.execute(
+            "SELECT chunker_version FROM chunks WHERE chunker_version > ? LIMIT 1",
+            (CHUNKER_VERSION,),
+        ).fetchone()
     if unexpected:
         raise RuntimeError(
             f"chunk store contains incompatible version {unexpected[0]}; "

--- a/corpus_store/chunk_index.py
+++ b/corpus_store/chunk_index.py
@@ -324,6 +324,18 @@ def main() -> None:
     n_docs = n_chunks = n_fallback = n_recipe_bytes = 0
     stats_by_pattern: dict[str, int] = {}
     batch: list[tuple] = []
+
+    def flush_batch() -> None:
+        if not batch:
+            return
+        with chunks:
+            chunks.executemany(
+                "INSERT INTO chunks (document_id, path, chunk_index, pattern,"
+                " start_offset, end_offset, spans_json, token_count,"
+                " heading_path, chunk_hash, chunker_version, corpus_version)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", batch)
+        batch.clear()
+
     for doc_id, path, raw in iter_documents(
         corpus, last_document_id, repair_ids
     ):
@@ -385,6 +397,10 @@ def main() -> None:
             n_chunks += 1
             stats_by_pattern[pat] = stats_by_pattern.get(pat, 0) + 1
         if doc_id in repair_ids:
+            # A repair commits rows with this document_id immediately. Flush
+            # earlier new documents first so a crash cannot advance the
+            # MAX(document_id) checkpoint past chunks that only exist in batch.
+            flush_batch()
             old_chunk_ids = [
                 int(row[0])
                 for row in chunks.execute(
@@ -429,23 +445,11 @@ def main() -> None:
             print(f"  SLOW doc {doc_id} ({doc_dt:.0f}s, {len(raw) / 2**20:.1f} MiB,"
                   f" {len(doc_chunks)} chunks): {path}", flush=True)
         if len(batch) >= 5000:
-            with chunks:
-                chunks.executemany(
-                    "INSERT INTO chunks (document_id, path, chunk_index, pattern,"
-                    " start_offset, end_offset, spans_json, token_count,"
-                    " heading_path, chunk_hash, chunker_version, corpus_version)"
-                    " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", batch)
-            batch.clear()
+            flush_batch()
         if n_docs % 1000 == 0:
             print(f"  {n_docs:,} docs, {n_chunks:,} chunks "
                   f"({time.time() - t0:.0f}s)", flush=True)
-    if batch:
-        with chunks:
-            chunks.executemany(
-                "INSERT INTO chunks (document_id, path, chunk_index, pattern,"
-                " start_offset, end_offset, spans_json, token_count,"
-                " heading_path, chunk_hash, chunker_version, corpus_version)"
-                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", batch)
+    flush_batch()
 
     chunks.execute("PRAGMA wal_checkpoint(TRUNCATE)")
     size = chunks_path.stat().st_size

--- a/corpus_store/chunk_index.py
+++ b/corpus_store/chunk_index.py
@@ -30,14 +30,18 @@ import argparse
 import hashlib
 import json
 import sqlite3
-import sys
 import time
 from pathlib import Path
 
-from rag_poc.chunker import (
-    BOILERPLATE_H, DocPattern, H2_RE, _count_tokens, _inline_image_descriptions,
-    split_text)
 from corpus_store.db import connect
+from rag_poc.chunker import (
+    BOILERPLATE_H,
+    H2_RE,
+    DocPattern,
+    _count_tokens,
+    _inline_image_descriptions,
+    split_text,
+)
 
 CHUNKER_VERSION = "dof-chunker-v1"  # rag_poc.chunker, MAX_TOKENS=800, OVERLAP=50
 
@@ -225,10 +229,11 @@ def reconstruct(recipe: list, c: str) -> str:
     return "".join(parts)
 
 
-def iter_documents(conn: sqlite3.Connection):
+def iter_documents(conn: sqlite3.Connection, after_document_id: int = 0):
     from corpus_store.db import fetch_document_text
     cur = conn.execute(
-        "SELECT document_id, path, markdown FROM documents ORDER BY document_id")
+        "SELECT document_id, path, markdown FROM documents"
+        " WHERE document_id > ? ORDER BY document_id", (after_document_id,))
     for doc_id, path, text in cur:
         if text:
             yield doc_id, path, text
@@ -255,11 +260,18 @@ def main() -> None:
         chunks.executescript(SCHEMA)
         chunks.commit()
 
+    # Both stores are append-only and each document is committed only after
+    # all of its chunks have been built. Avoid decompressing the full corpus
+    # on every daily incremental run.
+    last_document_id = chunks.execute(
+        "SELECT COALESCE(MAX(document_id), 0) FROM chunks"
+    ).fetchone()[0]
+
     t0 = time.time()
     n_docs = n_chunks = n_fallback = n_recipe_bytes = 0
     stats_by_pattern: dict[str, int] = {}
     batch: list[tuple] = []
-    for doc_id, path, raw in iter_documents(corpus):
+    for doc_id, path, raw in iter_documents(corpus, last_document_id):
         doc_t0 = time.time()
         done = chunks.execute(
             "SELECT 1 FROM chunks WHERE document_id = ? AND chunker_version = ?"

--- a/corpus_store/chunk_index.py
+++ b/corpus_store/chunk_index.py
@@ -34,6 +34,7 @@ import time
 from pathlib import Path
 
 from corpus_store.db import connect
+from corpus_store.ingest import REPAIRS_DDL
 from rag_poc.chunker import (
     BOILERPLATE_H,
     H2_RE,
@@ -64,6 +65,10 @@ CREATE TABLE IF NOT EXISTS chunks (
 );
 CREATE INDEX IF NOT EXISTS chunks_document_idx ON chunks(document_id);
 CREATE INDEX IF NOT EXISTS chunks_chunker_idx ON chunks(chunker_version);
+CREATE TABLE IF NOT EXISTS chunk_vector_invalidations (
+    chunk_id INTEGER PRIMARY KEY,
+    invalidated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
 """
 
 ANCHOR = 24
@@ -229,16 +234,48 @@ def reconstruct(recipe: list, c: str) -> str:
     return "".join(parts)
 
 
-def iter_documents(conn: sqlite3.Connection, after_document_id: int = 0):
+def iter_documents(
+    conn: sqlite3.Connection,
+    after_document_id: int = 0,
+    include_document_ids: set[int] | None = None,
+):
     from corpus_store.db import fetch_document_text
-    cur = conn.execute(
-        "SELECT document_id, path, markdown FROM documents"
-        " WHERE document_id > ? ORDER BY document_id", (after_document_id,))
+    include_document_ids = include_document_ids or set()
+    if include_document_ids:
+        placeholders = ",".join("?" for _ in include_document_ids)
+        cur = conn.execute(
+            "SELECT document_id, path, markdown FROM documents"
+            f" WHERE document_id > ? OR document_id IN ({placeholders})"
+            " ORDER BY document_id",
+            [after_document_id, *sorted(include_document_ids)],
+        )
+    else:
+        cur = conn.execute(
+            "SELECT document_id, path, markdown FROM documents"
+            " WHERE document_id > ? ORDER BY document_id", (after_document_id,))
     for doc_id, path, text in cur:
         if text:
             yield doc_id, path, text
         else:
             yield doc_id, path, fetch_document_text(conn, doc_id)
+
+
+def require_current_chunker_version(chunks: sqlite3.Connection) -> None:
+    """Refuse to append a new chunk format to an existing versioned store."""
+    versions = {
+        row[0]
+        for row in chunks.execute(
+            "SELECT DISTINCT chunker_version FROM chunks"
+        )
+    }
+    unexpected = versions - {CHUNKER_VERSION}
+    if unexpected:
+        found = ", ".join(sorted(unexpected))
+        raise RuntimeError(
+            f"chunk store contains incompatible version(s): {found}; "
+            f"expected {CHUNKER_VERSION}. Rebuild the chunk, vector, and vec0 "
+            "stores together instead of mixing versions."
+        )
 
 
 def main() -> None:
@@ -247,39 +284,54 @@ def main() -> None:
     ap.add_argument("--chunks-db", required=True)
     args = ap.parse_args()
 
-    corpus = connect(args.corpus_db)
-    corpus_version = corpus.execute(
-        "SELECT value FROM corpus_meta WHERE key = 'corpus_version'").fetchone()[0]
-
     chunks_path = Path(args.chunks_db)
     fresh = not chunks_path.exists()
     chunks = sqlite3.connect(str(chunks_path))
     if fresh:
         chunks.execute("PRAGMA journal_mode = WAL")
         chunks.execute("PRAGMA synchronous = NORMAL")
-        chunks.executescript(SCHEMA)
-        chunks.commit()
+    chunks.executescript(SCHEMA)
+    chunks.commit()
+
+    try:
+        require_current_chunker_version(chunks)
+    except Exception:
+        chunks.close()
+        raise
+
+    corpus = connect(args.corpus_db)
+    corpus.executescript(REPAIRS_DDL)
+    corpus.commit()
+    corpus_version = corpus.execute(
+        "SELECT value FROM corpus_meta WHERE key = 'corpus_version'").fetchone()[0]
+    repair_ids = {
+        int(row[0])
+        for row in corpus.execute(
+            "SELECT document_id FROM document_repairs"
+            " WHERE chunks_pending = 1 ORDER BY document_id"
+        )
+    }
 
     # Both stores are append-only and each document is committed only after
     # all of its chunks have been built. Avoid decompressing the full corpus
-    # on every daily incremental run. The checkpoint is keyed by chunker
-    # version so bumping CHUNKER_VERSION re-chunks the full corpus instead
-    # of silently skipping every previously chunked document.
+    # on every daily incremental run. A version mismatch is rejected above:
+    # retaining two versions would duplicate retrieval results and vectors.
     last_document_id = chunks.execute(
         "SELECT COALESCE(MAX(document_id), 0) FROM chunks"
-        " WHERE chunker_version = ?", (CHUNKER_VERSION,)
     ).fetchone()[0]
 
     t0 = time.time()
     n_docs = n_chunks = n_fallback = n_recipe_bytes = 0
     stats_by_pattern: dict[str, int] = {}
     batch: list[tuple] = []
-    for doc_id, path, raw in iter_documents(corpus, last_document_id):
+    for doc_id, path, raw in iter_documents(
+        corpus, last_document_id, repair_ids
+    ):
         doc_t0 = time.time()
         done = chunks.execute(
             "SELECT 1 FROM chunks WHERE document_id = ? AND chunker_version = ?"
             " LIMIT 1", (doc_id, CHUNKER_VERSION)).fetchone()
-        if done:
+        if done and doc_id not in repair_ids:
             continue  # resume
         doc_chunks = split_text(raw, len(raw.encode("utf-8")), Path(path).stem)
         c = normalized_text(raw, doc_chunks[0].pattern) if doc_chunks else ""
@@ -288,6 +340,7 @@ def main() -> None:
         cursor = 0
         lo = 0
         prev_len = 0
+        doc_batch: list[tuple] = []
         for ch in doc_chunks:
             pat = ch.pattern.value
             recipe = None
@@ -319,7 +372,7 @@ def main() -> None:
                 first = 0
                 n_fallback += 1
             n_recipe_bytes += len(json.dumps(recipe))
-            batch.append((
+            doc_batch.append((
                 doc_id, path, ch.chunk_index, pat,
                 recipe[0][0] if isinstance(recipe[0], list) else 0,
                 recipe[-1][1] if isinstance(recipe[-1], list) else 0,
@@ -331,6 +384,45 @@ def main() -> None:
             ))
             n_chunks += 1
             stats_by_pattern[pat] = stats_by_pattern.get(pat, 0) + 1
+        if doc_id in repair_ids:
+            old_chunk_ids = [
+                int(row[0])
+                for row in chunks.execute(
+                    "SELECT chunk_id FROM chunks WHERE document_id = ?",
+                    (doc_id,),
+                )
+            ]
+            next_chunk_id = chunks.execute(
+                "SELECT COALESCE(MAX(chunk_id), 0) + 1 FROM chunks"
+            ).fetchone()[0]
+            repair_rows = [
+                (next_chunk_id + offset, *row)
+                for offset, row in enumerate(doc_batch)
+            ]
+            with chunks:
+                chunks.executemany(
+                    "INSERT OR IGNORE INTO chunk_vector_invalidations(chunk_id)"
+                    " VALUES (?)",
+                    [(chunk_id,) for chunk_id in old_chunk_ids],
+                )
+                chunks.execute(
+                    "DELETE FROM chunks WHERE document_id = ?", (doc_id,)
+                )
+                chunks.executemany(
+                    "INSERT INTO chunks (chunk_id, document_id, path, chunk_index,"
+                    " pattern, start_offset, end_offset, spans_json, token_count,"
+                    " heading_path, chunk_hash, chunker_version, corpus_version)"
+                    " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    repair_rows,
+                )
+            with corpus:
+                corpus.execute(
+                    "UPDATE document_repairs SET chunks_pending = 0"
+                    " WHERE document_id = ?",
+                    (doc_id,),
+                )
+        else:
+            batch.extend(doc_batch)
         n_docs += 1
         doc_dt = time.time() - doc_t0
         if doc_dt > 60:
@@ -363,6 +455,8 @@ def main() -> None:
     print(f"recipe bytes total: {n_recipe_bytes / 2**20:.1f} MiB "
           f"({n_recipe_bytes / max(n_chunks, 1):.0f} B/chunk)")
     print(f"chunks db size: {size / 2**20:.1f} MiB in {time.time() - t0:.0f}s")
+    corpus.close()
+    chunks.close()
 
 
 if __name__ == "__main__":

--- a/corpus_store/embed.py
+++ b/corpus_store/embed.py
@@ -59,6 +59,10 @@ CREATE TABLE IF NOT EXISTS chunk_vectors (
     embedding BLOB NOT NULL
 );
 CREATE TABLE IF NOT EXISTS vector_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+CREATE TABLE IF NOT EXISTS vector_deletions (
+    chunk_id INTEGER PRIMARY KEY,
+    recorded_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
 """
 
 INSERT_EVERY = 2048  # vectors per committed batch
@@ -203,6 +207,35 @@ def iter_pending(chunks: sqlite3.Connection, after_id: int):
         yield from rows
 
 
+def apply_chunk_vector_invalidations(
+    chunks: sqlite3.Connection, vectors: sqlite3.Connection
+) -> int:
+    """Delete stale embeddings and durably queue matching vec0 deletions."""
+    chunk_ids = [
+        int(row[0])
+        for row in chunks.execute(
+            "SELECT chunk_id FROM chunk_vector_invalidations ORDER BY chunk_id"
+        )
+    ]
+    if not chunk_ids:
+        return 0
+    with vectors:
+        vectors.executemany(
+            "DELETE FROM chunk_vectors WHERE chunk_id = ?",
+            [(chunk_id,) for chunk_id in chunk_ids],
+        )
+        vectors.executemany(
+            "INSERT OR IGNORE INTO vector_deletions(chunk_id) VALUES (?)",
+            [(chunk_id,) for chunk_id in chunk_ids],
+        )
+    with chunks:
+        chunks.executemany(
+            "DELETE FROM chunk_vector_invalidations WHERE chunk_id = ?",
+            [(chunk_id,) for chunk_id in chunk_ids],
+        )
+    return len(chunk_ids)
+
+
 def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--corpus-db", required=True)
@@ -232,12 +265,17 @@ def main() -> None:
     vectors = (init_vectors_db(vectors_path, meta) if fresh
                else sqlite3.connect(str(vectors_path)))
     if not fresh:
+        vectors.executescript(SCHEMA)
+        vectors.commit()
         check_meta(vectors, meta)
-    last_id = vectors.execute(
-        "SELECT COALESCE(MAX(chunk_id), 0) FROM chunk_vectors").fetchone()[0]
 
     corpus = connect(args.corpus_db)
     chunks = sqlite3.connect(args.chunks_db)
+    invalidated = apply_chunk_vector_invalidations(chunks, vectors)
+    if invalidated:
+        print(f"invalidated {invalidated:,} stale chunk vectors", flush=True)
+    last_id = vectors.execute(
+        "SELECT COALESCE(MAX(chunk_id), 0) FROM chunk_vectors").fetchone()[0]
     total = chunks.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
     pending_total = total - chunks.execute(
         "SELECT COUNT(*) FROM chunks WHERE chunk_id <= ?", (last_id,)).fetchone()[0]
@@ -246,6 +284,9 @@ def main() -> None:
     print(f"{total:,} chunks in store, {last_id:,} already embedded, "
           f"embedding {pending_total:,}", flush=True)
     if pending_total == 0:
+        corpus.close()
+        chunks.close()
+        vectors.close()
         return
 
     proc = start_server(args.gguf, args.ctx, args.port)
@@ -289,6 +330,8 @@ def main() -> None:
     finally:
         stop_server(proc)
     vectors.close()
+    chunks.close()
+    corpus.close()
 
 
 def flush(vectors: sqlite3.Connection, buf: list[tuple[int, str]],

--- a/corpus_store/embed.py
+++ b/corpus_store/embed.py
@@ -59,10 +59,6 @@ CREATE TABLE IF NOT EXISTS chunk_vectors (
     embedding BLOB NOT NULL
 );
 CREATE TABLE IF NOT EXISTS vector_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
-CREATE TABLE IF NOT EXISTS vector_deletions (
-    chunk_id INTEGER PRIMARY KEY,
-    recorded_at TEXT NOT NULL DEFAULT (datetime('now'))
-);
 """
 
 INSERT_EVERY = 2048  # vectors per committed batch
@@ -207,35 +203,6 @@ def iter_pending(chunks: sqlite3.Connection, after_id: int):
         yield from rows
 
 
-def apply_chunk_vector_invalidations(
-    chunks: sqlite3.Connection, vectors: sqlite3.Connection
-) -> int:
-    """Delete stale embeddings and durably queue matching vec0 deletions."""
-    chunk_ids = [
-        int(row[0])
-        for row in chunks.execute(
-            "SELECT chunk_id FROM chunk_vector_invalidations ORDER BY chunk_id"
-        )
-    ]
-    if not chunk_ids:
-        return 0
-    with vectors:
-        vectors.executemany(
-            "DELETE FROM chunk_vectors WHERE chunk_id = ?",
-            [(chunk_id,) for chunk_id in chunk_ids],
-        )
-        vectors.executemany(
-            "INSERT OR IGNORE INTO vector_deletions(chunk_id) VALUES (?)",
-            [(chunk_id,) for chunk_id in chunk_ids],
-        )
-    with chunks:
-        chunks.executemany(
-            "DELETE FROM chunk_vector_invalidations WHERE chunk_id = ?",
-            [(chunk_id,) for chunk_id in chunk_ids],
-        )
-    return len(chunk_ids)
-
-
 def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--corpus-db", required=True)
@@ -265,17 +232,12 @@ def main() -> None:
     vectors = (init_vectors_db(vectors_path, meta) if fresh
                else sqlite3.connect(str(vectors_path)))
     if not fresh:
-        vectors.executescript(SCHEMA)
-        vectors.commit()
         check_meta(vectors, meta)
+    last_id = vectors.execute(
+        "SELECT COALESCE(MAX(chunk_id), 0) FROM chunk_vectors").fetchone()[0]
 
     corpus = connect(args.corpus_db)
     chunks = sqlite3.connect(args.chunks_db)
-    invalidated = apply_chunk_vector_invalidations(chunks, vectors)
-    if invalidated:
-        print(f"invalidated {invalidated:,} stale chunk vectors", flush=True)
-    last_id = vectors.execute(
-        "SELECT COALESCE(MAX(chunk_id), 0) FROM chunk_vectors").fetchone()[0]
     total = chunks.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
     pending_total = total - chunks.execute(
         "SELECT COUNT(*) FROM chunks WHERE chunk_id <= ?", (last_id,)).fetchone()[0]
@@ -284,9 +246,6 @@ def main() -> None:
     print(f"{total:,} chunks in store, {last_id:,} already embedded, "
           f"embedding {pending_total:,}", flush=True)
     if pending_total == 0:
-        corpus.close()
-        chunks.close()
-        vectors.close()
         return
 
     proc = start_server(args.gguf, args.ctx, args.port)
@@ -330,8 +289,6 @@ def main() -> None:
     finally:
         stop_server(proc)
     vectors.close()
-    chunks.close()
-    corpus.close()
 
 
 def flush(vectors: sqlite3.Connection, buf: list[tuple[int, str]],

--- a/corpus_store/ingest.py
+++ b/corpus_store/ingest.py
@@ -105,12 +105,10 @@ def ingest_batch(conn: sqlite3.Connection, corpus: Path, batch: list[dict],
         for rec in batch:
             rel = rec["relpath"]
             exists = conn.execute(
-                "SELECT d.document_id, d.byte_length,"
-                " EXISTS(SELECT 1 FROM document_segments AS s"
-                " WHERE s.document_id = d.document_id)"
+                "SELECT d.document_id, d.byte_length"
                 " FROM documents AS d WHERE d.path = ?", (rel,)).fetchone()
-            if exists and (exists[1] <= segment_threshold or exists[2]):
-                continue  # resume: already ingested and structurally complete
+            if exists and exists[1] <= segment_threshold:
+                continue  # resume: small document already ingested
             raw = (corpus / rel).read_bytes()
             digest = hashlib.sha256(raw).digest()
             size = len(raw)
@@ -119,6 +117,16 @@ def ingest_batch(conn: sqlite3.Connection, corpus: Path, batch: list[dict],
                 # metadata row with empty text; content lives in segments
                 if exists:
                     doc_id = exists[0]
+                    # EXISTS alone is not enough: an interrupted import can
+                    # leave only a subset of the expected segments. Compare
+                    # count and total length against the source file.
+                    coverage = conn.execute(
+                        "SELECT COUNT(*), COALESCE(SUM(LENGTH(segment_text)), 0)"
+                        " FROM document_segments WHERE document_id = ?",
+                        (doc_id,)).fetchone()
+                    expected = -(-len(text) // segment_threshold)
+                    if tuple(coverage) == (expected, len(text)):
+                        continue  # resume: oversized doc structurally complete
                     conn.execute(
                         "UPDATE documents SET source = ?, year = ?,"
                         " publication_date = ?, section = ?, byte_length = ?,"

--- a/corpus_store/ingest.py
+++ b/corpus_store/ingest.py
@@ -105,29 +105,51 @@ def ingest_batch(conn: sqlite3.Connection, corpus: Path, batch: list[dict],
         for rec in batch:
             rel = rec["relpath"]
             exists = conn.execute(
-                "SELECT 1 FROM documents WHERE path = ?", (rel,)).fetchone()
-            if exists:
-                continue  # resume: already ingested
+                "SELECT d.document_id, d.byte_length,"
+                " EXISTS(SELECT 1 FROM document_segments AS s"
+                " WHERE s.document_id = d.document_id)"
+                " FROM documents AS d WHERE d.path = ?", (rel,)).fetchone()
+            if exists and (exists[1] <= segment_threshold or exists[2]):
+                continue  # resume: already ingested and structurally complete
             raw = (corpus / rel).read_bytes()
             digest = hashlib.sha256(raw).digest()
             size = len(raw)
             text = raw.decode("utf-8")
             if size > segment_threshold:
                 # metadata row with empty text; content lives in segments
-                cur = conn.execute(
-                    "INSERT INTO documents (path, source, year, publication_date, section,"
-                    " markdown, byte_length, sha256, corpus_version)"
-                    " VALUES (?, ?, ?, ?, ?, '', ?, ?, ?)",
-                    (rel, source, rec["year"], rec["publication_date"], rec["section"],
-                     size, digest, corpus_version))
-                doc_id = cur.lastrowid
-                for i, start in enumerate(range(0, size, segment_threshold)):
+                if exists:
+                    doc_id = exists[0]
+                    conn.execute(
+                        "UPDATE documents SET source = ?, year = ?,"
+                        " publication_date = ?, section = ?, byte_length = ?,"
+                        " sha256 = ?, corpus_version = ?"
+                        " WHERE document_id = ?",
+                        (source, rec["year"], rec["publication_date"], rec["section"],
+                         size, digest, corpus_version, doc_id))
+                    conn.execute(
+                        "DELETE FROM document_segments WHERE document_id = ?", (doc_id,))
+                    print(f"  repairing incomplete oversized doc {doc_id}: {rel}",
+                          flush=True)
+                else:
+                    cur = conn.execute(
+                        "INSERT INTO documents (path, source, year, publication_date, section,"
+                        " markdown, byte_length, sha256, corpus_version)"
+                        " VALUES (?, ?, ?, ?, ?, '', ?, ?, ?)",
+                        (rel, source, rec["year"], rec["publication_date"], rec["section"],
+                         size, digest, corpus_version))
+                    doc_id = cur.lastrowid
+                for i, start in enumerate(range(0, len(text), segment_threshold)):
                     seg = text[start:start + segment_threshold]
                     conn.execute(
                         "INSERT INTO document_segments (document_id, segment_index,"
                         " start_offset, end_offset, segment_text) VALUES (?, ?, ?, ?, ?)",
                         (doc_id, i, start, start + len(seg), seg))
             else:
+                if exists:
+                    raise RuntimeError(
+                        f"document {rel} shrank below the segment threshold; refusing "
+                        "an implicit destructive rewrite"
+                    )
                 conn.execute(
                     "INSERT INTO documents (path, source, year, publication_date, section,"
                     " markdown, byte_length, sha256, corpus_version)"
@@ -239,7 +261,9 @@ def main() -> None:
     corpus = Path(args.corpus)
     db_path = Path(args.db)
     db_path.parent.mkdir(parents=True, exist_ok=True)
-    manifest = [json.loads(l) for l in Path(args.manifest).read_text().splitlines()]
+    manifest = [
+        json.loads(line) for line in Path(args.manifest).read_text().splitlines()
+    ]
     if args.max_docs:
         manifest = manifest[: args.max_docs]
 

--- a/corpus_store/ingest.py
+++ b/corpus_store/ingest.py
@@ -35,17 +35,6 @@ BATCH_SIZE = 256
 
 SOURCE_RE = re.compile(r"^[a-z0-9_]+$")  # safe for dict_chooser group names
 
-REPAIRS_DDL = """
-CREATE TABLE IF NOT EXISTS document_repairs (
-    document_id INTEGER PRIMARY KEY,
-    repaired_sha256 BLOB NOT NULL,
-    previous_markdown TEXT,
-    fts_pending INTEGER NOT NULL DEFAULT 1 CHECK (fts_pending IN (0, 1)),
-    chunks_pending INTEGER NOT NULL DEFAULT 1 CHECK (chunks_pending IN (0, 1)),
-    repaired_at TEXT NOT NULL DEFAULT (datetime('now'))
-);
-"""
-
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS documents (
     document_id INTEGER PRIMARY KEY,
@@ -79,7 +68,7 @@ CREATE TABLE IF NOT EXISTS ingestion_log (
     docs_inserted INTEGER NOT NULL,
     bytes_inserted INTEGER NOT NULL
 );
-""" + REPAIRS_DDL
+"""
 
 # dict_chooser is source-aware so future sources (constitucion, state laws)
 # train their own dictionaries instead of diluting the DOF ones. Changing
@@ -102,37 +91,6 @@ def already_compressed(conn: sqlite3.Connection) -> bool:
     return row is not None
 
 
-def segments_match_source(
-    conn: sqlite3.Connection,
-    document_id: int,
-    text: str,
-    segment_threshold: int,
-) -> bool:
-    """Verify exact segment indices, offsets, and text against the source."""
-    rows = conn.execute(
-        "SELECT segment_index, start_offset, end_offset, segment_text"
-        " FROM document_segments WHERE document_id = ? ORDER BY segment_index",
-        (document_id,),
-    )
-    expected_index = 0
-    expected_start = 0
-    for segment_index, start_offset, end_offset, segment_text in rows:
-        expected_text = text[expected_start:expected_start + segment_threshold]
-        if not expected_text:
-            return False  # extra row after the source is already covered
-        expected_end = expected_start + len(expected_text)
-        if (
-            segment_index != expected_index
-            or start_offset != expected_start
-            or end_offset != expected_end
-            or segment_text != expected_text
-        ):
-            return False
-        expected_index += 1
-        expected_start = expected_end
-    return expected_start == len(text)
-
-
 def ingest_batch(conn: sqlite3.Connection, corpus: Path, batch: list[dict],
                  segment_threshold: int, source: str = "dof",
                  corpus_version: str = CORPUS_VERSION) -> tuple[int, int]:
@@ -147,78 +105,29 @@ def ingest_batch(conn: sqlite3.Connection, corpus: Path, batch: list[dict],
         for rec in batch:
             rel = rec["relpath"]
             exists = conn.execute(
-                "SELECT d.document_id, d.byte_length"
-                " FROM documents AS d WHERE d.path = ?", (rel,)).fetchone()
-            if exists and exists[1] <= segment_threshold:
-                continue  # resume: small document already ingested
+                "SELECT 1 FROM documents WHERE path = ?", (rel,)).fetchone()
+            if exists:
+                continue  # resume: already ingested
             raw = (corpus / rel).read_bytes()
             digest = hashlib.sha256(raw).digest()
             size = len(raw)
             text = raw.decode("utf-8")
             if size > segment_threshold:
                 # metadata row with empty text; content lives in segments
-                if exists:
-                    doc_id = exists[0]
-                    # Validate the complete ordered recipe, not only row count:
-                    # imported/corrupt stores can have gaps or wrong offsets
-                    # whose lengths happen to add up to the source length.
-                    if segments_match_source(
-                        conn, doc_id, text, segment_threshold
-                    ):
-                        continue  # resume: oversized doc structurally complete
-                    previous_text = "".join(
-                        row[0]
-                        for row in conn.execute(
-                            "SELECT segment_text FROM document_segments"
-                            " WHERE document_id = ? ORDER BY segment_index",
-                            (doc_id,),
-                        )
-                    )
-                    conn.execute(
-                        "UPDATE documents SET source = ?, year = ?,"
-                        " publication_date = ?, section = ?, byte_length = ?,"
-                        " sha256 = ?, corpus_version = ?"
-                        " WHERE document_id = ?",
-                        (source, rec["year"], rec["publication_date"], rec["section"],
-                         size, digest, corpus_version, doc_id))
-                    conn.execute(
-                        "DELETE FROM document_segments WHERE document_id = ?", (doc_id,))
-                    conn.execute(
-                        "INSERT INTO document_repairs"
-                        " (document_id, repaired_sha256, previous_markdown,"
-                        " fts_pending, chunks_pending) VALUES (?, ?, ?, 1, 1)"
-                        " ON CONFLICT(document_id) DO UPDATE SET"
-                        " repaired_sha256 = excluded.repaired_sha256,"
-                        " previous_markdown = CASE"
-                        "   WHEN document_repairs.fts_pending = 1"
-                        "   THEN document_repairs.previous_markdown"
-                        "   ELSE excluded.previous_markdown END,"
-                        " fts_pending = 1, chunks_pending = 1,"
-                        " repaired_at = datetime('now')",
-                        (doc_id, digest, previous_text),
-                    )
-                    print(f"  repairing incomplete oversized doc {doc_id}: {rel}",
-                          flush=True)
-                else:
-                    cur = conn.execute(
-                        "INSERT INTO documents (path, source, year, publication_date, section,"
-                        " markdown, byte_length, sha256, corpus_version)"
-                        " VALUES (?, ?, ?, ?, ?, '', ?, ?, ?)",
-                        (rel, source, rec["year"], rec["publication_date"], rec["section"],
-                         size, digest, corpus_version))
-                    doc_id = cur.lastrowid
-                for i, start in enumerate(range(0, len(text), segment_threshold)):
+                cur = conn.execute(
+                    "INSERT INTO documents (path, source, year, publication_date, section,"
+                    " markdown, byte_length, sha256, corpus_version)"
+                    " VALUES (?, ?, ?, ?, ?, '', ?, ?, ?)",
+                    (rel, source, rec["year"], rec["publication_date"], rec["section"],
+                     size, digest, corpus_version))
+                doc_id = cur.lastrowid
+                for i, start in enumerate(range(0, size, segment_threshold)):
                     seg = text[start:start + segment_threshold]
                     conn.execute(
                         "INSERT INTO document_segments (document_id, segment_index,"
                         " start_offset, end_offset, segment_text) VALUES (?, ?, ?, ?, ?)",
                         (doc_id, i, start, start + len(seg), seg))
             else:
-                if exists:
-                    raise RuntimeError(
-                        f"document {rel} shrank below the segment threshold; refusing "
-                        "an implicit destructive rewrite"
-                    )
                 conn.execute(
                     "INSERT INTO documents (path, source, year, publication_date, section,"
                     " markdown, byte_length, sha256, corpus_version)"
@@ -330,9 +239,7 @@ def main() -> None:
     corpus = Path(args.corpus)
     db_path = Path(args.db)
     db_path.parent.mkdir(parents=True, exist_ok=True)
-    manifest = [
-        json.loads(line) for line in Path(args.manifest).read_text().splitlines()
-    ]
+    manifest = [json.loads(l) for l in Path(args.manifest).read_text().splitlines()]
     if args.max_docs:
         manifest = manifest[: args.max_docs]
 
@@ -349,9 +256,6 @@ def main() -> None:
                      (str(args.manifest),))
         conn.execute("INSERT INTO corpus_meta VALUES ('compression_level', ?)",
                      (str(args.level),))
-        conn.commit()
-    else:
-        conn.executescript(REPAIRS_DDL)
         conn.commit()
 
     t0 = time.time()

--- a/corpus_store/ingest.py
+++ b/corpus_store/ingest.py
@@ -35,6 +35,17 @@ BATCH_SIZE = 256
 
 SOURCE_RE = re.compile(r"^[a-z0-9_]+$")  # safe for dict_chooser group names
 
+REPAIRS_DDL = """
+CREATE TABLE IF NOT EXISTS document_repairs (
+    document_id INTEGER PRIMARY KEY,
+    repaired_sha256 BLOB NOT NULL,
+    previous_markdown TEXT,
+    fts_pending INTEGER NOT NULL DEFAULT 1 CHECK (fts_pending IN (0, 1)),
+    chunks_pending INTEGER NOT NULL DEFAULT 1 CHECK (chunks_pending IN (0, 1)),
+    repaired_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+"""
+
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS documents (
     document_id INTEGER PRIMARY KEY,
@@ -68,7 +79,7 @@ CREATE TABLE IF NOT EXISTS ingestion_log (
     docs_inserted INTEGER NOT NULL,
     bytes_inserted INTEGER NOT NULL
 );
-"""
+""" + REPAIRS_DDL
 
 # dict_chooser is source-aware so future sources (constitucion, state laws)
 # train their own dictionaries instead of diluting the DOF ones. Changing
@@ -89,6 +100,37 @@ def already_compressed(conn: sqlite3.Connection) -> bool:
     row = conn.execute(
         "SELECT 1 FROM sqlite_master WHERE name = '_documents_zstd'").fetchone()
     return row is not None
+
+
+def segments_match_source(
+    conn: sqlite3.Connection,
+    document_id: int,
+    text: str,
+    segment_threshold: int,
+) -> bool:
+    """Verify exact segment indices, offsets, and text against the source."""
+    rows = conn.execute(
+        "SELECT segment_index, start_offset, end_offset, segment_text"
+        " FROM document_segments WHERE document_id = ? ORDER BY segment_index",
+        (document_id,),
+    )
+    expected_index = 0
+    expected_start = 0
+    for segment_index, start_offset, end_offset, segment_text in rows:
+        expected_text = text[expected_start:expected_start + segment_threshold]
+        if not expected_text:
+            return False  # extra row after the source is already covered
+        expected_end = expected_start + len(expected_text)
+        if (
+            segment_index != expected_index
+            or start_offset != expected_start
+            or end_offset != expected_end
+            or segment_text != expected_text
+        ):
+            return False
+        expected_index += 1
+        expected_start = expected_end
+    return expected_start == len(text)
 
 
 def ingest_batch(conn: sqlite3.Connection, corpus: Path, batch: list[dict],
@@ -117,16 +159,21 @@ def ingest_batch(conn: sqlite3.Connection, corpus: Path, batch: list[dict],
                 # metadata row with empty text; content lives in segments
                 if exists:
                     doc_id = exists[0]
-                    # EXISTS alone is not enough: an interrupted import can
-                    # leave only a subset of the expected segments. Compare
-                    # count and total length against the source file.
-                    coverage = conn.execute(
-                        "SELECT COUNT(*), COALESCE(SUM(LENGTH(segment_text)), 0)"
-                        " FROM document_segments WHERE document_id = ?",
-                        (doc_id,)).fetchone()
-                    expected = -(-len(text) // segment_threshold)
-                    if tuple(coverage) == (expected, len(text)):
+                    # Validate the complete ordered recipe, not only row count:
+                    # imported/corrupt stores can have gaps or wrong offsets
+                    # whose lengths happen to add up to the source length.
+                    if segments_match_source(
+                        conn, doc_id, text, segment_threshold
+                    ):
                         continue  # resume: oversized doc structurally complete
+                    previous_text = "".join(
+                        row[0]
+                        for row in conn.execute(
+                            "SELECT segment_text FROM document_segments"
+                            " WHERE document_id = ? ORDER BY segment_index",
+                            (doc_id,),
+                        )
+                    )
                     conn.execute(
                         "UPDATE documents SET source = ?, year = ?,"
                         " publication_date = ?, section = ?, byte_length = ?,"
@@ -136,6 +183,20 @@ def ingest_batch(conn: sqlite3.Connection, corpus: Path, batch: list[dict],
                          size, digest, corpus_version, doc_id))
                     conn.execute(
                         "DELETE FROM document_segments WHERE document_id = ?", (doc_id,))
+                    conn.execute(
+                        "INSERT INTO document_repairs"
+                        " (document_id, repaired_sha256, previous_markdown,"
+                        " fts_pending, chunks_pending) VALUES (?, ?, ?, 1, 1)"
+                        " ON CONFLICT(document_id) DO UPDATE SET"
+                        " repaired_sha256 = excluded.repaired_sha256,"
+                        " previous_markdown = CASE"
+                        "   WHEN document_repairs.fts_pending = 1"
+                        "   THEN document_repairs.previous_markdown"
+                        "   ELSE excluded.previous_markdown END,"
+                        " fts_pending = 1, chunks_pending = 1,"
+                        " repaired_at = datetime('now')",
+                        (doc_id, digest, previous_text),
+                    )
                     print(f"  repairing incomplete oversized doc {doc_id}: {rel}",
                           flush=True)
                 else:
@@ -288,6 +349,9 @@ def main() -> None:
                      (str(args.manifest),))
         conn.execute("INSERT INTO corpus_meta VALUES ('compression_level', ?)",
                      (str(args.level),))
+        conn.commit()
+    else:
+        conn.executescript(REPAIRS_DDL)
         conn.commit()
 
     t0 = time.time()

--- a/docs/daily-updates.md
+++ b/docs/daily-updates.md
@@ -14,7 +14,6 @@ native macOS scheduler and runs a missed calendar job after the Mac wakes.
 3. Append new documents to `dof_db/dof_corpus_l3.sqlite`.
 4. Add the documents to FTS5 and build their chunk recipes.
 5. Generate Jina binary embeddings and append them to the sqlite-vec index.
-6. Verify that document, FTS, chunk, embedding, and vec0 coverage agree.
 
 Downloads are content-checked: an HTML error page returned under a `.doc`
 filename is rejected and retried on the next run. The converter applies the
@@ -22,12 +21,12 @@ same check and quarantines such files to `<name>.doc.invalid`, which is
 invisible to both the `*.doc` conversion scan and the downloader's resume
 glob, so a stale error page can never block the watermark forever.
 Conversion is restricted to the active date window, so an unrelated failed
-file elsewhere in the same year cannot block today's watermark. Failures
-inside the active window keep the contiguous completion watermark unchanged
-while successfully converted documents continue through the indexes. When a
-DOF listing page has no Word links, SIDOF notices for that date are still
-checked. Empty HTTP 200 responses count as successful only when the expected
-dated DOF/SIDOF page structure or DOF's explicit empty-date message is present.
+file elsewhere in the same year cannot block today's watermark. A failed stage
+stops the run and leaves the contiguous completion watermark unchanged; files
+already downloaded or converted remain available for the next run. When a DOF
+listing page has no Word links, SIDOF notices for that date are still checked.
+Empty HTTP 200 responses count as successful only when the expected dated
+DOF/SIDOF page structure or DOF's explicit empty-date message is present.
 
 The updater uses a non-blocking lock, so a scheduled run exits harmlessly if a
 catch-up is still running. It keeps raw Word files for auditability and because
@@ -112,9 +111,6 @@ must rebuild `dof_chunks.sqlite`, `dof_vectors_jina_binary.sqlite`, and
 `dof_vec0_jina_binary.sqlite` together; the daily updater refuses to mix old
 and new chunk recipes in live retrieval indexes.
 
-If ingestion repairs an interrupted oversized document, it records that
-document in a durable repair ledger. The FTS builder replaces the stale terms,
-the chunk builder revisits the document even when it is below its checkpoint,
-and the embedding and vec0 builders consume deletion queues before adding the
-replacement chunks. The updater advances its watermark only after those queues
-are empty and all four indexes agree on coverage.
+The daily pipeline is intentionally append-only. Replacing an already ingested
+path or repairing historical corpus rows is an offline migration and must
+rebuild or explicitly reconcile the affected derived indexes.

--- a/docs/daily-updates.md
+++ b/docs/daily-updates.md
@@ -1,9 +1,11 @@
-# Daily DOF updates on macOS
+# Daily DOF updates
 
-The production corpus is updated by the macOS `launchd` job
-`com.jackbravo.dof-rag-daily`. It runs at 05:30 local time and once whenever
-the job is loaded. `launchd` is used instead of Unix cron because it is the
-native macOS scheduler and runs a missed calendar job after the Mac wakes.
+In production the corpus is updated automatically once per day: on macOS by
+the `launchd` job `com.jackbravo.dof-rag-daily`, on Linux by the systemd user
+timer `dof-rag-daily.timer`. Both run at 05:30 local time and catch up on
+missed runs (launchd refires after the Mac wakes; the timer uses
+`Persistent=true`). `launchd`/`systemd` are used instead of Unix cron because
+they are the native schedulers.
 
 ## What each run does
 
@@ -114,3 +116,34 @@ and new chunk recipes in live retrieval indexes.
 The daily pipeline is intentionally append-only. Replacing an already ingested
 path or repairing historical corpus rows is an offline migration and must
 rebuild or explicitly reconcile the affected derived indexes.
+
+## systemd operations (Linux)
+
+Install or reload the timer (renders the checkout path into the unit template,
+then enables and starts the timer):
+
+```bash
+scripts/install_dof_systemd.sh
+```
+
+The checked-in template units are `ops/systemd/dof-rag-daily.service` and
+`ops/systemd/dof-rag-daily.timer`; the installed rendered copies live in
+`~/.config/systemd/user/`. Re-run the installer after moving the repository.
+The runner `scripts/run_dof_daily_linux.sh` accepts the same arguments as the
+macOS runner, e.g. `scripts/run_dof_daily_linux.sh --dry-run`.
+
+Inspect and operate:
+
+```bash
+systemctl --user list-timers dof-rag-daily.timer
+journalctl --user -u dof-rag-daily.service -e
+tail -f logs/dof-daily.log logs/dof-daily.error.log
+systemctl --user start dof-rag-daily.service   # extra run; the overlap lock applies
+systemctl --user disable --now dof-rag-daily.timer
+```
+
+Enable lingering so the timer fires without an open session:
+
+```bash
+loginctl enable-linger $USER
+```

--- a/docs/daily-updates.md
+++ b/docs/daily-updates.md
@@ -17,9 +17,14 @@ native macOS scheduler and runs a missed calendar job after the Mac wakes.
 6. Verify that document, FTS, chunk, embedding, and vec0 coverage agree.
 
 Downloads are content-checked: an HTML error page returned under a `.doc`
-filename is rejected and retried on the next run. Conversion failures also
+filename is rejected and retried on the next run. The converter applies the
+same check and quarantines such files to `<name>.doc.invalid`, which is
+invisible to both the `*.doc` conversion scan and the downloader's resume
+glob, so a stale error page can never block the watermark forever.
+Conversion failures also
 keep the contiguous completion watermark unchanged while successfully
-converted documents continue through the indexes.
+converted documents continue through the indexes. When a DOF listing page
+has no Word links, SIDOF notices for that date are still checked.
 
 The updater uses a non-blocking lock, so a scheduled run exits harmlessly if a
 catch-up is still running. It keeps raw Word files for auditability and because
@@ -89,6 +94,8 @@ launchctl bootout gui/$(id -u)/com.jackbravo.dof-rag-daily
 
 The checked-in plist is at
 `ops/launchd/com.jackbravo.dof-rag-daily.plist`; the installed copy is
-`~/Library/LaunchAgents/com.jackbravo.dof-rag-daily.plist`. The installer also
-copies the tiny shell launcher to `~/Library/Application Support/DOF-RAG/` so
-macOS can open it outside the protected Documents folder.
+`~/Library/LaunchAgents/com.jackbravo.dof-rag-daily.plist`. Both the plist
+and the tiny shell launcher under
+`~/Library/Application Support/DOF-RAG/` are templates: the installer bakes
+in this checkout's absolute paths, so the job works from any clone and any
+account. Re-run the installer after moving the repository.

--- a/docs/daily-updates.md
+++ b/docs/daily-updates.md
@@ -21,10 +21,13 @@ filename is rejected and retried on the next run. The converter applies the
 same check and quarantines such files to `<name>.doc.invalid`, which is
 invisible to both the `*.doc` conversion scan and the downloader's resume
 glob, so a stale error page can never block the watermark forever.
-Conversion failures also
-keep the contiguous completion watermark unchanged while successfully
-converted documents continue through the indexes. When a DOF listing page
-has no Word links, SIDOF notices for that date are still checked.
+Conversion is restricted to the active date window, so an unrelated failed
+file elsewhere in the same year cannot block today's watermark. Failures
+inside the active window keep the contiguous completion watermark unchanged
+while successfully converted documents continue through the indexes. When a
+DOF listing page has no Word links, SIDOF notices for that date are still
+checked. Empty HTTP 200 responses count as successful only when the expected
+dated DOF/SIDOF page structure or DOF's explicit empty-date message is present.
 
 The updater uses a non-blocking lock, so a scheduled run exits harmlessly if a
 catch-up is still running. It keeps raw Word files for auditability and because
@@ -34,10 +37,14 @@ the download and conversion stages are resumable.
 
 Without arguments, the updater reads a contiguous completion watermark from
 `var/dof_update_state.json`. On its first run it migrates from the last date in
-the full-build manifest. If that watermark is behind, it starts on the
-following day; otherwise it rechecks the last seven days. This means an outage
-longer than seven days still catches up automatically, a recent-date test
-cannot hide an older gap, and late or corrected DOF posts are revisited.
+the full-build manifest. It starts on the day after the watermark when the
+database is more than seven days behind; otherwise it starts at the beginning
+of the seven-day overlap. This means an outage longer than seven days still
+catches up automatically, a recent-date test cannot hide an older gap, and
+late posts with new note IDs are discovered. Existing files are intentionally
+kept for auditability, so same-path corrections require explicit replacement
+detection and are not refreshed by the overlap alone. Historical test windows
+never move an existing completion watermark backward.
 
 Preview the window without changing anything:
 
@@ -94,8 +101,20 @@ launchctl bootout gui/$(id -u)/com.jackbravo.dof-rag-daily
 
 The checked-in plist is at
 `ops/launchd/com.jackbravo.dof-rag-daily.plist`; the installed copy is
-`~/Library/LaunchAgents/com.jackbravo.dof-rag-daily.plist`. Both the plist
-and the tiny shell launcher under
-`~/Library/Application Support/DOF-RAG/` are templates: the installer bakes
-in this checkout's absolute paths, so the job works from any clone and any
-account. Re-run the installer after moving the repository.
+`~/Library/LaunchAgents/com.jackbravo.dof-rag-daily.plist`. The installer
+writes paths with `plutil` and passes the checkout through `DOF_REPO_DIR` to
+the tiny launcher under `~/Library/Application Support/DOF-RAG/`, so spaces
+and XML-special characters in account or clone paths are preserved. Re-run
+the installer after moving the repository.
+
+The chunk store accepts only the current `CHUNKER_VERSION`. A version change
+must rebuild `dof_chunks.sqlite`, `dof_vectors_jina_binary.sqlite`, and
+`dof_vec0_jina_binary.sqlite` together; the daily updater refuses to mix old
+and new chunk recipes in live retrieval indexes.
+
+If ingestion repairs an interrupted oversized document, it records that
+document in a durable repair ledger. The FTS builder replaces the stale terms,
+the chunk builder revisits the document even when it is below its checkpoint,
+and the embedding and vec0 builders consume deletion queues before adding the
+replacement chunks. The updater advances its watermark only after those queues
+are empty and all four indexes agree on coverage.

--- a/docs/daily-updates.md
+++ b/docs/daily-updates.md
@@ -1,0 +1,94 @@
+# Daily DOF updates on macOS
+
+The production corpus is updated by the macOS `launchd` job
+`com.jackbravo.dof-rag-daily`. It runs at 05:30 local time and once whenever
+the job is loaded. `launchd` is used instead of Unix cron because it is the
+native macOS scheduler and runs a missed calendar job after the Mac wakes.
+
+## What each run does
+
+`scripts/update_dof_daily.py` runs the existing resumable pipeline in order:
+
+1. Download both MAT and VES Word editions into the ignored `dof_word/` tree.
+2. Convert new `.doc` files into the canonical `../dof_md` Markdown tree.
+3. Append new documents to `dof_db/dof_corpus_l3.sqlite`.
+4. Add the documents to FTS5 and build their chunk recipes.
+5. Generate Jina binary embeddings and append them to the sqlite-vec index.
+6. Verify that document, FTS, chunk, embedding, and vec0 coverage agree.
+
+Downloads are content-checked: an HTML error page returned under a `.doc`
+filename is rejected and retried on the next run. Conversion failures also
+keep the contiguous completion watermark unchanged while successfully
+converted documents continue through the indexes.
+
+The updater uses a non-blocking lock, so a scheduled run exits harmlessly if a
+catch-up is still running. It keeps raw Word files for auditability and because
+the download and conversion stages are resumable.
+
+## Date-window behavior
+
+Without arguments, the updater reads a contiguous completion watermark from
+`var/dof_update_state.json`. On its first run it migrates from the last date in
+the full-build manifest. If that watermark is behind, it starts on the
+following day; otherwise it rechecks the last seven days. This means an outage
+longer than seven days still catches up automatically, a recent-date test
+cannot hide an older gap, and late or corrected DOF posts are revisited.
+
+Preview the window without changing anything:
+
+```bash
+scripts/run_dof_daily.sh --dry-run
+```
+
+Run a specific test window:
+
+```bash
+scripts/run_dof_daily.sh --start-date 2026-08-24 --end-date 2026-08-27
+```
+
+Start or resume the full catch-up explicitly:
+
+```bash
+scripts/run_dof_daily.sh --start-date 2026-04-25
+```
+
+The default command already selects that catch-up start while the database is
+at 2026-04-24, so an explicit date is usually unnecessary.
+
+## launchd operations
+
+Install or reload the job:
+
+```bash
+scripts/install_dof_launchd.sh
+```
+
+Inspect it:
+
+```bash
+launchctl print gui/$(id -u)/com.jackbravo.dof-rag-daily
+```
+
+Follow logs:
+
+```bash
+tail -f logs/dof-daily.log logs/dof-daily.error.log
+```
+
+Trigger an extra run (the overlap lock still applies):
+
+```bash
+launchctl kickstart gui/$(id -u)/com.jackbravo.dof-rag-daily
+```
+
+Unload it without deleting the plist:
+
+```bash
+launchctl bootout gui/$(id -u)/com.jackbravo.dof-rag-daily
+```
+
+The checked-in plist is at
+`ops/launchd/com.jackbravo.dof-rag-daily.plist`; the installed copy is
+`~/Library/LaunchAgents/com.jackbravo.dof-rag-daily.plist`. The installer also
+copies the tiny shell launcher to `~/Library/Application Support/DOF-RAG/` so
+macOS can open it outside the protected Documents folder.

--- a/get_word_dof.py
+++ b/get_word_dof.py
@@ -154,6 +154,41 @@ def extract_notice_links(html_content: str) -> List[tuple[str, str]]:
     return notice_links
 
 
+def is_valid_dof_listing(
+    html_content: str, date_str: str, edition: str
+) -> bool:
+    """Recognize a populated listing or an explicit validated empty date."""
+    soup = BeautifulSoup(html_content, "html.parser")
+    title = soup.title.get_text(" ", strip=True).casefold() if soup.title else ""
+    if "diario oficial de la federación" not in title:
+        return False
+    if soup.find(id="cuerpo_principal") is None:
+        return False
+
+    text = " ".join(soup.stripped_strings).casefold()
+    edition_name = {"MAT": "matutina", "VES": "vespertina"}.get(edition)
+    if not edition_name:
+        return False
+    expected_header = f"fecha: {date_str} - edición {edition_name}".casefold()
+    return (
+        expected_header in text
+        or "no hay datos para la fecha seleccionada" in text
+    )
+
+
+def is_valid_sidof_listing(
+    html_content: str, day: str, month: str, year: str
+) -> bool:
+    """Require the dated SIDOF publication shell before accepting no notices."""
+    soup = BeautifulSoup(html_content, "html.parser")
+    title = soup.title.get_text(" ", strip=True).casefold() if soup.title else ""
+    if "diario oficial de la federación" not in title:
+        return False
+    if f"{day}-{month}-{year}" not in html_content:
+        return False
+    return soup.find(id="resp-tab2") is not None or soup.find(id="resp-tab3") is not None
+
+
 def _download_file(session: requests.Session, url: str, output_path: Path, file_type: str = "file") -> bool:
     """
     Internal function to download a file from a URL
@@ -267,12 +302,21 @@ def process_sidof_notices(session: requests.Session, day: str, month: str, year:
     Returns:
         Number of notice files downloaded successfully
     """
+    global ERROR_COUNT
     sidof_url = f"https://sidof.segob.gob.mx/welcome/{day}-{month}-{year}"
     
     try:
         logging.info(f"Processing SIDOF page: {sidof_url}")
         response = session.get(sidof_url, timeout=30)
         response.raise_for_status()
+
+        if not is_valid_sidof_listing(response.text, day, month, year):
+            ERROR_COUNT += 1
+            logging.error(
+                f"SIDOF returned an unrecognized listing for "
+                f"{day}/{month}/{year}; refusing to validate an empty date"
+            )
+            return 0
         
         notice_links = extract_notice_links(response.text)
         
@@ -308,7 +352,6 @@ def process_sidof_notices(session: requests.Session, day: str, month: str, year:
         return downloaded_count
         
     except Exception as e:
-        global ERROR_COUNT
         ERROR_COUNT += 1
         logging.error(f"Error processing SIDOF page {sidof_url}: {e}")
         return 0
@@ -328,6 +371,7 @@ def process_dof_page(session: requests.Session, date_str: str, edition: str, out
     Returns:
         Number of files downloaded successfully
     """
+    global ERROR_COUNT
     day, month, year = date_str.split('/')
     
     dof_url = f"https://www.dof.gob.mx/index.php?year={year}&month={month}&day={day}&edicion={edition}"
@@ -337,7 +381,15 @@ def process_dof_page(session: requests.Session, date_str: str, edition: str, out
         response = session.get(dof_url, timeout=30)
         response.raise_for_status()
         
-        word_links = extract_word_links(response.text)
+        if is_valid_dof_listing(response.text, date_str, edition):
+            word_links = extract_word_links(response.text)
+        else:
+            ERROR_COUNT += 1
+            logging.error(
+                f"DOF returned an unrecognized listing for {date_str} - {edition}; "
+                "refusing to validate an empty date"
+            )
+            word_links = []
         downloaded_count = 0
 
         if not word_links:
@@ -371,7 +423,6 @@ def process_dof_page(session: requests.Session, date_str: str, edition: str, out
         return downloaded_count
         
     except Exception as e:
-        global ERROR_COUNT
         ERROR_COUNT += 1
         logging.error(f"Error processing page {dof_url}: {e}")
         return 0
@@ -408,6 +459,9 @@ def main(
     python get_word_dof.py 01/01/2023 31/01/2023 --output-dir ./dof --editions both --sleep-delay 1.5
     """
     
+    global ERROR_COUNT
+    ERROR_COUNT = 0
+
     log_levels = {
         'DEBUG': logging.DEBUG,
         'INFO': logging.INFO,

--- a/get_word_dof.py
+++ b/get_word_dof.py
@@ -176,17 +176,24 @@ def is_valid_dof_listing(
 
 
 def is_valid_sidof_listing(
-    html_content: str, day: str, month: str, year: str, edition: str
+    html_content: str, day: str, month: str, year: str
 ) -> bool:
-    """Require the dated SIDOF publication shell before accepting no notices."""
+    """Require the dated SIDOF publication shell before accepting no notices.
+
+    The listing page is edition-agnostic (edition filtering happens during
+    notice extraction). Either notices tab may be absent on normal days, so
+    the presence of either one (plus title and date) proves the real page.
+    """
     soup = BeautifulSoup(html_content, "html.parser")
     title = soup.title.get_text(" ", strip=True).casefold() if soup.title else ""
     if "diario oficial de la federación" not in title:
         return False
     if f"{day}-{month}-{year}" not in html_content:
         return False
-    expected_tab = {"VES": "resp-tab2", "MAT": "resp-tab3"}.get(edition)
-    return expected_tab is not None and soup.find(id=expected_tab) is not None
+    return (
+        soup.find(id="resp-tab2") is not None
+        or soup.find(id="resp-tab3") is not None
+    )
 
 
 def _download_file(session: requests.Session, url: str, output_path: Path, file_type: str = "file") -> bool:
@@ -321,7 +328,7 @@ def process_sidof_notices(session: requests.Session, day: str, month: str, year:
         response = session.get(sidof_url, timeout=30)
         response.raise_for_status()
 
-        if not is_valid_sidof_listing(response.text, day, month, year, edition):
+        if not is_valid_sidof_listing(response.text, day, month, year):
             ERROR_COUNT += 1
             logging.error(
                 f"SIDOF returned an unrecognized listing for "

--- a/get_word_dof.py
+++ b/get_word_dof.py
@@ -14,11 +14,11 @@ Simplified version - Only downloads WORD files
 
 """
 
+import logging
 import re
 import ssl
 import sys
 import time
-import logging
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import List, Optional
@@ -35,6 +35,8 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 # Constants
 MIN_FILE_SIZE = 1024  # Minimum file size in bytes for validation
+ERROR_COUNT = 0
+HTML_PREFIXES = (b"<!doctype html", b"<html")
 
 
 class TLSAdapter(HTTPAdapter):
@@ -165,30 +167,41 @@ def _download_file(session: requests.Session, url: str, output_path: Path, file_
     Returns:
         True if download was successful, False otherwise
     """
+    global ERROR_COUNT
     try:
         logging.info(f"Downloading {file_type}: {url}")
         
         response = session.get(url, timeout=30)
         response.raise_for_status()
         
+        if not is_valid_word_payload(response.content):
+            logging.error(f"Invalid WORD payload returned by {url}")
+            if output_path.exists() and not is_valid_word_file(output_path):
+                output_path.unlink()
+            ERROR_COUNT += 1
+            return False
+
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        
-        with open(output_path, 'wb') as f:
+        temporary = output_path.with_suffix(output_path.suffix + ".part")
+        with open(temporary, 'wb') as f:
             f.write(response.content)
-        
-        if output_path.exists() and output_path.stat().st_size >= MIN_FILE_SIZE:
+        temporary.replace(output_path)
+
+        if is_valid_word_file(output_path):
             logging.info(f"Downloaded successfully: {output_path}")
             return True
         else:
             logging.warning(f"Invalid file (missing or too small), deleting: {output_path}")
             if output_path.exists():
                 output_path.unlink()
+            ERROR_COUNT += 1
             return False
             
     except Exception as e:
         logging.error(f"Error downloading {url}: {e}")
         if output_path.exists():
             output_path.unlink()
+        ERROR_COUNT += 1
         return False
 
 
@@ -205,6 +218,30 @@ def download_notice_file(session: requests.Session, note_id: str, output_path: P
     """
     url = f"https://sidof.segob.gob.mx/notas/getDoc/{note_id}"
     return _download_file(session, url, output_path, file_type="notice")
+
+
+def is_valid_word_payload(content: bytes) -> bool:
+    """Reject DOF/SIDOF HTML error pages masquerading as Word downloads."""
+    if len(content) < MIN_FILE_SIZE:
+        return False
+    prefix = content[:512].lstrip().lower()
+    return not prefix.startswith(HTML_PREFIXES)
+
+
+def is_valid_word_file(path: Path) -> bool:
+    try:
+        if path.stat().st_size < MIN_FILE_SIZE:
+            return False
+        with path.open("rb") as stream:
+            prefix = stream.read(512).lstrip().lower()
+        return not prefix.startswith(HTML_PREFIXES)
+    except OSError:
+        return False
+
+
+def has_valid_download(date_dir: Path, note_id: str) -> bool:
+    """Return whether this note exists under any page-order sequence number."""
+    return any(is_valid_word_file(path) for path in date_dir.glob(f"*_{note_id}.doc"))
 
 
 def _create_edition_dir(output_dir: Path, day: str, month: str, year: str, edition: str) -> Path:
@@ -259,8 +296,8 @@ def process_sidof_notices(session: requests.Session, day: str, month: str, year:
             filename = f"{str(index+1).zfill(3)}_AVISO_{year}{month}{day}_{edition}_{note_id}.doc"
             output_path = date_dir / filename
             
-            if output_path.exists() and output_path.stat().st_size >= MIN_FILE_SIZE:
-                logging.warning(f"File already exists: {output_path}")
+            if has_valid_download(date_dir, note_id):
+                logging.info(f"Notice already downloaded: {note_id}")
                 continue
             
             if download_notice_file(session, note_id, output_path):
@@ -271,6 +308,8 @@ def process_sidof_notices(session: requests.Session, day: str, month: str, year:
         return downloaded_count
         
     except Exception as e:
+        global ERROR_COUNT
+        ERROR_COUNT += 1
         logging.error(f"Error processing SIDOF page {sidof_url}: {e}")
         return 0
 
@@ -314,8 +353,8 @@ def process_dof_page(session: requests.Session, date_str: str, edition: str, out
             filename = f"{str(index+1).zfill(3)}_DOF_{year}{month}{day}_{edition}_{codnota}.doc"
             output_path = date_dir / filename
             
-            if output_path.exists() and output_path.stat().st_size >= MIN_FILE_SIZE:
-                logging.warning(f"File already exists: {output_path}")
+            if has_valid_download(date_dir, codnota):
+                logging.info(f"WORD note already downloaded: {codnota}")
                 continue
             
             if download_word_file(session, word_url, output_path):
@@ -330,6 +369,8 @@ def process_dof_page(session: requests.Session, date_str: str, edition: str, out
         return downloaded_count
         
     except Exception as e:
+        global ERROR_COUNT
+        ERROR_COUNT += 1
         logging.error(f"Error processing page {dof_url}: {e}")
         return 0
 
@@ -438,6 +479,9 @@ def main(
     
     logging.info("-" * 60)
     logging.info(f"Download completed. Total files downloaded: {total_downloaded}")
+    if ERROR_COUNT:
+        logging.error(f"Download completed with {ERROR_COUNT} error(s)")
+        raise typer.Exit(code=1)
 
 
 if __name__ == "__main__":

--- a/get_word_dof.py
+++ b/get_word_dof.py
@@ -30,13 +30,13 @@ import urllib3
 from bs4 import BeautifulSoup
 from requests.adapters import HTTPAdapter
 
+from word_validation import is_valid_word_file, is_valid_word_payload
+
 # Disable SSL warnings
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 # Constants
-MIN_FILE_SIZE = 1024  # Minimum file size in bytes for validation
 ERROR_COUNT = 0
-HTML_PREFIXES = (b"<!doctype html", b"<html")
 
 
 class TLSAdapter(HTTPAdapter):
@@ -177,7 +177,7 @@ def is_valid_dof_listing(
 
 
 def is_valid_sidof_listing(
-    html_content: str, day: str, month: str, year: str
+    html_content: str, day: str, month: str, year: str, edition: str
 ) -> bool:
     """Require the dated SIDOF publication shell before accepting no notices."""
     soup = BeautifulSoup(html_content, "html.parser")
@@ -186,7 +186,8 @@ def is_valid_sidof_listing(
         return False
     if f"{day}-{month}-{year}" not in html_content:
         return False
-    return soup.find(id="resp-tab2") is not None or soup.find(id="resp-tab3") is not None
+    expected_tab = {"VES": "resp-tab2", "MAT": "resp-tab3"}.get(edition)
+    return expected_tab is not None and soup.find(id=expected_tab) is not None
 
 
 def _download_file(session: requests.Session, url: str, output_path: Path, file_type: str = "file") -> bool:
@@ -255,25 +256,6 @@ def download_notice_file(session: requests.Session, note_id: str, output_path: P
     return _download_file(session, url, output_path, file_type="notice")
 
 
-def is_valid_word_payload(content: bytes) -> bool:
-    """Reject DOF/SIDOF HTML error pages masquerading as Word downloads."""
-    if len(content) < MIN_FILE_SIZE:
-        return False
-    prefix = content[:512].lstrip().lower()
-    return not prefix.startswith(HTML_PREFIXES)
-
-
-def is_valid_word_file(path: Path) -> bool:
-    try:
-        if path.stat().st_size < MIN_FILE_SIZE:
-            return False
-        with path.open("rb") as stream:
-            prefix = stream.read(512).lstrip().lower()
-        return not prefix.startswith(HTML_PREFIXES)
-    except OSError:
-        return False
-
-
 def has_valid_download(date_dir: Path, note_id: str) -> bool:
     """Return whether this note exists under any page-order sequence number."""
     return any(is_valid_word_file(path) for path in date_dir.glob(f"*_{note_id}.doc"))
@@ -310,7 +292,7 @@ def process_sidof_notices(session: requests.Session, day: str, month: str, year:
         response = session.get(sidof_url, timeout=30)
         response.raise_for_status()
 
-        if not is_valid_sidof_listing(response.text, day, month, year):
+        if not is_valid_sidof_listing(response.text, day, month, year, edition):
             ERROR_COUNT += 1
             logging.error(
                 f"SIDOF returned an unrecognized listing for "

--- a/get_word_dof.py
+++ b/get_word_dof.py
@@ -21,8 +21,7 @@ import sys
 import time
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import List, Optional
-from urllib.parse import urljoin
+from urllib.parse import unquote, urljoin
 
 import requests
 import typer
@@ -72,7 +71,7 @@ def setup_session() -> requests.Session:
     return session
 
 
-def extract_word_links(html_content: str, base_url: str = 'https://www.dof.gob.mx') -> List[tuple[str, str]]:
+def extract_word_links(html_content: str, base_url: str = 'https://www.dof.gob.mx') -> list[tuple[str, str]]:
     """
     Extracts WORD file links from HTML content
     
@@ -100,7 +99,7 @@ def extract_word_links(html_content: str, base_url: str = 'https://www.dof.gob.m
     return word_links
 
 
-def extract_notice_links(html_content: str) -> List[tuple[str, str]]:
+def extract_notice_links(html_content: str) -> list[tuple[str, str]]:
     """
     Extracts notice links from SIDOF HTML content for all AVISOS subsections
     Detects edition (MAT/VES) based on tab-pane container
@@ -211,6 +210,18 @@ def _download_file(session: requests.Session, url: str, output_path: Path, file_
         response.raise_for_status()
         
         if not is_valid_word_payload(response.content):
+            if _is_permanent_missing(response):
+                # The source states the file does not exist; retrying on
+                # every daily run would fail forever. Record a tombstone
+                # next to the target and skip it from now on (delete the
+                # marker to force a retry). Not counted as an error.
+                marker = output_path.with_suffix(output_path.suffix + ".missing")
+                marker.write_text(response.url + "\n", encoding="utf-8")
+                logging.warning(
+                    f"Source reports the file does not exist; "
+                    f"marking permanently missing: {url}"
+                )
+                return False
             logging.error(f"Invalid WORD payload returned by {url}")
             if output_path.exists() and not is_valid_word_file(output_path):
                 output_path.unlink()
@@ -259,6 +270,24 @@ def download_notice_file(session: requests.Session, note_id: str, output_path: P
 def has_valid_download(date_dir: Path, note_id: str) -> bool:
     """Return whether this note exists under any page-order sequence number."""
     return any(is_valid_word_file(path) for path in date_dir.glob(f"*_{note_id}.doc"))
+
+
+def _is_permanent_missing(response: requests.Response) -> bool:
+    """Whether the source server states that the file does not exist.
+
+    SIDOF redirects such notes to an "El archivo no existe" HTML page; that
+    is a permanent source-side absence, not a transient download failure.
+    """
+    if "archivo no existe" in unquote(response.url).lower():
+        return True
+    if "html" not in response.headers.get("Content-Type", "").lower():
+        return False
+    return "el archivo no existe" in response.text.lower()
+
+
+def has_missing_marker(date_dir: Path, note_id: str) -> bool:
+    """Whether a previous run recorded this note as permanently unavailable."""
+    return any(date_dir.glob(f"*_{note_id}.doc.missing"))
 
 
 def _create_edition_dir(output_dir: Path, day: str, month: str, year: str, edition: str) -> Path:
@@ -324,6 +353,10 @@ def process_sidof_notices(session: requests.Session, day: str, month: str, year:
             
             if has_valid_download(date_dir, note_id):
                 logging.info(f"Notice already downloaded: {note_id}")
+                continue
+            
+            if has_missing_marker(date_dir, note_id):
+                logging.info(f"Notice permanently missing, skipping: {note_id}")
                 continue
             
             if download_notice_file(session, note_id, output_path):
@@ -393,6 +426,10 @@ def process_dof_page(session: requests.Session, date_str: str, edition: str, out
                     logging.info(f"WORD note already downloaded: {codnota}")
                     continue
 
+                if has_missing_marker(date_dir, codnota):
+                    logging.info(f"WORD note permanently missing, skipping: {codnota}")
+                    continue
+
                 if download_word_file(session, word_url, output_path):
                     downloaded_count += 1
 
@@ -412,7 +449,7 @@ def process_dof_page(session: requests.Session, date_str: str, edition: str, out
 
 def main(
     date: str = typer.Argument(..., help="Fecha (DD/MM/YYYY) o fecha de inicio para rango"),
-    end_date: Optional[str] = typer.Argument(None, help="Fecha de fin (DD/MM/YYYY) - opcional para rango de fechas"),
+    end_date: str | None = typer.Argument(None, help="Fecha de fin (DD/MM/YYYY) - opcional para rango de fechas"),
     output_dir: str = typer.Option("./dof_word", help="Directorio de salida"),
     editions: str = typer.Option("both", help="Ediciones a descargar: 'mat', 'ves', o 'both'"),
     log_level: str = typer.Option("INFO", help="Nivel de logging: DEBUG, INFO, WARNING, ERROR"),

--- a/get_word_dof.py
+++ b/get_word_dof.py
@@ -338,30 +338,32 @@ def process_dof_page(session: requests.Session, date_str: str, edition: str, out
         response.raise_for_status()
         
         word_links = extract_word_links(response.text)
-        
-        if not word_links:
-            logging.info(f"No WORD files found for {date_str} - {edition}")
-            return 0
-        
-        logging.info(f"Found {len(word_links)} WORD files")
-        
-        date_dir = _create_edition_dir(output_dir, day, month, year, edition)
-        
         downloaded_count = 0
-        
-        for index, (word_url, codnota) in enumerate(word_links):
-            filename = f"{str(index+1).zfill(3)}_DOF_{year}{month}{day}_{edition}_{codnota}.doc"
-            output_path = date_dir / filename
-            
-            if has_valid_download(date_dir, codnota):
-                logging.info(f"WORD note already downloaded: {codnota}")
-                continue
-            
-            if download_word_file(session, word_url, output_path):
-                downloaded_count += 1
-            
-            time.sleep(sleep_delay)
-        
+
+        if not word_links:
+            # No Word documents on the main page does not imply the edition
+            # is empty: SIDOF notices may still exist for this date.
+            logging.info(
+                f"No WORD files found for {date_str} - {edition}; "
+                "still checking SIDOF notices")
+        else:
+            logging.info(f"Found {len(word_links)} WORD files")
+
+            date_dir = _create_edition_dir(output_dir, day, month, year, edition)
+
+            for index, (word_url, codnota) in enumerate(word_links):
+                filename = f"{str(index+1).zfill(3)}_DOF_{year}{month}{day}_{edition}_{codnota}.doc"
+                output_path = date_dir / filename
+
+                if has_valid_download(date_dir, codnota):
+                    logging.info(f"WORD note already downloaded: {codnota}")
+                    continue
+
+                if download_word_file(session, word_url, output_path):
+                    downloaded_count += 1
+
+                time.sleep(sleep_delay)
+
         logging.info(f"Now processing SIDOF notices for {date_str} - {edition}")
         notices_downloaded = process_sidof_notices(session, day, month, year, edition, output_dir, sleep_delay, start_index=len(word_links))
         downloaded_count += notices_downloaded

--- a/ops/launchd/com.jackbravo.dof-rag-daily.plist
+++ b/ops/launchd/com.jackbravo.dof-rag-daily.plist
@@ -12,7 +12,7 @@
         <string>10</string>
         <string>/usr/bin/caffeinate</string>
         <string>-i</string>
-        <string>/Users/jackbravo/Library/Application Support/DOF-RAG/run_dof_daily.sh</string>
+        <string>@DOF_RUNNER@</string>
     </array>
 
     <key>RunAtLoad</key>
@@ -30,8 +30,8 @@
     <key>LowPriorityIO</key>
     <true/>
     <key>StandardOutPath</key>
-    <string>/Users/jackbravo/Documents/jackbravo/dof-rag/logs/dof-daily.log</string>
+    <string>@DOF_LOG_DIR@/dof-daily.log</string>
     <key>StandardErrorPath</key>
-    <string>/Users/jackbravo/Documents/jackbravo/dof-rag/logs/dof-daily.error.log</string>
+    <string>@DOF_LOG_DIR@/dof-daily.error.log</string>
 </dict>
 </plist>

--- a/ops/launchd/com.jackbravo.dof-rag-daily.plist
+++ b/ops/launchd/com.jackbravo.dof-rag-daily.plist
@@ -29,6 +29,11 @@
     <string>Background</string>
     <key>LowPriorityIO</key>
     <true/>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>DOF_REPO_DIR</key>
+        <string>@DOF_REPO_DIR@</string>
+    </dict>
     <key>StandardOutPath</key>
     <string>@DOF_LOG_DIR@/dof-daily.log</string>
     <key>StandardErrorPath</key>

--- a/ops/launchd/com.jackbravo.dof-rag-daily.plist
+++ b/ops/launchd/com.jackbravo.dof-rag-daily.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.jackbravo.dof-rag-daily</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/nice</string>
+        <string>-n</string>
+        <string>10</string>
+        <string>/usr/bin/caffeinate</string>
+        <string>-i</string>
+        <string>/Users/jackbravo/Library/Application Support/DOF-RAG/run_dof_daily.sh</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>5</integer>
+        <key>Minute</key>
+        <integer>30</integer>
+    </dict>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+    <key>LowPriorityIO</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/Users/jackbravo/Documents/jackbravo/dof-rag/logs/dof-daily.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/jackbravo/Documents/jackbravo/dof-rag/logs/dof-daily.error.log</string>
+</dict>
+</plist>

--- a/ops/systemd/dof-rag-daily.service
+++ b/ops/systemd/dof-rag-daily.service
@@ -6,7 +6,6 @@ After=network-online.target
 [Service]
 Type=oneshot
 Nice=10
-Environment=DOF_REPO_DIR=%h/Documents/dof/dof-rag
-ExecStart=%h/Documents/dof/dof-rag/scripts/run_dof_daily_linux.sh
-StandardOutput=append:%h/Documents/dof/dof-rag/logs/dof-daily.log
-StandardError=append:%h/Documents/dof/dof-rag/logs/dof-daily.error.log
+ExecStart=@DOF_REPO_DIR@/scripts/run_dof_daily_linux.sh
+StandardOutput=append:@DOF_REPO_DIR@/logs/dof-daily.log
+StandardError=append:@DOF_REPO_DIR@/logs/dof-daily.error.log

--- a/ops/systemd/dof-rag-daily.service
+++ b/ops/systemd/dof-rag-daily.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=DOF daily corpus update (download, convert, index, embed)
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+Nice=10
+Environment=DOF_REPO_DIR=%h/Documents/dof/dof-rag
+ExecStart=%h/Documents/dof/dof-rag/scripts/run_dof_daily_linux.sh
+StandardOutput=append:%h/Documents/dof/dof-rag/logs/dof-daily.log
+StandardError=append:%h/Documents/dof/dof-rag/logs/dof-daily.error.log

--- a/ops/systemd/dof-rag-daily.timer
+++ b/ops/systemd/dof-rag-daily.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Daily DOF corpus update at 05:30 local time
+
+[Timer]
+OnCalendar=*-*-* 05:30:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/rag_poc/chunker.py
+++ b/rag_poc/chunker.py
@@ -186,13 +186,17 @@ def _split_h2_compound(text: str, doc_id: str, pattern: DocPattern) -> list[Chun
         if not content.strip():
             continue
         content = BOILERPLATE_H.sub("", content)
-        chunk_text = f"## {heading}\n\n{content}"
+        # heading is "" for the preamble (content before the first H2);
+        # emit it without inventing a heading prefix.
+        prefix = f"## {heading}\n\n" if heading else ""
+        base_path = [heading] if heading else _extract_h1(content)
+        chunk_text = prefix + content
         token_count = _count_tokens(chunk_text)
         if token_count <= H2_MAX_TOKENS:
             chunks.append(
                 Chunk(
                     text=chunk_text,
-                    heading_path=[heading],
+                    heading_path=base_path,
                     chunk_index=len(chunks),
                     pattern=pattern,
                     has_image=bool(IMAGE_RE.search(content)),
@@ -205,7 +209,6 @@ def _split_h2_compound(text: str, doc_id: str, pattern: DocPattern) -> list[Chun
             if len(sub_sections) == 1 and sub_sections[0][0] == "":
                 sub_content = BOILERPLATE_H.sub("", sub_sections[0][1])
                 if sub_content.strip():
-                    prefix = f"## {heading}\n\n"
                     prefix_tokens = _count_tokens(prefix)
                     budget = max(1, MAX_TOKENS - prefix_tokens)
                     overlap = min(OVERLAP_TOKENS, budget - 1)
@@ -214,7 +217,7 @@ def _split_h2_compound(text: str, doc_id: str, pattern: DocPattern) -> list[Chun
                         chunks.append(
                             Chunk(
                                 text=prefix + part,
-                                heading_path=[heading],
+                                heading_path=base_path,
                                 chunk_index=len(chunks),
                                 pattern=pattern,
                                 has_image=bool(IMAGE_RE.search(part)),
@@ -226,16 +229,18 @@ def _split_h2_compound(text: str, doc_id: str, pattern: DocPattern) -> list[Chun
                 sub_content = BOILERPLATE_H.sub("", sub_content)
                 if not sub_content.strip():
                     continue
-                prefix = f"## {heading}\n### {sub_heading}\n\n"
-                prefix_tokens = _count_tokens(prefix)
+                # sub_heading is "" for the section preamble (content before
+                # the first H3): keep the H2 prefix, invent no H3 prefix.
+                sub_prefix = prefix + (f"### {sub_heading}\n\n" if sub_heading else "")
+                prefix_tokens = _count_tokens(sub_prefix)
                 budget = max(1, MAX_TOKENS - prefix_tokens)
                 overlap = min(OVERLAP_TOKENS, budget - 1)
                 parts = _split_by_tokens(sub_content, budget, overlap)
                 for part in parts:
                     chunks.append(
                         Chunk(
-                            text=f"## {heading}\n### {sub_heading}\n\n{part}",
-                            heading_path=[heading, sub_heading],
+                            text=sub_prefix + part,
+                            heading_path=base_path + ([sub_heading] if sub_heading else []),
                             chunk_index=len(chunks),
                             pattern=pattern,
                             has_image=bool(IMAGE_RE.search(part)),
@@ -357,11 +362,21 @@ def _inline_image_descriptions(md_text: str) -> str:
 
 
 def _split_by_heading(text: str, heading_re: re.Pattern) -> list[tuple[str, str]]:
-    """Divide texto por un patrón de heading → (heading, contenido)."""
+    """Divide texto por un patrón de heading → (heading, contenido).
+
+    The preamble (content before the first heading) is preserved as a
+    leading ("", preamble) entry when non-empty; callers must handle the
+    empty heading (no prefix). Before, the preamble was silently dropped —
+    for documents whose only H2s are the trailing rubric signatures, that
+    discarded the whole document body and produced zero chunks.
+    """
     positions = [(m.start(), m.group(1)) for m in heading_re.finditer(text)]
     if not positions:
         return [("", text)]
     result = []
+    preamble = text[: positions[0][0]]
+    if preamble.strip():
+        result.append(("", preamble))
     for i, (pos, heading) in enumerate(positions):
         end = positions[i + 1][0] if i + 1 < len(positions) else len(text)
         # Safe newline search: handle heading at EOF without trailing \n

--- a/scripts/build_fts_full.py
+++ b/scripts/build_fts_full.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from corpus_store.db import connect, fetch_document_text  # noqa: E402
+from corpus_store.ingest import REPAIRS_DDL  # noqa: E402
 
 FTS_DDL = """CREATE VIRTUAL TABLE documents_fts USING fts5(
     markdown, content='documents', content_rowid='document_id',
@@ -40,6 +41,46 @@ def set_meta(conn, key: str, value: int) -> None:
     conn.execute(
         "INSERT INTO _fts_build_meta(k, v) VALUES (?, ?) "
         "ON CONFLICT(k) DO UPDATE SET v = excluded.v", (key, value))
+
+
+def repair_fts_documents(conn) -> tuple[int, int]:
+    """Reindex repaired rows using the exact text previously in FTS5."""
+    repairs = conn.execute(
+        "SELECT document_id, previous_markdown FROM document_repairs"
+        " WHERE fts_pending = 1 ORDER BY document_id"
+    ).fetchall()
+    if not repairs:
+        return 0, 0
+
+    newly_indexed = 0
+    with conn:
+        for document_id, previous_markdown in repairs:
+            indexed = conn.execute(
+                "SELECT 1 FROM documents_fts_docsize WHERE id = ?",
+                (document_id,),
+            ).fetchone()
+            if indexed:
+                if previous_markdown is None:
+                    raise RuntimeError(
+                        f"repair {document_id} lacks previous FTS text"
+                    )
+                conn.execute(
+                    "INSERT INTO documents_fts"
+                    " (documents_fts, rowid, markdown) VALUES ('delete', ?, ?)",
+                    (document_id, previous_markdown),
+                )
+            else:
+                newly_indexed += 1
+            conn.execute(
+                "INSERT INTO documents_fts(rowid, markdown) VALUES (?, ?)",
+                (document_id, fetch_document_text(conn, document_id)),
+            )
+            conn.execute(
+                "UPDATE document_repairs SET fts_pending = 0,"
+                " previous_markdown = NULL WHERE document_id = ?",
+                (document_id,),
+            )
+    return len(repairs), newly_indexed
 
 
 def main() -> None:
@@ -70,7 +111,12 @@ def main() -> None:
         conn.commit()
         print(f"created documents_fts ({time.time() - t0:.0f}s)", flush=True)
     conn.execute(META_DDL)
+    conn.executescript(REPAIRS_DDL)
     conn.commit()
+
+    repaired, _ = repair_fts_documents(conn)
+    if repaired:
+        print(f"reindexed {repaired} repaired FTS documents", flush=True)
 
     total = conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0]
     max_id = conn.execute("SELECT MAX(document_id) FROM documents").fetchone()[0]

--- a/scripts/build_fts_full.py
+++ b/scripts/build_fts_full.py
@@ -20,7 +20,6 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from corpus_store.db import connect, fetch_document_text  # noqa: E402
-from corpus_store.ingest import REPAIRS_DDL  # noqa: E402
 
 FTS_DDL = """CREATE VIRTUAL TABLE documents_fts USING fts5(
     markdown, content='documents', content_rowid='document_id',
@@ -31,56 +30,10 @@ META_DDL = ("CREATE TABLE IF NOT EXISTS _fts_build_meta"
             "(k TEXT PRIMARY KEY, v INTEGER)")
 
 
-def get_meta(conn, key: str) -> int:
-    row = conn.execute(
-        "SELECT v FROM _fts_build_meta WHERE k = ?", (key,)).fetchone()
-    return row[0] if row else 0
-
-
 def set_meta(conn, key: str, value: int) -> None:
     conn.execute(
         "INSERT INTO _fts_build_meta(k, v) VALUES (?, ?) "
         "ON CONFLICT(k) DO UPDATE SET v = excluded.v", (key, value))
-
-
-def repair_fts_documents(conn) -> tuple[int, int]:
-    """Reindex repaired rows using the exact text previously in FTS5."""
-    repairs = conn.execute(
-        "SELECT document_id, previous_markdown FROM document_repairs"
-        " WHERE fts_pending = 1 ORDER BY document_id"
-    ).fetchall()
-    if not repairs:
-        return 0, 0
-
-    newly_indexed = 0
-    with conn:
-        for document_id, previous_markdown in repairs:
-            indexed = conn.execute(
-                "SELECT 1 FROM documents_fts_docsize WHERE id = ?",
-                (document_id,),
-            ).fetchone()
-            if indexed:
-                if previous_markdown is None:
-                    raise RuntimeError(
-                        f"repair {document_id} lacks previous FTS text"
-                    )
-                conn.execute(
-                    "INSERT INTO documents_fts"
-                    " (documents_fts, rowid, markdown) VALUES ('delete', ?, ?)",
-                    (document_id, previous_markdown),
-                )
-            else:
-                newly_indexed += 1
-            conn.execute(
-                "INSERT INTO documents_fts(rowid, markdown) VALUES (?, ?)",
-                (document_id, fetch_document_text(conn, document_id)),
-            )
-            conn.execute(
-                "UPDATE document_repairs SET fts_pending = 0,"
-                " previous_markdown = NULL WHERE document_id = ?",
-                (document_id,),
-            )
-    return len(repairs), newly_indexed
 
 
 def main() -> None:
@@ -111,12 +64,7 @@ def main() -> None:
         conn.commit()
         print(f"created documents_fts ({time.time() - t0:.0f}s)", flush=True)
     conn.execute(META_DDL)
-    conn.executescript(REPAIRS_DDL)
     conn.commit()
-
-    repaired, _ = repair_fts_documents(conn)
-    if repaired:
-        print(f"reindexed {repaired} repaired FTS documents", flush=True)
 
     total = conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0]
     max_id = conn.execute("SELECT MAX(document_id) FROM documents").fetchone()[0]

--- a/scripts/build_fts_full.py
+++ b/scripts/build_fts_full.py
@@ -4,8 +4,9 @@ Batched by document_id ranges so we get progress logging and small
 transactions (the embedding run reads this db concurrently in WAL mode).
 
 NOTE: documents_fts is an EXTERNAL CONTENT table, so COUNT(*)/MAX(rowid)
-against it scan the content table (documents), NOT the FTS index. Progress
-is therefore tracked in a sidecar table `_fts_build_meta` instead.
+against it scan the content table (documents), NOT the FTS index. Actual
+progress is read from the FTS5 ``documents_fts_docsize`` shadow table. The
+sidecar `_fts_build_meta` remains as human-readable operational metadata.
 
 Usage:
     uv run python scripts/build_fts_full.py \
@@ -73,20 +74,29 @@ def main() -> None:
 
     total = conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0]
     max_id = conn.execute("SELECT MAX(document_id) FROM documents").fetchone()[0]
-    lo = get_meta(conn, "indexed_through")
-    done = get_meta(conn, "indexed_count")
+    done = conn.execute("SELECT COUNT(*) FROM documents_fts_docsize").fetchone()[0]
+    first_missing = conn.execute(
+        "SELECT MIN(d.document_id) FROM documents AS d"
+        " LEFT JOIN documents_fts_docsize AS f ON f.id = d.document_id"
+        " WHERE f.id IS NULL"
+    ).fetchone()[0]
+    lo = first_missing - 1 if first_missing is not None else max_id
+    set_meta(conn, "indexed_through", lo)
+    set_meta(conn, "indexed_count", done)
+    conn.commit()
     print(f"documents: {total:,}  max_id: {max_id:,}  "
           f"already indexed: {done:,} (through id {lo:,})", flush=True)
 
     while lo < max_id:
-        hi = lo + args.batch
+        hi = min(lo + args.batch, max_id)
         t = time.time()
         with conn:
             cur = conn.execute(
                 "INSERT INTO documents_fts(rowid, markdown) "
                 "SELECT document_id, markdown FROM documents "
+                "LEFT JOIN documents_fts_docsize AS f ON f.id = document_id "
                 "WHERE document_id > ? AND document_id <= ? "
-                "AND markdown != ''",
+                "AND f.id IS NULL AND markdown != ''",
                 (lo, hi),
             )
             done += cur.rowcount
@@ -99,10 +109,14 @@ def main() -> None:
               f"batch {time.time() - t:.1f}s)", flush=True)
         lo = hi
 
-    # 32 oversized docs are stored as segments (markdown = ''), reassemble
-    if not get_meta(conn, "segmented_done"):
-        seg_ids = [r[0] for r in conn.execute(
-            "SELECT DISTINCT document_id FROM document_segments")]
+    # Oversized docs are stored as segments (markdown = ''), so reassemble any
+    # missing from the actual FTS shadow table, including documents appended
+    # after the original full build.
+    seg_ids = [r[0] for r in conn.execute(
+        "SELECT DISTINCT s.document_id FROM document_segments AS s"
+        " LEFT JOIN documents_fts_docsize AS f ON f.id = s.document_id"
+        " WHERE f.id IS NULL")]
+    if seg_ids:
         with conn:
             for doc_id in seg_ids:
                 conn.execute(
@@ -114,12 +128,14 @@ def main() -> None:
             set_meta(conn, "segmented_done", 1)
         print(f"indexed {len(seg_ids)} segmented docs", flush=True)
 
+    done = conn.execute("SELECT COUNT(*) FROM documents_fts_docsize").fetchone()[0]
     assert done == total, f"fts count {done} != documents {total}"
     # real index sanity: a MATCH query (COUNT(*) scans the content table!)
     n = conn.execute(
         "SELECT COUNT(*) FROM documents_fts"
         " WHERE documents_fts MATCH 'decreto'").fetchone()[0]
-    assert n > 10_000, f"suspiciously few MATCH results: {n}"
+    expected_min = min(10_000, max(total - 1, 0))
+    assert n > expected_min, f"suspiciously few MATCH results: {n}"
     set_meta(conn, "complete", 1)
     conn.commit()
     print(f"FTS5 build complete: {done:,} docs in "

--- a/scripts/build_fts_full.py
+++ b/scripts/build_fts_full.py
@@ -134,8 +134,13 @@ def main() -> None:
     n = conn.execute(
         "SELECT COUNT(*) FROM documents_fts"
         " WHERE documents_fts MATCH 'decreto'").fetchone()[0]
-    expected_min = min(10_000, max(total - 1, 0))
-    assert n > expected_min, f"suspiciously few MATCH results: {n}"
+    if total > 10_000:
+        assert n > 10_000, f"suspiciously few MATCH results: {n}"
+    else:
+        # Small test/incremental corpora are guarded by the exact count
+        # equality above; 'decreto' frequency is unrepresentative there.
+        print(f"small corpus ({total:,} docs): {n:,} 'decreto' matches "
+              "(MATCH threshold only applies above 10,000 docs)", flush=True)
     set_meta(conn, "complete", 1)
     conn.commit()
     print(f"FTS5 build complete: {done:,} docs in "

--- a/scripts/build_vec0_full.py
+++ b/scripts/build_vec0_full.py
@@ -13,13 +13,41 @@ Usage:
 
 import argparse
 import sqlite3
-import sys
 import time
 from pathlib import Path
 
 import sqlite_vec
 
 DDL = "CREATE VIRTUAL TABLE chunk_vec USING vec0(embedding bit[1024])"
+DELETIONS_DDL = """
+CREATE TABLE IF NOT EXISTS vector_deletions (
+    chunk_id INTEGER PRIMARY KEY,
+    recorded_at TEXT NOT NULL DEFAULT (datetime('now'))
+)
+"""
+
+
+def apply_vector_deletions(conn, vectors) -> int:
+    """Remove stale vec0 rows, then acknowledge the durable deletion queue."""
+    chunk_ids = [
+        int(row[0])
+        for row in vectors.execute(
+            "SELECT chunk_id FROM vector_deletions ORDER BY chunk_id"
+        )
+    ]
+    if not chunk_ids:
+        return 0
+    with conn:
+        conn.executemany(
+            "DELETE FROM chunk_vec WHERE rowid = ?",
+            [(chunk_id,) for chunk_id in chunk_ids],
+        )
+    with vectors:
+        vectors.executemany(
+            "DELETE FROM vector_deletions WHERE chunk_id = ?",
+            [(chunk_id,) for chunk_id in chunk_ids],
+        )
+    return len(chunk_ids)
 
 
 def main() -> None:
@@ -42,12 +70,18 @@ def main() -> None:
         conn.commit()
         print("created chunk_vec vec0(bit[1024])", flush=True)
 
+    vectors = sqlite3.connect(args.vectors_db)
+    vectors.execute(DELETIONS_DDL)
+    vectors.commit()
+    invalidated = apply_vector_deletions(conn, vectors)
+    if invalidated:
+        print(f"invalidated {invalidated:,} stale vec0 vectors", flush=True)
+
     lo = conn.execute("SELECT COALESCE(MAX(rowid), 0) FROM chunk_vec")
     lo = lo.fetchone()[0]
     if lo:
         print(f"resuming after rowid {lo:,}", flush=True)
 
-    vectors = sqlite3.connect(args.vectors_db)
     total = vectors.execute(
         "SELECT COUNT(*) FROM chunk_vectors WHERE chunk_id > ?",
         (lo,)).fetchone()[0]

--- a/scripts/build_vec0_full.py
+++ b/scripts/build_vec0_full.py
@@ -13,41 +13,13 @@ Usage:
 
 import argparse
 import sqlite3
+import sys
 import time
 from pathlib import Path
 
 import sqlite_vec
 
 DDL = "CREATE VIRTUAL TABLE chunk_vec USING vec0(embedding bit[1024])"
-DELETIONS_DDL = """
-CREATE TABLE IF NOT EXISTS vector_deletions (
-    chunk_id INTEGER PRIMARY KEY,
-    recorded_at TEXT NOT NULL DEFAULT (datetime('now'))
-)
-"""
-
-
-def apply_vector_deletions(conn, vectors) -> int:
-    """Remove stale vec0 rows, then acknowledge the durable deletion queue."""
-    chunk_ids = [
-        int(row[0])
-        for row in vectors.execute(
-            "SELECT chunk_id FROM vector_deletions ORDER BY chunk_id"
-        )
-    ]
-    if not chunk_ids:
-        return 0
-    with conn:
-        conn.executemany(
-            "DELETE FROM chunk_vec WHERE rowid = ?",
-            [(chunk_id,) for chunk_id in chunk_ids],
-        )
-    with vectors:
-        vectors.executemany(
-            "DELETE FROM vector_deletions WHERE chunk_id = ?",
-            [(chunk_id,) for chunk_id in chunk_ids],
-        )
-    return len(chunk_ids)
 
 
 def main() -> None:
@@ -70,18 +42,12 @@ def main() -> None:
         conn.commit()
         print("created chunk_vec vec0(bit[1024])", flush=True)
 
-    vectors = sqlite3.connect(args.vectors_db)
-    vectors.execute(DELETIONS_DDL)
-    vectors.commit()
-    invalidated = apply_vector_deletions(conn, vectors)
-    if invalidated:
-        print(f"invalidated {invalidated:,} stale vec0 vectors", flush=True)
-
     lo = conn.execute("SELECT COALESCE(MAX(rowid), 0) FROM chunk_vec")
     lo = lo.fetchone()[0]
     if lo:
         print(f"resuming after rowid {lo:,}", flush=True)
 
+    vectors = sqlite3.connect(args.vectors_db)
     total = vectors.execute(
         "SELECT COUNT(*) FROM chunk_vectors WHERE chunk_id > ?",
         (lo,)).fetchone()[0]

--- a/scripts/install_dof_launchd.sh
+++ b/scripts/install_dof_launchd.sh
@@ -19,8 +19,16 @@ if launchctl print "$domain/$label" >/dev/null 2>&1; then
     launchctl bootout "$domain/$label"
 fi
 
-install -m 0644 "$source_plist" "$target_plist"
-install -m 0755 "$source_runner" "$target_runner"
+# The checked-in plist and runner are templates: bake this account's paths in
+# at install time so the job works from any checkout, not just one developer's.
+sed -e "s|@DOF_RUNNER@|$target_runner|g" \
+    -e "s|@DOF_LOG_DIR@|$repo_dir/logs|g" \
+    "$source_plist" > "$target_plist"
+chmod 0644 "$target_plist"
+
+sed "s|^repo_dir=.*|repo_dir="$repo_dir"|" "$source_runner" > "$target_runner"
+chmod 0755 "$target_runner"
+
 launchctl bootstrap "$domain" "$target_plist"
 launchctl enable "$domain/$label"
 launchctl print "$domain/$label"

--- a/scripts/install_dof_launchd.sh
+++ b/scripts/install_dof_launchd.sh
@@ -23,6 +23,10 @@ render_plist() {
     # preserves spaces and XML-special characters in paths.
     install -m 0644 "$source_plist" "$destination"
     plutil -replace ProgramArguments.5 -string "$runner" "$destination"
+    # On macOS, replacing an array index with plutil appends the value while
+    # retaining the template element. Remove the now-stale placeholder so the
+    # runner is not invoked with @DOF_RUNNER@ as an extra argument.
+    plutil -remove ProgramArguments.6 "$destination"
     plutil -replace EnvironmentVariables.DOF_REPO_DIR \
         -string "$repository" "$destination"
     plutil -replace StandardOutPath \

--- a/scripts/install_dof_launchd.sh
+++ b/scripts/install_dof_launchd.sh
@@ -1,0 +1,26 @@
+#!/bin/zsh
+set -eu
+
+script_dir=${0:A:h}
+repo_dir=${script_dir:h}
+source_plist="$repo_dir/ops/launchd/com.jackbravo.dof-rag-daily.plist"
+target_dir="$HOME/Library/LaunchAgents"
+target_plist="$target_dir/com.jackbravo.dof-rag-daily.plist"
+support_dir="$HOME/Library/Application Support/DOF-RAG"
+source_runner="$repo_dir/scripts/run_dof_daily.sh"
+target_runner="$support_dir/run_dof_daily.sh"
+domain="gui/$(id -u)"
+label="com.jackbravo.dof-rag-daily"
+
+mkdir -p "$target_dir" "$support_dir" "$repo_dir/logs"
+plutil -lint "$source_plist"
+
+if launchctl print "$domain/$label" >/dev/null 2>&1; then
+    launchctl bootout "$domain/$label"
+fi
+
+install -m 0644 "$source_plist" "$target_plist"
+install -m 0755 "$source_runner" "$target_runner"
+launchctl bootstrap "$domain" "$target_plist"
+launchctl enable "$domain/$label"
+launchctl print "$domain/$label"

--- a/scripts/install_dof_launchd.sh
+++ b/scripts/install_dof_launchd.sh
@@ -12,22 +12,45 @@ target_runner="$support_dir/run_dof_daily.sh"
 domain="gui/$(id -u)"
 label="com.jackbravo.dof-rag-daily"
 
-mkdir -p "$target_dir" "$support_dir" "$repo_dir/logs"
 plutil -lint "$source_plist"
+
+render_plist() {
+    local destination=$1
+    local runner=$2
+    local repository=$3
+
+    # Let plutil write path values. Unlike sed string replacement, this
+    # preserves spaces and XML-special characters in paths.
+    install -m 0644 "$source_plist" "$destination"
+    plutil -replace ProgramArguments.5 -string "$runner" "$destination"
+    plutil -replace EnvironmentVariables.DOF_REPO_DIR \
+        -string "$repository" "$destination"
+    plutil -replace StandardOutPath \
+        -string "$repository/logs/dof-daily.log" "$destination"
+    plutil -replace StandardErrorPath \
+        -string "$repository/logs/dof-daily.error.log" "$destination"
+    plutil -lint "$destination"
+}
+
+if [[ ${1:-} == "--render-plist" ]]; then
+    if (( $# != 4 )); then
+        print -u2 "usage: $0 --render-plist OUTPUT RUNNER REPOSITORY"
+        exit 2
+    fi
+    render_plist "$2" "$3" "$4"
+    exit 0
+fi
+
+mkdir -p "$target_dir" "$support_dir" "$repo_dir/logs"
+temporary_plist="$target_plist.new"
+render_plist "$temporary_plist" "$target_runner" "$repo_dir"
+install -m 0755 "$source_runner" "$target_runner"
 
 if launchctl print "$domain/$label" >/dev/null 2>&1; then
     launchctl bootout "$domain/$label"
 fi
 
-# The checked-in plist and runner are templates: bake this account's paths in
-# at install time so the job works from any checkout, not just one developer's.
-sed -e "s|@DOF_RUNNER@|$target_runner|g" \
-    -e "s|@DOF_LOG_DIR@|$repo_dir/logs|g" \
-    "$source_plist" > "$target_plist"
-chmod 0644 "$target_plist"
-
-sed "s|^repo_dir=.*|repo_dir="$repo_dir"|" "$source_runner" > "$target_runner"
-chmod 0755 "$target_runner"
+mv "$temporary_plist" "$target_plist"
 
 launchctl bootstrap "$domain" "$target_plist"
 launchctl enable "$domain/$label"

--- a/scripts/install_dof_systemd.sh
+++ b/scripts/install_dof_systemd.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Install the DOF daily updater as a systemd --user timer.
+# Renders @DOF_REPO_DIR@ in the checked-in unit template with the actual
+# checkout path, so clones may live anywhere (including paths with spaces).
+set -eu
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_dir="$(dirname "$script_dir")"
+source_service="$repo_dir/ops/systemd/dof-rag-daily.service"
+source_timer="$repo_dir/ops/systemd/dof-rag-daily.timer"
+target_dir="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+target_service="$target_dir/dof-rag-daily.service"
+target_timer="$target_dir/dof-rag-daily.timer"
+
+mkdir -p "$target_dir" "$repo_dir/logs"
+
+# Escape sed's replacement metacharacters so spaces and & are preserved.
+escaped_repo_dir=$(printf '%s' "$repo_dir" | sed 's/[&|\]/\\&/g')
+
+temporary_service="$target_service.new"
+sed "s|@DOF_REPO_DIR@|$escaped_repo_dir|g" "$source_service" > "$temporary_service"
+install -m 0644 "$source_timer" "$target_timer"
+mv "$temporary_service" "$target_service"
+
+systemctl --user daemon-reload
+systemctl --user enable --now dof-rag-daily.timer
+systemctl --user list-timers dof-rag-daily.timer --no-pager
+
+if [ "$(loginctl show-user "$USER" --property=Linger --value 2>/dev/null)" != "yes" ]; then
+    echo "note: run 'loginctl enable-linger $USER' so the timer fires without an open session"
+fi

--- a/scripts/run_dof_daily.sh
+++ b/scripts/run_dof_daily.sh
@@ -1,10 +1,9 @@
 #!/bin/zsh
 set -eu
 
-# Self-locate the repository when run from a checkout (e.g. --dry-run tests).
-# install_dof_launchd.sh replaces this line with the absolute repository path
-# baked into the copy installed under ~/Library/Application Support/DOF-RAG.
-repo_dir=$(cd -- "${0:A:h}/.." && pwd)
+# Direct use self-locates from scripts/. The installed launchd plist sets the
+# exact checkout path, allowing the copied runner to live in Application Support.
+repo_dir="${DOF_REPO_DIR:-$(cd -- "${0:A:h}/.." && pwd)}"
 
 export PATH="${HOME}/.local/bin:${HOME}/.cargo/bin:/Applications/LibreOffice.app/Contents/MacOS:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 export PYTHONUNBUFFERED=1

--- a/scripts/run_dof_daily.sh
+++ b/scripts/run_dof_daily.sh
@@ -1,7 +1,10 @@
 #!/bin/zsh
 set -eu
 
-repo_dir="/Users/jackbravo/Documents/jackbravo/dof-rag"
+# Self-locate the repository when run from a checkout (e.g. --dry-run tests).
+# install_dof_launchd.sh replaces this line with the absolute repository path
+# baked into the copy installed under ~/Library/Application Support/DOF-RAG.
+repo_dir=$(cd -- "${0:A:h}/.." && pwd)
 
 export PATH="${HOME}/.local/bin:${HOME}/.cargo/bin:/Applications/LibreOffice.app/Contents/MacOS:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 export PYTHONUNBUFFERED=1

--- a/scripts/run_dof_daily.sh
+++ b/scripts/run_dof_daily.sh
@@ -1,0 +1,11 @@
+#!/bin/zsh
+set -eu
+
+repo_dir="/Users/jackbravo/Documents/jackbravo/dof-rag"
+
+export PATH="${HOME}/.local/bin:${HOME}/.cargo/bin:/Applications/LibreOffice.app/Contents/MacOS:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+export PYTHONUNBUFFERED=1
+export UV_CACHE_DIR="${TMPDIR:-/tmp}/dof-rag-uv-cache"
+
+cd "$repo_dir"
+exec uv run python -m scripts.update_dof_daily "$@"

--- a/scripts/run_dof_daily_linux.sh
+++ b/scripts/run_dof_daily_linux.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Linux counterpart to run_dof_daily.sh (launchd/zsh on macOS).
+# Self-locates the repo from scripts/. DOF_REPO_DIR overrides.
+set -eu
+
+repo_dir="${DOF_REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+export PATH="${HOME}/.local/bin:${HOME}/.cargo/bin:/usr/local/bin:/usr/bin:/bin"
+export PYTHONUNBUFFERED=1
+
+cd "$repo_dir"
+
+# Prefer the repo's pre-built venv (slim install); fall back to uv run, which
+# materializes the full locked environment on first use.
+if [[ -x "$repo_dir/.venv/bin/python" ]]; then
+    exec "$repo_dir/.venv/bin/python" -m scripts.update_dof_daily "$@"
+fi
+exec uv run python -m scripts.update_dof_daily "$@"

--- a/scripts/update_dof_daily.py
+++ b/scripts/update_dof_daily.py
@@ -25,6 +25,7 @@ from pathlib import Path
 import sqlite_vec
 
 from corpus_store.db import connect
+from corpus_store.ingest import REPAIRS_DDL
 from corpus_store.sampler import parse_metadata
 
 REPO = Path(__file__).resolve().parent.parent
@@ -107,6 +108,11 @@ def write_state(path: Path, completed: date) -> None:
     temporary.replace(path)
 
 
+def non_regressing_watermark(current: date | None, completed: date) -> date:
+    """A successful historical window must never move state backward."""
+    return max(current, completed) if current is not None else completed
+
+
 def build_manifest(corpus: Path, start: date, end: date, output: Path) -> int:
     """Write a small manifest containing Markdown files in the update window."""
     records: list[dict] = []
@@ -160,6 +166,29 @@ def run_step(label: str, command: list[str], *, check: bool = True) -> int:
     return result.returncode
 
 
+def conversion_command(
+    args: argparse.Namespace, start: date, end: date
+) -> list[str]:
+    """Build a converter command scoped to the active publication window."""
+    years = [str(year) for year in range(start.year, end.year + 1)]
+    return [
+        sys.executable,
+        "convert_doc_to_md.py",
+        "--years",
+        *years,
+        "--start-date",
+        start.isoformat(),
+        "--end-date",
+        end.isoformat(),
+        "--workers",
+        str(args.workers),
+        "--input-dir",
+        str(args.word_dir),
+        "--output-dir",
+        str(args.corpus),
+    ]
+
+
 def preflight(args: argparse.Namespace) -> None:
     required_files = [
         args.corpus_db,
@@ -186,18 +215,50 @@ def preflight(args: argparse.Namespace) -> None:
         )
 
 
+def ensure_repair_schema(args: argparse.Namespace) -> None:
+    """Migrate the three writable stores before taking the initial snapshot."""
+    with closing(connect(args.corpus_db)) as corpus:
+        corpus.executescript(REPAIRS_DDL)
+        corpus.commit()
+    with closing(sqlite3.connect(args.chunks_db)) as chunks:
+        chunks.execute(
+            "CREATE TABLE IF NOT EXISTS chunk_vector_invalidations ("
+            " chunk_id INTEGER PRIMARY KEY,"
+            " invalidated_at TEXT NOT NULL DEFAULT (datetime('now')))"
+        )
+        chunks.commit()
+    with closing(sqlite3.connect(args.vectors_db)) as vectors:
+        vectors.execute(
+            "CREATE TABLE IF NOT EXISTS vector_deletions ("
+            " chunk_id INTEGER PRIMARY KEY,"
+            " recorded_at TEXT NOT NULL DEFAULT (datetime('now')))"
+        )
+        vectors.commit()
+
+
 def snapshot(args: argparse.Namespace) -> dict[str, int | str | None]:
     with closing(connect(args.corpus_db)) as corpus:
         documents, latest, max_document = corpus.execute(
             "SELECT COUNT(*), MAX(publication_date), MAX(document_id) FROM documents"
         ).fetchone()
         fts = corpus.execute("SELECT COUNT(*) FROM documents_fts_docsize").fetchone()[0]
+        pending_repairs = corpus.execute(
+            "SELECT COUNT(*) FROM document_repairs"
+            " WHERE fts_pending = 1 OR chunks_pending = 1"
+        ).fetchone()[0]
     with closing(sqlite3.connect(args.chunks_db)) as chunks_db:
-        chunks, max_chunk_document = chunks_db.execute(
-            "SELECT COUNT(*), MAX(document_id) FROM chunks"
+        chunks, chunk_documents, max_chunk_document = chunks_db.execute(
+            "SELECT COUNT(*), COUNT(DISTINCT document_id), MAX(document_id)"
+            " FROM chunks"
         ).fetchone()
+        pending_chunk_invalidations = chunks_db.execute(
+            "SELECT COUNT(*) FROM chunk_vector_invalidations"
+        ).fetchone()[0]
     with closing(sqlite3.connect(args.vectors_db)) as vectors_db:
         vectors = vectors_db.execute("SELECT COUNT(*) FROM chunk_vectors").fetchone()[0]
+        pending_vector_deletions = vectors_db.execute(
+            "SELECT COUNT(*) FROM vector_deletions"
+        ).fetchone()[0]
     with closing(sqlite3.connect(args.vec0_db)) as vec0_db:
         vec0_db.enable_load_extension(True)
         sqlite_vec.load(vec0_db)
@@ -207,9 +268,13 @@ def snapshot(args: argparse.Namespace) -> dict[str, int | str | None]:
         "latest_publication": latest,
         "max_document_id": max_document,
         "fts_documents": fts,
+        "pending_repairs": pending_repairs,
         "chunks": chunks,
+        "chunk_documents": chunk_documents,
         "max_chunk_document_id": max_chunk_document,
+        "pending_chunk_invalidations": pending_chunk_invalidations,
         "vectors": vectors,
+        "pending_vector_deletions": pending_vector_deletions,
         "vec0_vectors": vec0,
     }
 
@@ -217,12 +282,20 @@ def snapshot(args: argparse.Namespace) -> dict[str, int | str | None]:
 def verify(state: dict[str, int | str | None], *, embeddings_complete: bool) -> None:
     if state["documents"] != state["fts_documents"]:
         raise RuntimeError(f"FTS coverage mismatch: {state}")
+    if state["pending_repairs"]:
+        raise RuntimeError(f"pending corpus repairs: {state}")
+    if state["documents"] != state["chunk_documents"]:
+        raise RuntimeError(f"chunk document coverage mismatch: {state}")
     if state["max_document_id"] != state["max_chunk_document_id"]:
         raise RuntimeError(f"chunk coverage mismatch: {state}")
     if embeddings_complete and state["chunks"] != state["vectors"]:
         raise RuntimeError(f"embedding coverage mismatch: {state}")
+    if embeddings_complete and state["pending_chunk_invalidations"]:
+        raise RuntimeError(f"pending chunk-vector invalidations: {state}")
     if state["vectors"] != state["vec0_vectors"]:
         raise RuntimeError(f"vec0 coverage mismatch: {state}")
+    if state["pending_vector_deletions"]:
+        raise RuntimeError(f"pending vec0 deletions: {state}")
 
 
 def acquire_lock(path: Path):
@@ -314,6 +387,7 @@ def main() -> int:
 
     try:
         preflight(args)
+        ensure_repair_schema(args)
         before = snapshot(args)
         LOG.info("before=%s", json.dumps(before, sort_keys=True))
 
@@ -334,21 +408,9 @@ def main() -> int:
             check=False,
         )
 
-        years = [str(year) for year in range(start.year, args.end_date.year + 1)]
         conversion_code = run_step(
             "convert",
-            [
-                sys.executable,
-                "convert_doc_to_md.py",
-                "--years",
-                *years,
-                "--workers",
-                str(args.workers),
-                "--input-dir",
-                str(args.word_dir),
-                "--output-dir",
-                str(args.corpus),
-            ],
+            conversion_command(args, start, args.end_date),
             check=False,
         )
 
@@ -438,8 +500,9 @@ def main() -> int:
                 + "; completed files were indexed and the next run will retry the rest"
             )
         if watermark is None or start <= watermark + timedelta(days=1):
-            write_state(args.state, args.end_date)
-            LOG.info("completed_through=%s", args.end_date)
+            completed = non_regressing_watermark(watermark, args.end_date)
+            write_state(args.state, completed)
+            LOG.info("completed_through=%s", completed)
         else:
             LOG.info(
                 "leaving completed_through=%s unchanged after non-contiguous test window",

--- a/scripts/update_dof_daily.py
+++ b/scripts/update_dof_daily.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python3
+"""Resumable daily update for the production DOF corpus and search stores.
+
+The default date window is self-healing: start with the day after the newest
+publication in the corpus database, or seven days ago if the database is
+already current.  Every pipeline stage is resumable and the process holds a
+non-blocking file lock so launchd cannot overlap runs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import json
+import logging
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+from contextlib import closing
+from datetime import date, timedelta
+from pathlib import Path
+
+import sqlite_vec
+
+from corpus_store.db import connect
+from corpus_store.sampler import parse_metadata
+
+REPO = Path(__file__).resolve().parent.parent
+WORKSPACE = REPO.parent
+DEFAULT_WORD_DIR = REPO / "dof_word"
+DEFAULT_CORPUS = WORKSPACE / "dof_md"
+DEFAULT_DB_DIR = REPO / "dof_db"
+DEFAULT_MANIFEST = REPO / "var" / "dof_incremental_manifest.jsonl"
+DEFAULT_LOCK = REPO / "var" / "dof_update.lock"
+DEFAULT_STATE = REPO / "var" / "dof_update_state.json"
+DEFAULT_GGUF = Path.home() / "dof-gguf" / "jina-v5-small-retrieval-F16.gguf"
+CORPUS_VERSION = "dof-full-v1"
+
+LOG = logging.getLogger("dof-update")
+
+
+def parse_iso_date(value: str) -> date:
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("expected YYYY-MM-DD") from exc
+
+
+def iter_dates(start: date, end: date):
+    current = start
+    while current <= end:
+        yield current
+        current += timedelta(days=1)
+
+
+def choose_start_date(last_publication: date, end: date, lookback_days: int) -> date:
+    """Choose a catch-up start while retaining a late-publication overlap."""
+    overlap_start = end - timedelta(days=lookback_days - 1)
+    catchup_start = last_publication + timedelta(days=1)
+    return min(overlap_start, catchup_start)
+
+
+def latest_publication(corpus_db: Path) -> date | None:
+    with closing(connect(corpus_db)) as conn:
+        value = conn.execute("SELECT MAX(publication_date) FROM documents").fetchone()[0]
+    return date.fromisoformat(value) if value else None
+
+
+def last_jsonl_record(path: Path) -> dict | None:
+    """Read the last non-empty JSONL record without loading a large manifest."""
+    if not path.is_file() or path.stat().st_size == 0:
+        return None
+    with path.open("rb") as stream:
+        position = stream.seek(0, os.SEEK_END)
+        data = b""
+        while position > 0:
+            size = min(4096, position)
+            position -= size
+            stream.seek(position)
+            data = stream.read(size) + data
+            lines = [line for line in data.splitlines() if line.strip()]
+            if len(lines) >= 2 or position == 0:
+                return json.loads(lines[-1]) if lines else None
+    return None
+
+
+def completed_through(state: Path, full_manifest: Path, corpus_db: Path) -> date | None:
+    """Return the contiguous update watermark, with migration fallbacks."""
+    if state.is_file():
+        payload = json.loads(state.read_text(encoding="utf-8"))
+        return date.fromisoformat(payload["completed_through"])
+    record = last_jsonl_record(full_manifest)
+    if record and record.get("publication_date"):
+        return date.fromisoformat(record["publication_date"])
+    return latest_publication(corpus_db)
+
+
+def write_state(path: Path, completed: date) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps({"completed_through": completed.isoformat()}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(path)
+
+
+def build_manifest(corpus: Path, start: date, end: date, output: Path) -> int:
+    """Write a small manifest containing Markdown files in the update window."""
+    records: list[dict] = []
+    for day in iter_dates(start, end):
+        day_dir = corpus / day.strftime("%Y/%m/%d%m%Y")
+        if not day_dir.is_dir():
+            continue
+        for path in sorted(day_dir.rglob("*.md")):
+            if path.name.endswith(".bak") or not path.is_file():
+                continue
+            relpath = str(path.relative_to(corpus))
+            records.append(
+                {
+                    "relpath": relpath,
+                    "size_bytes": path.stat().st_size,
+                    **parse_metadata(relpath),
+                }
+            )
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary = output.with_suffix(output.suffix + ".tmp")
+    with temporary.open("w", encoding="utf-8") as stream:
+        for record in records:
+            stream.write(json.dumps(record, ensure_ascii=False) + "\n")
+    temporary.replace(output)
+    return len(records)
+
+
+def command_environment() -> dict[str, str]:
+    env = os.environ.copy()
+    home = str(Path.home())
+    preferred = [
+        f"{home}/.local/bin",
+        f"{home}/.cargo/bin",
+        "/Applications/LibreOffice.app/Contents/MacOS",
+        "/opt/homebrew/bin",
+        "/usr/local/bin",
+        "/usr/bin",
+        "/bin",
+    ]
+    env["PATH"] = ":".join(preferred)
+    env["PYTHONUNBUFFERED"] = "1"
+    return env
+
+
+def run_step(label: str, command: list[str], *, check: bool = True) -> int:
+    LOG.info("stage=%s", label)
+    result = subprocess.run(command, cwd=REPO, env=command_environment(), check=False)
+    if check and result.returncode:
+        raise subprocess.CalledProcessError(result.returncode, command)
+    return result.returncode
+
+
+def preflight(args: argparse.Namespace) -> None:
+    required_files = [
+        args.corpus_db,
+        args.chunks_db,
+        args.vectors_db,
+        args.vec0_db,
+        args.gguf,
+    ]
+    missing = [str(path) for path in required_files if not path.is_file()]
+    if missing:
+        raise RuntimeError("missing required file(s): " + ", ".join(missing))
+    if not args.corpus.is_dir():
+        raise RuntimeError(f"canonical corpus directory not found: {args.corpus}")
+    for executable in ("soffice", "pandoc", "llama-server"):
+        if not shutil.which(executable, path=command_environment()["PATH"]):
+            raise RuntimeError(f"required executable not found: {executable}")
+    free_gib = shutil.disk_usage(args.corpus).free / 2**30
+    if free_gib < args.minimum_free_gb:
+        raise RuntimeError(
+            f"only {free_gib:.1f} GiB free; require {args.minimum_free_gb:.1f} GiB"
+        )
+
+
+def snapshot(args: argparse.Namespace) -> dict[str, int | str | None]:
+    with closing(connect(args.corpus_db)) as corpus:
+        documents, latest, max_document = corpus.execute(
+            "SELECT COUNT(*), MAX(publication_date), MAX(document_id) FROM documents"
+        ).fetchone()
+        fts = corpus.execute("SELECT COUNT(*) FROM documents_fts_docsize").fetchone()[0]
+    with closing(sqlite3.connect(args.chunks_db)) as chunks_db:
+        chunks, max_chunk_document = chunks_db.execute(
+            "SELECT COUNT(*), MAX(document_id) FROM chunks"
+        ).fetchone()
+    with closing(sqlite3.connect(args.vectors_db)) as vectors_db:
+        vectors = vectors_db.execute("SELECT COUNT(*) FROM chunk_vectors").fetchone()[0]
+    with closing(sqlite3.connect(args.vec0_db)) as vec0_db:
+        vec0_db.enable_load_extension(True)
+        sqlite_vec.load(vec0_db)
+        vec0 = vec0_db.execute("SELECT COUNT(*) FROM chunk_vec").fetchone()[0]
+    return {
+        "documents": documents,
+        "latest_publication": latest,
+        "max_document_id": max_document,
+        "fts_documents": fts,
+        "chunks": chunks,
+        "max_chunk_document_id": max_chunk_document,
+        "vectors": vectors,
+        "vec0_vectors": vec0,
+    }
+
+
+def verify(state: dict[str, int | str | None], *, embeddings_complete: bool) -> None:
+    if state["documents"] != state["fts_documents"]:
+        raise RuntimeError(f"FTS coverage mismatch: {state}")
+    if state["max_document_id"] != state["max_chunk_document_id"]:
+        raise RuntimeError(f"chunk coverage mismatch: {state}")
+    if embeddings_complete and state["chunks"] != state["vectors"]:
+        raise RuntimeError(f"embedding coverage mismatch: {state}")
+    if state["vectors"] != state["vec0_vectors"]:
+        raise RuntimeError(f"vec0 coverage mismatch: {state}")
+
+
+def acquire_lock(path: Path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    stream = path.open("a+")
+    try:
+        fcntl.flock(stream, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        stream.close()
+        return None
+    stream.seek(0)
+    stream.truncate()
+    stream.write(str(os.getpid()))
+    stream.flush()
+    return stream
+
+
+def make_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--start-date", type=parse_iso_date)
+    parser.add_argument("--end-date", type=parse_iso_date, default=date.today())
+    parser.add_argument("--lookback-days", type=int, default=7)
+    parser.add_argument("--workers", type=int, default=2)
+    parser.add_argument("--sleep-delay", type=float, default=1.0)
+    parser.add_argument("--skip-embeddings", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--minimum-free-gb", type=float, default=5.0)
+    parser.add_argument("--word-dir", type=Path, default=DEFAULT_WORD_DIR)
+    parser.add_argument("--corpus", type=Path, default=DEFAULT_CORPUS)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--lock", type=Path, default=DEFAULT_LOCK)
+    parser.add_argument("--state", type=Path, default=DEFAULT_STATE)
+    parser.add_argument("--db-dir", type=Path, default=DEFAULT_DB_DIR)
+    parser.add_argument("--gguf", type=Path, default=DEFAULT_GGUF)
+    return parser
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S%z",
+    )
+    args = make_parser().parse_args()
+    if args.lookback_days < 1:
+        raise SystemExit("--lookback-days must be at least 1")
+    if args.workers < 1:
+        raise SystemExit("--workers must be at least 1")
+
+    args.corpus_db = args.db_dir / "dof_corpus_l3.sqlite"
+    args.chunks_db = args.db_dir / "dof_chunks.sqlite"
+    args.vectors_db = args.db_dir / "dof_vectors_jina_binary.sqlite"
+    args.vec0_db = args.db_dir / "dof_vec0_jina_binary.sqlite"
+
+    last_publication = latest_publication(args.corpus_db)
+    watermark = completed_through(
+        args.state, args.db_dir / "manifest_full.jsonl", args.corpus_db
+    )
+    if args.start_date:
+        start = args.start_date
+    elif watermark:
+        start = choose_start_date(watermark, args.end_date, args.lookback_days)
+    else:
+        raise SystemExit("empty corpus database; provide --start-date explicitly")
+    if start > args.end_date:
+        raise SystemExit("start date must not be after end date")
+
+    LOG.info(
+        "window=%s..%s completed_through=%s database_latest=%s",
+        start,
+        args.end_date,
+        watermark,
+        last_publication,
+    )
+    if args.dry_run:
+        return 0
+
+    lock = acquire_lock(args.lock)
+    if lock is None:
+        LOG.info("another DOF update is already running; exiting")
+        return 0
+
+    try:
+        preflight(args)
+        before = snapshot(args)
+        LOG.info("before=%s", json.dumps(before, sort_keys=True))
+
+        download_code = run_step(
+            "download",
+            [
+                sys.executable,
+                "get_word_dof.py",
+                start.strftime("%d/%m/%Y"),
+                args.end_date.strftime("%d/%m/%Y"),
+                "--output-dir",
+                str(args.word_dir),
+                "--editions",
+                "both",
+                "--sleep-delay",
+                str(args.sleep_delay),
+            ],
+            check=False,
+        )
+
+        years = [str(year) for year in range(start.year, args.end_date.year + 1)]
+        conversion_code = run_step(
+            "convert",
+            [
+                sys.executable,
+                "convert_doc_to_md.py",
+                "--years",
+                *years,
+                "--workers",
+                str(args.workers),
+                "--input-dir",
+                str(args.word_dir),
+                "--output-dir",
+                str(args.corpus),
+            ],
+            check=False,
+        )
+
+        manifest_count = build_manifest(args.corpus, start, args.end_date, args.manifest)
+        LOG.info("manifest=%s documents=%d", args.manifest, manifest_count)
+        if manifest_count:
+            run_step(
+                "corpus",
+                [
+                    sys.executable,
+                    "-m",
+                    "corpus_store.ingest",
+                    "--corpus",
+                    str(args.corpus),
+                    "--manifest",
+                    str(args.manifest),
+                    "--db",
+                    str(args.corpus_db),
+                    "--level",
+                    "3",
+                    "--corpus-version",
+                    CORPUS_VERSION,
+                ],
+            )
+
+        run_step(
+            "fts",
+            [
+                sys.executable,
+                "scripts/build_fts_full.py",
+                "--corpus-db",
+                str(args.corpus_db),
+            ],
+        )
+        run_step(
+            "chunks",
+            [
+                sys.executable,
+                "-m",
+                "corpus_store.chunk_index",
+                "--corpus-db",
+                str(args.corpus_db),
+                "--chunks-db",
+                str(args.chunks_db),
+            ],
+        )
+        if not args.skip_embeddings:
+            run_step(
+                "embeddings",
+                [
+                    sys.executable,
+                    "-m",
+                    "corpus_store.embed",
+                    "--corpus-db",
+                    str(args.corpus_db),
+                    "--chunks-db",
+                    str(args.chunks_db),
+                    "--vectors-db",
+                    str(args.vectors_db),
+                    "--gguf",
+                    str(args.gguf),
+                ],
+            )
+        run_step(
+            "vec0",
+            [
+                sys.executable,
+                "scripts/build_vec0_full.py",
+                "--vectors-db",
+                str(args.vectors_db),
+                "--vec0-db",
+                str(args.vec0_db),
+            ],
+        )
+
+        after = snapshot(args)
+        verify(after, embeddings_complete=not args.skip_embeddings)
+        LOG.info("after=%s", json.dumps(after, sort_keys=True))
+        incomplete = []
+        if download_code:
+            incomplete.append("one or more downloads failed")
+        if conversion_code:
+            incomplete.append("one or more Word conversions failed")
+        if incomplete:
+            raise RuntimeError(
+                "; ".join(incomplete)
+                + "; completed files were indexed and the next run will retry the rest"
+            )
+        if watermark is None or start <= watermark + timedelta(days=1):
+            write_state(args.state, args.end_date)
+            LOG.info("completed_through=%s", args.end_date)
+        else:
+            LOG.info(
+                "leaving completed_through=%s unchanged after non-contiguous test window",
+                watermark,
+            )
+        return 0
+    finally:
+        lock.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/update_dof_daily.py
+++ b/scripts/update_dof_daily.py
@@ -166,14 +166,17 @@ def preflight(args: argparse.Namespace) -> None:
         args.chunks_db,
         args.vectors_db,
         args.vec0_db,
-        args.gguf,
     ]
+    executables = ["soffice", "pandoc"]
+    if not args.skip_embeddings:
+        required_files.append(args.gguf)
+        executables.append("llama-server")
     missing = [str(path) for path in required_files if not path.is_file()]
     if missing:
         raise RuntimeError("missing required file(s): " + ", ".join(missing))
     if not args.corpus.is_dir():
         raise RuntimeError(f"canonical corpus directory not found: {args.corpus}")
-    for executable in ("soffice", "pandoc", "llama-server"):
+    for executable in executables:
         if not shutil.which(executable, path=command_environment()["PATH"]):
             raise RuntimeError(f"required executable not found: {executable}")
     free_gib = shutil.disk_usage(args.corpus).free / 2**30
@@ -273,6 +276,13 @@ def main() -> int:
     args.chunks_db = args.db_dir / "dof_chunks.sqlite"
     args.vectors_db = args.db_dir / "dof_vectors_jina_binary.sqlite"
     args.vec0_db = args.db_dir / "dof_vec0_jina_binary.sqlite"
+
+    if not args.corpus_db.is_file():
+        raise SystemExit(
+            f"corpus database not found: {args.corpus_db}\n"
+            "run the full corpus build first (docs/full-corpus-build.md), "
+            "or pass --db-dir"
+        )
 
     last_publication = latest_publication(args.corpus_db)
     watermark = completed_through(

--- a/scripts/update_dof_daily.py
+++ b/scripts/update_dof_daily.py
@@ -14,18 +14,13 @@ import fcntl
 import json
 import logging
 import os
-import shutil
-import sqlite3
 import subprocess
 import sys
 from contextlib import closing
 from datetime import date, timedelta
 from pathlib import Path
 
-import sqlite_vec
-
 from corpus_store.db import connect
-from corpus_store.ingest import REPAIRS_DDL
 from corpus_store.sampler import parse_metadata
 
 REPO = Path(__file__).resolve().parent.parent
@@ -40,13 +35,6 @@ DEFAULT_GGUF = Path.home() / "dof-gguf" / "jina-v5-small-retrieval-F16.gguf"
 CORPUS_VERSION = "dof-full-v1"
 
 LOG = logging.getLogger("dof-update")
-
-
-def parse_iso_date(value: str) -> date:
-    try:
-        return date.fromisoformat(value)
-    except ValueError as exc:
-        raise argparse.ArgumentTypeError("expected YYYY-MM-DD") from exc
 
 
 def iter_dates(start: date, end: date):
@@ -74,7 +62,7 @@ def last_jsonl_record(path: Path) -> dict | None:
     if not path.is_file() or path.stat().st_size == 0:
         return None
     with path.open("rb") as stream:
-        position = stream.seek(0, os.SEEK_END)
+        position = stream.seek(0, 2)
         data = b""
         while position > 0:
             size = min(4096, position)
@@ -108,11 +96,6 @@ def write_state(path: Path, completed: date) -> None:
     temporary.replace(path)
 
 
-def non_regressing_watermark(current: date | None, completed: date) -> date:
-    """A successful historical window must never move state backward."""
-    return max(current, completed) if current is not None else completed
-
-
 def build_manifest(corpus: Path, start: date, end: date, output: Path) -> int:
     """Write a small manifest containing Markdown files in the update window."""
     records: list[dict] = []
@@ -141,38 +124,15 @@ def build_manifest(corpus: Path, start: date, end: date, output: Path) -> int:
     return len(records)
 
 
-def command_environment() -> dict[str, str]:
-    env = os.environ.copy()
-    home = str(Path.home())
-    preferred = [
-        f"{home}/.local/bin",
-        f"{home}/.cargo/bin",
-        "/Applications/LibreOffice.app/Contents/MacOS",
-        "/opt/homebrew/bin",
-        "/usr/local/bin",
-        "/usr/bin",
-        "/bin",
-    ]
-    env["PATH"] = ":".join(preferred)
-    env["PYTHONUNBUFFERED"] = "1"
-    return env
-
-
-def run_step(label: str, command: list[str], *, check: bool = True) -> int:
+def run_step(label: str, *command: str) -> None:
     LOG.info("stage=%s", label)
-    result = subprocess.run(command, cwd=REPO, env=command_environment(), check=False)
-    if check and result.returncode:
-        raise subprocess.CalledProcessError(result.returncode, command)
-    return result.returncode
+    subprocess.run([sys.executable, *command], cwd=REPO, check=True)
 
 
-def conversion_command(
-    args: argparse.Namespace, start: date, end: date
-) -> list[str]:
+def conversion_command(workers: int, start: date, end: date) -> list[str]:
     """Build a converter command scoped to the active publication window."""
     years = [str(year) for year in range(start.year, end.year + 1)]
     return [
-        sys.executable,
         "convert_doc_to_md.py",
         "--years",
         *years,
@@ -181,121 +141,12 @@ def conversion_command(
         "--end-date",
         end.isoformat(),
         "--workers",
-        str(args.workers),
+        str(workers),
         "--input-dir",
-        str(args.word_dir),
+        str(DEFAULT_WORD_DIR),
         "--output-dir",
-        str(args.corpus),
+        str(DEFAULT_CORPUS),
     ]
-
-
-def preflight(args: argparse.Namespace) -> None:
-    required_files = [
-        args.corpus_db,
-        args.chunks_db,
-        args.vectors_db,
-        args.vec0_db,
-    ]
-    executables = ["soffice", "pandoc"]
-    if not args.skip_embeddings:
-        required_files.append(args.gguf)
-        executables.append("llama-server")
-    missing = [str(path) for path in required_files if not path.is_file()]
-    if missing:
-        raise RuntimeError("missing required file(s): " + ", ".join(missing))
-    if not args.corpus.is_dir():
-        raise RuntimeError(f"canonical corpus directory not found: {args.corpus}")
-    for executable in executables:
-        if not shutil.which(executable, path=command_environment()["PATH"]):
-            raise RuntimeError(f"required executable not found: {executable}")
-    free_gib = shutil.disk_usage(args.corpus).free / 2**30
-    if free_gib < args.minimum_free_gb:
-        raise RuntimeError(
-            f"only {free_gib:.1f} GiB free; require {args.minimum_free_gb:.1f} GiB"
-        )
-
-
-def ensure_repair_schema(args: argparse.Namespace) -> None:
-    """Migrate the three writable stores before taking the initial snapshot."""
-    with closing(connect(args.corpus_db)) as corpus:
-        corpus.executescript(REPAIRS_DDL)
-        corpus.commit()
-    with closing(sqlite3.connect(args.chunks_db)) as chunks:
-        chunks.execute(
-            "CREATE TABLE IF NOT EXISTS chunk_vector_invalidations ("
-            " chunk_id INTEGER PRIMARY KEY,"
-            " invalidated_at TEXT NOT NULL DEFAULT (datetime('now')))"
-        )
-        chunks.commit()
-    with closing(sqlite3.connect(args.vectors_db)) as vectors:
-        vectors.execute(
-            "CREATE TABLE IF NOT EXISTS vector_deletions ("
-            " chunk_id INTEGER PRIMARY KEY,"
-            " recorded_at TEXT NOT NULL DEFAULT (datetime('now')))"
-        )
-        vectors.commit()
-
-
-def snapshot(args: argparse.Namespace) -> dict[str, int | str | None]:
-    with closing(connect(args.corpus_db)) as corpus:
-        documents, latest, max_document = corpus.execute(
-            "SELECT COUNT(*), MAX(publication_date), MAX(document_id) FROM documents"
-        ).fetchone()
-        fts = corpus.execute("SELECT COUNT(*) FROM documents_fts_docsize").fetchone()[0]
-        pending_repairs = corpus.execute(
-            "SELECT COUNT(*) FROM document_repairs"
-            " WHERE fts_pending = 1 OR chunks_pending = 1"
-        ).fetchone()[0]
-    with closing(sqlite3.connect(args.chunks_db)) as chunks_db:
-        chunks, chunk_documents, max_chunk_document = chunks_db.execute(
-            "SELECT COUNT(*), COUNT(DISTINCT document_id), MAX(document_id)"
-            " FROM chunks"
-        ).fetchone()
-        pending_chunk_invalidations = chunks_db.execute(
-            "SELECT COUNT(*) FROM chunk_vector_invalidations"
-        ).fetchone()[0]
-    with closing(sqlite3.connect(args.vectors_db)) as vectors_db:
-        vectors = vectors_db.execute("SELECT COUNT(*) FROM chunk_vectors").fetchone()[0]
-        pending_vector_deletions = vectors_db.execute(
-            "SELECT COUNT(*) FROM vector_deletions"
-        ).fetchone()[0]
-    with closing(sqlite3.connect(args.vec0_db)) as vec0_db:
-        vec0_db.enable_load_extension(True)
-        sqlite_vec.load(vec0_db)
-        vec0 = vec0_db.execute("SELECT COUNT(*) FROM chunk_vec").fetchone()[0]
-    return {
-        "documents": documents,
-        "latest_publication": latest,
-        "max_document_id": max_document,
-        "fts_documents": fts,
-        "pending_repairs": pending_repairs,
-        "chunks": chunks,
-        "chunk_documents": chunk_documents,
-        "max_chunk_document_id": max_chunk_document,
-        "pending_chunk_invalidations": pending_chunk_invalidations,
-        "vectors": vectors,
-        "pending_vector_deletions": pending_vector_deletions,
-        "vec0_vectors": vec0,
-    }
-
-
-def verify(state: dict[str, int | str | None], *, embeddings_complete: bool) -> None:
-    if state["documents"] != state["fts_documents"]:
-        raise RuntimeError(f"FTS coverage mismatch: {state}")
-    if state["pending_repairs"]:
-        raise RuntimeError(f"pending corpus repairs: {state}")
-    if state["documents"] != state["chunk_documents"]:
-        raise RuntimeError(f"chunk document coverage mismatch: {state}")
-    if state["max_document_id"] != state["max_chunk_document_id"]:
-        raise RuntimeError(f"chunk coverage mismatch: {state}")
-    if embeddings_complete and state["chunks"] != state["vectors"]:
-        raise RuntimeError(f"embedding coverage mismatch: {state}")
-    if embeddings_complete and state["pending_chunk_invalidations"]:
-        raise RuntimeError(f"pending chunk-vector invalidations: {state}")
-    if state["vectors"] != state["vec0_vectors"]:
-        raise RuntimeError(f"vec0 coverage mismatch: {state}")
-    if state["pending_vector_deletions"]:
-        raise RuntimeError(f"pending vec0 deletions: {state}")
 
 
 def acquire_lock(path: Path):
@@ -315,20 +166,12 @@ def acquire_lock(path: Path):
 
 def make_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--start-date", type=parse_iso_date)
-    parser.add_argument("--end-date", type=parse_iso_date, default=date.today())
+    parser.add_argument("--start-date", type=date.fromisoformat)
+    parser.add_argument("--end-date", type=date.fromisoformat, default=date.today())
     parser.add_argument("--lookback-days", type=int, default=7)
     parser.add_argument("--workers", type=int, default=2)
     parser.add_argument("--sleep-delay", type=float, default=1.0)
-    parser.add_argument("--skip-embeddings", action="store_true")
     parser.add_argument("--dry-run", action="store_true")
-    parser.add_argument("--minimum-free-gb", type=float, default=5.0)
-    parser.add_argument("--word-dir", type=Path, default=DEFAULT_WORD_DIR)
-    parser.add_argument("--corpus", type=Path, default=DEFAULT_CORPUS)
-    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
-    parser.add_argument("--lock", type=Path, default=DEFAULT_LOCK)
-    parser.add_argument("--state", type=Path, default=DEFAULT_STATE)
-    parser.add_argument("--db-dir", type=Path, default=DEFAULT_DB_DIR)
     parser.add_argument("--gguf", type=Path, default=DEFAULT_GGUF)
     return parser
 
@@ -345,21 +188,20 @@ def main() -> int:
     if args.workers < 1:
         raise SystemExit("--workers must be at least 1")
 
-    args.corpus_db = args.db_dir / "dof_corpus_l3.sqlite"
-    args.chunks_db = args.db_dir / "dof_chunks.sqlite"
-    args.vectors_db = args.db_dir / "dof_vectors_jina_binary.sqlite"
-    args.vec0_db = args.db_dir / "dof_vec0_jina_binary.sqlite"
+    corpus_db = DEFAULT_DB_DIR / "dof_corpus_l3.sqlite"
+    chunks_db = DEFAULT_DB_DIR / "dof_chunks.sqlite"
+    vectors_db = DEFAULT_DB_DIR / "dof_vectors_jina_binary.sqlite"
+    vec0_db = DEFAULT_DB_DIR / "dof_vec0_jina_binary.sqlite"
 
-    if not args.corpus_db.is_file():
+    if not corpus_db.is_file():
         raise SystemExit(
-            f"corpus database not found: {args.corpus_db}\n"
-            "run the full corpus build first (docs/full-corpus-build.md), "
-            "or pass --db-dir"
+            f"corpus database not found: {corpus_db}\n"
+            "run the full corpus build first (docs/full-corpus-build.md)"
         )
 
-    last_publication = latest_publication(args.corpus_db)
+    last_publication = latest_publication(corpus_db)
     watermark = completed_through(
-        args.state, args.db_dir / "manifest_full.jsonl", args.corpus_db
+        DEFAULT_STATE, DEFAULT_DB_DIR / "manifest_full.jsonl", corpus_db
     )
     if args.start_date:
         start = args.start_date
@@ -380,128 +222,88 @@ def main() -> int:
     if args.dry_run:
         return 0
 
-    lock = acquire_lock(args.lock)
+    lock = acquire_lock(DEFAULT_LOCK)
     if lock is None:
         LOG.info("another DOF update is already running; exiting")
         return 0
 
     try:
-        preflight(args)
-        ensure_repair_schema(args)
-        before = snapshot(args)
-        LOG.info("before=%s", json.dumps(before, sort_keys=True))
-
-        download_code = run_step(
+        run_step(
             "download",
-            [
-                sys.executable,
-                "get_word_dof.py",
-                start.strftime("%d/%m/%Y"),
-                args.end_date.strftime("%d/%m/%Y"),
-                "--output-dir",
-                str(args.word_dir),
-                "--editions",
-                "both",
-                "--sleep-delay",
-                str(args.sleep_delay),
-            ],
-            check=False,
+            "get_word_dof.py",
+            start.strftime("%d/%m/%Y"),
+            args.end_date.strftime("%d/%m/%Y"),
+            "--output-dir",
+            str(DEFAULT_WORD_DIR),
+            "--editions",
+            "both",
+            "--sleep-delay",
+            str(args.sleep_delay),
         )
 
-        conversion_code = run_step(
-            "convert",
-            conversion_command(args, start, args.end_date),
-            check=False,
-        )
+        run_step("convert", *conversion_command(args.workers, start, args.end_date))
 
-        manifest_count = build_manifest(args.corpus, start, args.end_date, args.manifest)
-        LOG.info("manifest=%s documents=%d", args.manifest, manifest_count)
+        manifest_count = build_manifest(
+            DEFAULT_CORPUS, start, args.end_date, DEFAULT_MANIFEST
+        )
+        LOG.info("manifest=%s documents=%d", DEFAULT_MANIFEST, manifest_count)
         if manifest_count:
             run_step(
                 "corpus",
-                [
-                    sys.executable,
-                    "-m",
-                    "corpus_store.ingest",
-                    "--corpus",
-                    str(args.corpus),
-                    "--manifest",
-                    str(args.manifest),
-                    "--db",
-                    str(args.corpus_db),
-                    "--level",
-                    "3",
-                    "--corpus-version",
-                    CORPUS_VERSION,
-                ],
+                "-m",
+                "corpus_store.ingest",
+                "--corpus",
+                str(DEFAULT_CORPUS),
+                "--manifest",
+                str(DEFAULT_MANIFEST),
+                "--db",
+                str(corpus_db),
+                "--level",
+                "3",
+                "--corpus-version",
+                CORPUS_VERSION,
             )
 
         run_step(
             "fts",
-            [
-                sys.executable,
-                "scripts/build_fts_full.py",
-                "--corpus-db",
-                str(args.corpus_db),
-            ],
+            "scripts/build_fts_full.py",
+            "--corpus-db",
+            str(corpus_db),
         )
         run_step(
             "chunks",
-            [
-                sys.executable,
-                "-m",
-                "corpus_store.chunk_index",
-                "--corpus-db",
-                str(args.corpus_db),
-                "--chunks-db",
-                str(args.chunks_db),
-            ],
+            "-m",
+            "corpus_store.chunk_index",
+            "--corpus-db",
+            str(corpus_db),
+            "--chunks-db",
+            str(chunks_db),
         )
-        if not args.skip_embeddings:
-            run_step(
-                "embeddings",
-                [
-                    sys.executable,
-                    "-m",
-                    "corpus_store.embed",
-                    "--corpus-db",
-                    str(args.corpus_db),
-                    "--chunks-db",
-                    str(args.chunks_db),
-                    "--vectors-db",
-                    str(args.vectors_db),
-                    "--gguf",
-                    str(args.gguf),
-                ],
-            )
+        run_step(
+            "embeddings",
+            "-m",
+            "corpus_store.embed",
+            "--corpus-db",
+            str(corpus_db),
+            "--chunks-db",
+            str(chunks_db),
+            "--vectors-db",
+            str(vectors_db),
+            "--gguf",
+            str(args.gguf),
+        )
         run_step(
             "vec0",
-            [
-                sys.executable,
-                "scripts/build_vec0_full.py",
-                "--vectors-db",
-                str(args.vectors_db),
-                "--vec0-db",
-                str(args.vec0_db),
-            ],
+            "scripts/build_vec0_full.py",
+            "--vectors-db",
+            str(vectors_db),
+            "--vec0-db",
+            str(vec0_db),
         )
 
-        after = snapshot(args)
-        verify(after, embeddings_complete=not args.skip_embeddings)
-        LOG.info("after=%s", json.dumps(after, sort_keys=True))
-        incomplete = []
-        if download_code:
-            incomplete.append("one or more downloads failed")
-        if conversion_code:
-            incomplete.append("one or more Word conversions failed")
-        if incomplete:
-            raise RuntimeError(
-                "; ".join(incomplete)
-                + "; completed files were indexed and the next run will retry the rest"
-            )
         if watermark is None or start <= watermark + timedelta(days=1):
-            completed = non_regressing_watermark(watermark, args.end_date)
-            write_state(args.state, completed)
+            completed = max(watermark, args.end_date) if watermark else args.end_date
+            write_state(DEFAULT_STATE, completed)
             LOG.info("completed_through=%s", completed)
         else:
             LOG.info(

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -1,0 +1,84 @@
+"""Regression tests for rag_poc.chunker preamble preservation.
+
+Before the fix, _split_by_heading silently dropped the preamble (content
+before the first heading). For H2_COMPOUND documents whose only H2s are the
+trailing rubric signatures, that discarded the entire document body and the
+document ended up with zero chunks (breaking the daily updater's verify()).
+"""
+
+import unittest
+
+from rag_poc.chunker import split_text
+
+# Plain paragraphs only: no H2/H3/bold lines, no table rows, so padding does
+# not change how classify() sees the document.
+PARAGRAPH = (
+    "En observancia a la Constitución Política de los Estados Unidos "
+    "Mexicanos en su artículo 134, y de conformidad con la Ley de "
+    "Adquisiciones, Arrendamientos y Servicios del Sector Público, se "
+    "convoca a los interesados en participar en la licitación pública.\n\n"
+)
+
+
+def _pad(text: str, min_bytes: int = 7000) -> str:
+    while len(text.encode("utf-8")) < min_bytes:
+        text += PARAGRAPH
+    return text
+
+
+def _split(text: str):
+    return split_text(text, len(text.encode("utf-8")), "test-doc")
+
+
+class H2CompoundPreambleTest(unittest.TestCase):
+    def test_trailing_rubric_only_h2_keeps_body(self):
+        """Docs whose only H2s are trailing rubrics must not lose the body."""
+        body = _pad(
+            "SECRETARIA DE ENERGIA\n\n### CONVOCATORIA 006\n\n" + PARAGRAPH
+        )
+        text = body + "\n\n##  RUBRICA.\n\n\n## (R.- 123456)\n"
+        chunks = _split(text)
+        self.assertTrue(chunks, "expected chunks, got none")
+        joined = "\n".join(c.text for c in chunks)
+        self.assertIn("SECRETARIA DE ENERGIA", joined)
+        self.assertIn("artículo 134", joined)
+
+    def test_preamble_has_no_invented_heading_prefix(self):
+        body = _pad("# PODER EJECUTIVO\n\n# SECRETARIA DE GOBERNACION\n\n")
+        text = body + "## PRIMER DECRETO\n\n" + _pad(PARAGRAPH) + "\n## SEGUNDO DECRETO\n\nContenido.\n"
+        chunks = _split(text)
+        self.assertTrue(chunks)
+        self.assertTrue(chunks[0].text.startswith("# PODER EJECUTIVO"))
+        for chunk in chunks:
+            self.assertFalse(chunk.text.startswith("## \n"), repr(chunk.text[:40]))
+            self.assertNotIn("### \n\n", chunk.text)
+
+    def test_h3_preamble_inside_h2_section_is_kept(self):
+        section_body = _pad("Texto introductorio de la sección.\n\n" + PARAGRAPH)
+        text = (
+            "## PRIMER DECRETO\n\n"
+            + section_body
+            + "\n### Artículo primero\n\n"
+            + _pad(PARAGRAPH)
+            + "\n## SEGUNDO DECRETO\n\nContenido.\n"
+        )
+        chunks = _split(text)
+        self.assertTrue(chunks)
+        joined = "\n".join(c.text for c in chunks)
+        self.assertIn("Texto introductorio de la sección", joined)
+
+    def test_regular_compound_doc_still_splits_by_h2(self):
+        text = (
+            "## PRIMER DECRETO\n\n"
+            + _pad(PARAGRAPH)
+            + "\n## SEGUNDO DECRETO\n\n"
+            + _pad("Contenido del segundo decreto.\n\n" + PARAGRAPH)
+        )
+        chunks = _split(text)
+        self.assertTrue(chunks)
+        self.assertTrue(any(c.text.startswith("## PRIMER DECRETO") for c in chunks))
+        self.assertTrue(any(c.text.startswith("## SEGUNDO DECRETO") for c in chunks))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dof_update.py
+++ b/tests/test_dof_update.py
@@ -344,5 +344,72 @@ class DailyUpdateTests(unittest.TestCase):
             )
 
 
+class PermanentlyMissingDownloadTest(unittest.TestCase):
+    def _missing_response(self) -> mock.Mock:
+        response = mock.Mock()
+        response.content = (
+            b"<!DOCTYPE html><html><title>El archivo no existe</title>"
+            + b"x" * 1024
+        )
+        response.url = (
+            "https://sidof.segob.gob.mx/notificacion/page/204/"
+            "El%20archivo%20no%20existe"
+        )
+        response.headers = {"Content-Type": "text/html; charset=UTF-8"}
+        response.text = "<html><body>El archivo no existe</body></html>"
+        response.raise_for_status = lambda: None
+        return response
+
+    def test_permanent_missing_creates_tombstone_without_error(self):
+        session = mock.Mock()
+        session.get.return_value = self._missing_response()
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            target = root / "001_AVISO_20260825_MAT_5789248.doc"
+            old_errors = get_word_dof.ERROR_COUNT
+            try:
+                get_word_dof.ERROR_COUNT = 0
+                ok = get_word_dof._download_file(
+                    session,
+                    "https://sidof.segob.gob.mx/notas/getDoc/5789248",
+                    target,
+                )
+                self.assertFalse(ok)
+                self.assertEqual(get_word_dof.ERROR_COUNT, 0)
+            finally:
+                get_word_dof.ERROR_COUNT = old_errors
+            self.assertFalse(target.exists())
+            marker = root / "001_AVISO_20260825_MAT_5789248.doc.missing"
+            self.assertTrue(marker.exists())
+            self.assertTrue(get_word_dof.has_missing_marker(root, "5789248"))
+            self.assertFalse(get_word_dof.has_missing_marker(root, "99999"))
+
+    def test_invalid_payload_without_missing_page_still_errors(self):
+        session = mock.Mock()
+        response = mock.Mock()
+        response.content = b"<html><title>500</title></html>" + b"x" * 1024
+        response.url = "https://sidof.segob.gob.mx/notas/getDoc/5789248"
+        response.headers = {"Content-Type": "text/html"}
+        response.text = "<html><title>500</title></html>"
+        response.raise_for_status = lambda: None
+        session.get.return_value = response
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            target = root / "001_AVISO_20260825_MAT_5789248.doc"
+            old_errors = get_word_dof.ERROR_COUNT
+            try:
+                get_word_dof.ERROR_COUNT = 0
+                ok = get_word_dof._download_file(
+                    session,
+                    "https://sidof.segob.gob.mx/notas/getDoc/5789248",
+                    target,
+                )
+                self.assertFalse(ok)
+                self.assertEqual(get_word_dof.ERROR_COUNT, 1)
+            finally:
+                get_word_dof.ERROR_COUNT = old_errors
+            self.assertFalse(get_word_dof.has_missing_marker(root, "5789248"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_dof_update.py
+++ b/tests/test_dof_update.py
@@ -1,0 +1,129 @@
+import hashlib
+import sqlite3
+import tempfile
+import unittest
+from datetime import date
+from pathlib import Path
+
+from corpus_store.ingest import SCHEMA, ingest_batch
+from get_word_dof import has_valid_download, is_valid_word_payload
+from scripts.update_dof_daily import (
+    build_manifest,
+    choose_start_date,
+    completed_through,
+    last_jsonl_record,
+)
+
+
+class DailyUpdateTests(unittest.TestCase):
+    def test_catches_up_from_day_after_database(self):
+        self.assertEqual(
+            choose_start_date(date(2026, 4, 24), date(2026, 8, 27), 7),
+            date(2026, 4, 25),
+        )
+
+    def test_uses_overlap_when_database_is_current(self):
+        self.assertEqual(
+            choose_start_date(date(2026, 8, 27), date(2026, 8, 27), 7),
+            date(2026, 8, 21),
+        )
+
+    def test_manifest_contains_only_requested_dates(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            included = root / "2026/08/26082026/MAT/001_DOF_20260826_MAT_1.md"
+            excluded = root / "2026/08/20082026/MAT/001_DOF_20260820_MAT_2.md"
+            included.parent.mkdir(parents=True)
+            excluded.parent.mkdir(parents=True)
+            included.write_text("included", encoding="utf-8")
+            excluded.write_text("excluded", encoding="utf-8")
+            manifest = root / "manifest.jsonl"
+
+            count = build_manifest(
+                root, date(2026, 8, 24), date(2026, 8, 27), manifest
+            )
+
+            self.assertEqual(count, 1)
+            self.assertIn("001_DOF_20260826_MAT_1.md", manifest.read_text())
+            self.assertNotIn("001_DOF_20260820_MAT_2.md", manifest.read_text())
+
+    def test_existing_note_id_survives_page_reordering(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            existing = directory / "005_DOF_20260826_MAT_12345.doc"
+            existing.write_bytes(b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1" + b"x" * 1016)
+            self.assertTrue(has_valid_download(directory, "12345"))
+            self.assertFalse(has_valid_download(directory, "99999"))
+
+    def test_html_error_page_is_not_a_word_download(self):
+        payload = b"<!DOCTYPE html><title>500 error</title>" + b"x" * 1024
+        self.assertFalse(is_valid_word_payload(payload))
+
+    def test_ingest_repairs_oversized_row_missing_segments(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            corpus = Path(temporary)
+            relpath = "2026/08/17082026/MAT/006_DOF_test.md"
+            source = corpus / relpath
+            source.parent.mkdir(parents=True)
+            source.write_text("á" * 40, encoding="utf-8")
+            raw = source.read_bytes()
+            conn = sqlite3.connect(":memory:")
+            conn.executescript(SCHEMA)
+            conn.execute(
+                "INSERT INTO documents(path, year, publication_date, section, markdown,"
+                " byte_length, sha256, corpus_version) VALUES (?, 2026, '2026-08-17',"
+                " 'MAT', '', ?, ?, 'dof-full-v1')",
+                (relpath, len(raw), hashlib.sha256(raw).digest()),
+            )
+            conn.execute(
+                "CREATE TRIGGER preserve_empty_markdown BEFORE UPDATE OF markdown"
+                " ON documents BEGIN SELECT RAISE(ABORT, 'markdown was rewritten'); END"
+            )
+            doc_id = conn.execute("SELECT document_id FROM documents").fetchone()[0]
+
+            inserted, _ = ingest_batch(
+                conn,
+                corpus,
+                [{
+                    "relpath": relpath,
+                    "year": 2026,
+                    "publication_date": "2026-08-17",
+                    "section": "MAT",
+                }],
+                segment_threshold=16,
+                corpus_version="dof-full-v1",
+            )
+
+            self.assertEqual(inserted, 1)
+            self.assertEqual(
+                conn.execute(
+                    "SELECT COUNT(*) FROM document_segments WHERE document_id = ?",
+                    (doc_id,),
+                ).fetchone()[0],
+                3,
+            )
+            self.assertEqual(
+                conn.execute("SELECT document_id FROM documents").fetchone()[0], doc_id
+            )
+            conn.close()
+
+    def test_full_manifest_is_initial_contiguous_watermark(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manifest = root / "manifest.jsonl"
+            manifest.write_text(
+                '{"publication_date": "2026-04-23"}\n'
+                '{"publication_date": "2026-04-24"}\n',
+                encoding="utf-8",
+            )
+            self.assertEqual(
+                completed_through(root / "missing-state.json", manifest, root / "db"),
+                date(2026, 4, 24),
+            )
+            self.assertEqual(
+                last_jsonl_record(manifest), {"publication_date": "2026-04-24"}
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dof_update.py
+++ b/tests/test_dof_update.py
@@ -81,13 +81,29 @@ class DailyUpdateTests(unittest.TestCase):
             is_valid_word_payload(b'\xef\xbb\xbf{"error":true}' + b"x" * 1024)
         )
 
-    def test_sidof_listing_requires_requested_edition_tab(self):
+    def test_sidof_listing_accepts_dated_shell_with_either_notices_tab(self):
         html = (
             "<html><head><title>Diario Oficial de la Federación</title></head>"
             "<body><div id='resp-tab3'>26-08-2026</div></body></html>"
         )
-        self.assertTrue(is_valid_sidof_listing(html, "26", "08", "2026", "MAT"))
-        self.assertFalse(is_valid_sidof_listing(html, "26", "08", "2026", "VES"))
+        self.assertTrue(is_valid_sidof_listing(html, "26", "08", "2026"))
+
+    def test_sidof_listing_rejects_pages_without_the_publication_shell(self):
+        no_tabs = (
+            "<html><head><title>Diario Oficial de la Federación</title></head>"
+            "<body>26-08-2026</body></html>"
+        )
+        wrong_title = (
+            "<html><head><title>Error</title></head>"
+            "<body><div id='resp-tab3'>26-08-2026</div></body></html>"
+        )
+        wrong_date = (
+            "<html><head><title>Diario Oficial de la Federación</title></head>"
+            "<body><div id='resp-tab3'>25-08-2026</div></body></html>"
+        )
+        self.assertFalse(is_valid_sidof_listing(no_tabs, "26", "08", "2026"))
+        self.assertFalse(is_valid_sidof_listing(wrong_title, "26", "08", "2026"))
+        self.assertFalse(is_valid_sidof_listing(wrong_date, "26", "08", "2026"))
 
     def test_conversion_scan_is_limited_to_active_date_window(self):
         with tempfile.TemporaryDirectory() as temporary:

--- a/tests/test_dof_update.py
+++ b/tests/test_dof_update.py
@@ -590,6 +590,118 @@ class DailyUpdateTests(unittest.TestCase):
             )
             corpus.close()
 
+    def test_new_chunks_are_flushed_before_repair_checkpoint_advances(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            corpus_db = root / "corpus.sqlite"
+            chunks_db = root / "chunks.sqlite"
+            corpus = sqlite3.connect(corpus_db)
+            corpus.executescript(SCHEMA)
+            corpus.execute(
+                "INSERT INTO corpus_meta(key, value) VALUES ('corpus_version', 'v1')"
+            )
+            for path, text in (
+                ("old.md", "old document"),
+                ("new.md", "new document"),
+                ("repair.md", "repaired document"),
+            ):
+                raw = text.encode()
+                corpus.execute(
+                    "INSERT INTO documents(path, year, publication_date, section,"
+                    " markdown, byte_length, sha256, corpus_version)"
+                    " VALUES (?, 2026, '2026-08-26', 'MAT', ?, ?, ?, 'v1')",
+                    (path, text, len(raw), hashlib.sha256(raw).digest()),
+                )
+            corpus.execute(
+                "INSERT INTO document_repairs"
+                " (document_id, repaired_sha256, previous_markdown,"
+                " fts_pending, chunks_pending) VALUES (3, ?, 'stale', 0, 1)",
+                (hashlib.sha256(b"repaired document").digest(),),
+            )
+            corpus.commit()
+            corpus.close()
+
+            chunks = sqlite3.connect(chunks_db)
+            chunks.executescript(chunk_index.SCHEMA)
+            chunks.execute(
+                "INSERT INTO chunks (chunk_id, document_id, path, chunk_index, pattern,"
+                " start_offset, end_offset, spans_json, token_count, heading_path,"
+                " chunk_hash, chunker_version, corpus_version) VALUES"
+                " (1, 1, 'old.md', 0, 'plain_text', 0, 3, '{\"l\":\"old\"}',"
+                " 1, '[]', ?, ?, 'v1')",
+                (b"0" * 32, chunk_index.CHUNKER_VERSION),
+            )
+            chunks.commit()
+            chunks.close()
+
+            class ChunkConnectionProxy:
+                def __init__(self, connection):
+                    self.connection = connection
+                    self.chunk_inserts = 0
+
+                def __enter__(self):
+                    self.connection.__enter__()
+                    return self
+
+                def __exit__(self, *args):
+                    return self.connection.__exit__(*args)
+
+                def executemany(self, sql, parameters):
+                    rows = list(parameters)
+                    if sql.lstrip().startswith("INSERT INTO chunks"):
+                        self.chunk_inserts += 1
+                        # Before the fix, document 2 is the final flush after
+                        # repair document 3 has already advanced the checkpoint.
+                        if rows and rows[0][0] == 2 and self.chunk_inserts > 1:
+                            raise RuntimeError("simulated crash before final flush")
+                    return self.connection.executemany(sql, rows)
+
+                def __getattr__(self, name):
+                    return getattr(self.connection, name)
+
+            real_connect = sqlite3.connect
+            proxy = None
+
+            def connect_for_test(path, *args, **kwargs):
+                nonlocal proxy
+                connection = real_connect(path, *args, **kwargs)
+                if str(path) == str(chunks_db):
+                    proxy = ChunkConnectionProxy(connection)
+                    return proxy
+                return connection
+
+            def generated(text, *_):
+                return [
+                    SimpleNamespace(
+                        text=text,
+                        pattern=DocPattern.PLAIN_TEXT,
+                        chunk_index=0,
+                        heading_path=[],
+                    )
+                ]
+            argv = [
+                "chunk_index",
+                "--corpus-db", str(corpus_db),
+                "--chunks-db", str(chunks_db),
+            ]
+            with (
+                mock.patch.object(sys, "argv", argv),
+                mock.patch.object(chunk_index.sqlite3, "connect", side_effect=connect_for_test),
+                mock.patch.object(chunk_index, "split_text", side_effect=generated),
+                mock.patch.object(chunk_index, "_count_tokens", return_value=1),
+            ):
+                chunk_index.main()
+
+            self.assertEqual(proxy.chunk_inserts, 2)
+            check = sqlite3.connect(chunks_db)
+            self.assertEqual(
+                check.execute(
+                    "SELECT document_id FROM chunks ORDER BY document_id"
+                ).fetchall(),
+                [(1,), (2,), (3,)],
+            )
+            check.close()
+
     def test_repaired_document_replaces_stale_fts_tokens(self):
         conn = sqlite3.connect(":memory:")
         conn.executescript(SCHEMA)

--- a/tests/test_dof_update.py
+++ b/tests/test_dof_update.py
@@ -1,4 +1,5 @@
 import plistlib
+import shutil
 import sqlite3
 import subprocess
 import sys
@@ -294,6 +295,7 @@ class DailyUpdateTests(unittest.TestCase):
         with mock.patch.object(sys, "argv", argv):
             build_fts_full.main()
 
+    @unittest.skipUnless(shutil.which("zsh"), "launchd installer requires zsh (macOS)")
     def test_launchd_renderer_preserves_special_paths(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)

--- a/tests/test_dof_update.py
+++ b/tests/test_dof_update.py
@@ -23,7 +23,11 @@ from corpus_store.embed import (
     apply_chunk_vector_invalidations,
 )
 from corpus_store.ingest import SCHEMA, ingest_batch
-from get_word_dof import has_valid_download, is_valid_word_payload
+from get_word_dof import (
+    has_valid_download,
+    is_valid_sidof_listing,
+    is_valid_word_payload,
+)
 from rag_poc.chunker import DocPattern
 from scripts.build_fts_full import FTS_DDL, repair_fts_documents
 from scripts.build_vec0_full import (
@@ -86,6 +90,27 @@ class DailyUpdateTests(unittest.TestCase):
     def test_html_error_page_is_not_a_word_download(self):
         payload = b"<!DOCTYPE html><title>500 error</title>" + b"x" * 1024
         self.assertFalse(is_valid_word_payload(payload))
+
+    def test_only_known_word_signatures_are_valid(self):
+        self.assertTrue(
+            is_valid_word_payload(b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1" + b"x" * 1024)
+        )
+        self.assertTrue(is_valid_word_payload(b"PK\x03\x04" + b"x" * 1024))
+        self.assertFalse(
+            is_valid_word_payload(b"\xef\xbb\xbf{\"error\":true}" + b"x" * 1024)
+        )
+
+    def test_sidof_listing_requires_requested_edition_tab(self):
+        html = (
+            "<html><head><title>Diario Oficial de la Federación</title></head>"
+            "<body><div id='resp-tab3'>26-08-2026</div></body></html>"
+        )
+        self.assertTrue(
+            is_valid_sidof_listing(html, "26", "08", "2026", "MAT")
+        )
+        self.assertFalse(
+            is_valid_sidof_listing(html, "26", "08", "2026", "VES")
+        )
 
     def test_conversion_scan_is_limited_to_active_date_window(self):
         with tempfile.TemporaryDirectory() as temporary:
@@ -341,10 +366,24 @@ class DailyUpdateTests(unittest.TestCase):
 
             self.assertEqual(result["status"], "invalid_download")
             self.assertFalse(doc.exists())
-            self.assertTrue((root / "001_DOF_20260826_MAT_12345.doc.invalid").exists())
+            self.assertTrue(
+                (root / "001_DOF_20260826_MAT_12345.doc.invalid").exists()
+            )
             # The quarantined file is invisible to the downloader's resume
             # glob, so the notice is re-fetched on the next download pass.
             self.assertFalse(has_valid_download(root, "12345"))
+
+    def test_non_word_error_body_is_quarantined_for_redownload(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            doc = root / "001_DOF_20260826_MAT_12345.doc"
+            doc.write_bytes(b"\xef\xbb\xbf{\"error\":true}" + b"x" * 1024)
+
+            result = convert_single_doc(doc, root / "001_DOF_20260826_MAT_12345.md")
+
+            self.assertEqual(result["status"], "invalid_download")
+            self.assertFalse(doc.exists())
+            self.assertTrue((root / "001_DOF_20260826_MAT_12345.doc.invalid").exists())
 
     def test_sidof_notices_checked_when_page_has_no_word_links(self):
         session = mock.Mock()

--- a/tests/test_dof_update.py
+++ b/tests/test_dof_update.py
@@ -1,4 +1,3 @@
-import hashlib
 import plistlib
 import sqlite3
 import subprocess
@@ -7,54 +6,38 @@ import tempfile
 import unittest
 from datetime import date
 from pathlib import Path
-from types import SimpleNamespace
 from unittest import mock
-
-import sqlite_vec
 
 import convert_doc_to_md
 import get_word_dof
 from convert_doc_to_md import convert_single_doc
 from corpus_store import chunk_index
-from corpus_store.embed import (
-    SCHEMA as VECTOR_SCHEMA,
-)
-from corpus_store.embed import (
-    apply_chunk_vector_invalidations,
-)
-from corpus_store.ingest import SCHEMA, ingest_batch
+from corpus_store.ingest import SCHEMA as CORPUS_SCHEMA
 from get_word_dof import (
     has_valid_download,
     is_valid_sidof_listing,
     is_valid_word_payload,
 )
-from rag_poc.chunker import DocPattern
-from scripts.build_fts_full import FTS_DDL, repair_fts_documents
-from scripts.build_vec0_full import (
-    DDL as VEC0_DDL,
-)
-from scripts.build_vec0_full import (
-    DELETIONS_DDL,
-    apply_vector_deletions,
-)
+from scripts import build_fts_full
 from scripts.update_dof_daily import (
     build_manifest,
     choose_start_date,
     completed_through,
     conversion_command,
     last_jsonl_record,
-    non_regressing_watermark,
 )
+
+WORD_BYTES = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1" + b"x" * 1016
 
 
 class DailyUpdateTests(unittest.TestCase):
-    def test_catches_up_from_day_after_database(self):
+    def test_catches_up_from_day_after_watermark(self):
         self.assertEqual(
             choose_start_date(date(2026, 4, 24), date(2026, 8, 27), 7),
             date(2026, 4, 25),
         )
 
-    def test_uses_overlap_when_database_is_current(self):
+    def test_uses_overlap_when_watermark_is_current(self):
         self.assertEqual(
             choose_start_date(date(2026, 8, 27), date(2026, 8, 27), 7),
             date(2026, 8, 21),
@@ -83,21 +66,18 @@ class DailyUpdateTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary:
             directory = Path(temporary)
             existing = directory / "005_DOF_20260826_MAT_12345.doc"
-            existing.write_bytes(b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1" + b"x" * 1016)
+            existing.write_bytes(WORD_BYTES)
             self.assertTrue(has_valid_download(directory, "12345"))
             self.assertFalse(has_valid_download(directory, "99999"))
 
-    def test_html_error_page_is_not_a_word_download(self):
-        payload = b"<!DOCTYPE html><title>500 error</title>" + b"x" * 1024
-        self.assertFalse(is_valid_word_payload(payload))
-
     def test_only_known_word_signatures_are_valid(self):
-        self.assertTrue(
-            is_valid_word_payload(b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1" + b"x" * 1024)
-        )
+        self.assertTrue(is_valid_word_payload(WORD_BYTES))
         self.assertTrue(is_valid_word_payload(b"PK\x03\x04" + b"x" * 1024))
         self.assertFalse(
-            is_valid_word_payload(b"\xef\xbb\xbf{\"error\":true}" + b"x" * 1024)
+            is_valid_word_payload(b"<!DOCTYPE html><title>500</title>" + b"x" * 1024)
+        )
+        self.assertFalse(
+            is_valid_word_payload(b'\xef\xbb\xbf{"error":true}' + b"x" * 1024)
         )
 
     def test_sidof_listing_requires_requested_edition_tab(self):
@@ -105,12 +85,8 @@ class DailyUpdateTests(unittest.TestCase):
             "<html><head><title>Diario Oficial de la Federación</title></head>"
             "<body><div id='resp-tab3'>26-08-2026</div></body></html>"
         )
-        self.assertTrue(
-            is_valid_sidof_listing(html, "26", "08", "2026", "MAT")
-        )
-        self.assertFalse(
-            is_valid_sidof_listing(html, "26", "08", "2026", "VES")
-        )
+        self.assertTrue(is_valid_sidof_listing(html, "26", "08", "2026", "MAT"))
+        self.assertFalse(is_valid_sidof_listing(html, "26", "08", "2026", "VES"))
 
     def test_conversion_scan_is_limited_to_active_date_window(self):
         with tempfile.TemporaryDirectory() as temporary:
@@ -129,15 +105,8 @@ class DailyUpdateTests(unittest.TestCase):
 
             self.assertEqual(files, [active])
 
-    def test_updater_passes_the_active_window_to_converter(self):
-        args = SimpleNamespace(
-            workers=2,
-            word_dir=Path("word"),
-            corpus=Path("markdown"),
-        )
-        command = conversion_command(
-            args, date(2025, 12, 30), date(2026, 1, 2)
-        )
+    def test_updater_passes_active_window_to_converter(self):
+        command = conversion_command(2, date(2025, 12, 30), date(2026, 1, 2))
         self.assertEqual(
             command[command.index("--years") + 1:command.index("--start-date")],
             ["2025", "2026"],
@@ -145,247 +114,20 @@ class DailyUpdateTests(unittest.TestCase):
         self.assertEqual(command[command.index("--start-date") + 1], "2025-12-30")
         self.assertEqual(command[command.index("--end-date") + 1], "2026-01-02")
 
-    def test_ingest_repairs_oversized_row_missing_segments(self):
-        with tempfile.TemporaryDirectory() as temporary:
-            corpus = Path(temporary)
-            relpath = "2026/08/17082026/MAT/006_DOF_test.md"
-            source = corpus / relpath
-            source.parent.mkdir(parents=True)
-            source.write_text("á" * 40, encoding="utf-8")
-            raw = source.read_bytes()
-            conn = sqlite3.connect(":memory:")
-            conn.executescript(SCHEMA)
-            conn.execute(
-                "INSERT INTO documents(path, year, publication_date, section, markdown,"
-                " byte_length, sha256, corpus_version) VALUES (?, 2026, '2026-08-17',"
-                " 'MAT', '', ?, ?, 'dof-full-v1')",
-                (relpath, len(raw), hashlib.sha256(raw).digest()),
-            )
-            conn.execute(
-                "CREATE TRIGGER preserve_empty_markdown BEFORE UPDATE OF markdown"
-                " ON documents BEGIN SELECT RAISE(ABORT, 'markdown was rewritten'); END"
-            )
-            doc_id = conn.execute("SELECT document_id FROM documents").fetchone()[0]
-
-            inserted, _ = ingest_batch(
-                conn,
-                corpus,
-                [{
-                    "relpath": relpath,
-                    "year": 2026,
-                    "publication_date": "2026-08-17",
-                    "section": "MAT",
-                }],
-                segment_threshold=16,
-                corpus_version="dof-full-v1",
-            )
-
-            self.assertEqual(inserted, 1)
-            self.assertEqual(
-                conn.execute(
-                    "SELECT COUNT(*) FROM document_segments WHERE document_id = ?",
-                    (doc_id,),
-                ).fetchone()[0],
-                3,
-            )
-            self.assertEqual(
-                conn.execute("SELECT document_id FROM documents").fetchone()[0], doc_id
-            )
-            conn.close()
-
-    def test_ingest_repairs_partial_segments(self):
-        with tempfile.TemporaryDirectory() as temporary:
-            corpus = Path(temporary)
-            relpath = "2026/08/17082026/MAT/006_DOF_test.md"
-            source = corpus / relpath
-            source.parent.mkdir(parents=True)
-            source.write_text("á" * 40, encoding="utf-8")
-            raw = source.read_bytes()
-            conn = sqlite3.connect(":memory:")
-            conn.executescript(SCHEMA)
-            conn.execute(
-                "INSERT INTO documents(path, year, publication_date, section, markdown,"
-                " byte_length, sha256, corpus_version) VALUES (?, 2026, '2026-08-17',"
-                " 'MAT', '', ?, ?, 'dof-full-v1')",
-                (relpath, len(raw), hashlib.sha256(raw).digest()),
-            )
-            doc_id = conn.execute("SELECT document_id FROM documents").fetchone()[0]
-            # An interrupted import left only the first of three segments.
-            conn.execute(
-                "INSERT INTO document_segments (document_id, segment_index,"
-                " start_offset, end_offset, segment_text) VALUES (?, 0, 0, 16, ?)",
-                (doc_id, "á" * 16),
-            )
-
-            inserted, _ = ingest_batch(
-                conn,
-                corpus,
-                [{
-                    "relpath": relpath,
-                    "year": 2026,
-                    "publication_date": "2026-08-17",
-                    "section": "MAT",
-                }],
-                segment_threshold=16,
-                corpus_version="dof-full-v1",
-            )
-
-            self.assertEqual(inserted, 1)
-            segments = conn.execute(
-                "SELECT segment_text FROM document_segments"
-                " WHERE document_id = ? ORDER BY segment_index",
-                (doc_id,),
-            ).fetchall()
-            self.assertEqual(len(segments), 3)
-            self.assertEqual("".join(row[0] for row in segments), "á" * 40)
-            self.assertEqual(
-                conn.execute(
-                    "SELECT previous_markdown, fts_pending, chunks_pending"
-                    " FROM document_repairs WHERE document_id = ?",
-                    (doc_id,),
-                ).fetchone(),
-                ("á" * 16, 1, 1),
-            )
-            conn.close()
-
-    def test_ingest_skips_structurally_complete_segmented_doc(self):
-        with tempfile.TemporaryDirectory() as temporary:
-            corpus = Path(temporary)
-            relpath = "2026/08/17082026/MAT/006_DOF_test.md"
-            source = corpus / relpath
-            source.parent.mkdir(parents=True)
-            source.write_text("á" * 40, encoding="utf-8")
-            raw = source.read_bytes()
-            conn = sqlite3.connect(":memory:")
-            conn.executescript(SCHEMA)
-            conn.execute(
-                "INSERT INTO documents(path, year, publication_date, section, markdown,"
-                " byte_length, sha256, corpus_version) VALUES (?, 2026, '2026-08-17',"
-                " 'MAT', '', ?, ?, 'dof-full-v1')",
-                (relpath, len(raw), hashlib.sha256(raw).digest()),
-            )
-            doc_id = conn.execute("SELECT document_id FROM documents").fetchone()[0]
-            for index, start in enumerate((0, 16, 32)):
-                segment = ("á" * 40)[start:start + 16]
-                conn.execute(
-                    "INSERT INTO document_segments (document_id, segment_index,"
-                    " start_offset, end_offset, segment_text)"
-                    " VALUES (?, ?, ?, ?, ?)",
-                    (doc_id, index, start, start + len(segment), segment),
-                )
-
-            inserted, _ = ingest_batch(
-                conn,
-                corpus,
-                [{
-                    "relpath": relpath,
-                    "year": 2026,
-                    "publication_date": "2026-08-17",
-                    "section": "MAT",
-                }],
-                segment_threshold=16,
-                corpus_version="dof-full-v1",
-            )
-
-            self.assertEqual(inserted, 0)
-            self.assertEqual(
-                conn.execute(
-                    "SELECT COUNT(*) FROM document_segments WHERE document_id = ?",
-                    (doc_id,),
-                ).fetchone()[0],
-                3,
-            )
-            conn.close()
-
-    def test_ingest_repairs_segments_with_wrong_offsets_and_content(self):
-        with tempfile.TemporaryDirectory() as temporary:
-            corpus = Path(temporary)
-            relpath = "2026/08/17082026/MAT/006_DOF_test.md"
-            source = corpus / relpath
-            source.parent.mkdir(parents=True)
-            source.write_text("á" * 40, encoding="utf-8")
-            raw = source.read_bytes()
-            conn = sqlite3.connect(":memory:")
-            conn.executescript(SCHEMA)
-            conn.execute(
-                "INSERT INTO documents(path, year, publication_date, section, markdown,"
-                " byte_length, sha256, corpus_version) VALUES (?, 2026, '2026-08-17',"
-                " 'MAT', '', ?, ?, 'dof-full-v1')",
-                (relpath, len(raw), hashlib.sha256(raw).digest()),
-            )
-            doc_id = conn.execute("SELECT document_id FROM documents").fetchone()[0]
-            # Count and total text length look complete, but the second row has
-            # corrupt offsets/content. The old SUM(LENGTH) check accepted this.
-            segments = [
-                (0, 0, 16, "á" * 16),
-                (1, 99, 115, "x" * 16),
-                (2, 32, 40, "á" * 8),
-            ]
-            conn.executemany(
-                "INSERT INTO document_segments (document_id, segment_index,"
-                " start_offset, end_offset, segment_text) VALUES (?, ?, ?, ?, ?)",
-                [(doc_id, *segment) for segment in segments],
-            )
-
-            inserted, _ = ingest_batch(
-                conn,
-                corpus,
-                [{
-                    "relpath": relpath,
-                    "year": 2026,
-                    "publication_date": "2026-08-17",
-                    "section": "MAT",
-                }],
-                segment_threshold=16,
-                corpus_version="dof-full-v1",
-            )
-
-            self.assertEqual(inserted, 1)
-            repaired = conn.execute(
-                "SELECT segment_index, start_offset, end_offset, segment_text"
-                " FROM document_segments WHERE document_id = ? ORDER BY segment_index",
-                (doc_id,),
-            ).fetchall()
-            self.assertEqual(
-                repaired,
-                [
-                    (0, 0, 16, "á" * 16),
-                    (1, 16, 32, "á" * 16),
-                    (2, 32, 40, "á" * 8),
-                ],
-            )
-            conn.close()
-
-    def test_html_download_is_quarantined_for_redownload(self):
+    def test_invalid_word_is_quarantined_for_redownload(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
             doc = root / "001_DOF_20260826_MAT_12345.doc"
             doc.write_bytes(b"<!DOCTYPE html><title>500</title>" + b"x" * 1024)
 
-            result = convert_single_doc(doc, root / "001_DOF_20260826_MAT_12345.md")
+            result = convert_single_doc(doc, doc.with_suffix(".md"))
 
             self.assertEqual(result["status"], "invalid_download")
             self.assertFalse(doc.exists())
-            self.assertTrue(
-                (root / "001_DOF_20260826_MAT_12345.doc.invalid").exists()
-            )
-            # The quarantined file is invisible to the downloader's resume
-            # glob, so the notice is re-fetched on the next download pass.
+            self.assertTrue((root / f"{doc.name}.invalid").exists())
             self.assertFalse(has_valid_download(root, "12345"))
 
-    def test_non_word_error_body_is_quarantined_for_redownload(self):
-        with tempfile.TemporaryDirectory() as temporary:
-            root = Path(temporary)
-            doc = root / "001_DOF_20260826_MAT_12345.doc"
-            doc.write_bytes(b"\xef\xbb\xbf{\"error\":true}" + b"x" * 1024)
-
-            result = convert_single_doc(doc, root / "001_DOF_20260826_MAT_12345.md")
-
-            self.assertEqual(result["status"], "invalid_download")
-            self.assertFalse(doc.exists())
-            self.assertTrue((root / "001_DOF_20260826_MAT_12345.doc.invalid").exists())
-
-    def test_sidof_notices_checked_when_page_has_no_word_links(self):
+    def test_sidof_notices_are_checked_when_page_has_no_word_links(self):
         session = mock.Mock()
         response = mock.Mock()
         response.text = (
@@ -395,6 +137,7 @@ class DailyUpdateTests(unittest.TestCase):
         )
         response.raise_for_status = lambda: None
         session.get.return_value = response
+
         with tempfile.TemporaryDirectory() as temporary:
             with mock.patch.object(
                 get_word_dof, "process_sidof_notices", return_value=0
@@ -402,28 +145,28 @@ class DailyUpdateTests(unittest.TestCase):
                 downloaded = get_word_dof.process_dof_page(
                     session, "26/08/2026", "MAT", Path(temporary), sleep_delay=0
                 )
+
         self.assertEqual(downloaded, 0)
         notices.assert_called_once()
 
-    def test_malformed_empty_listing_is_an_error(self):
+    def test_malformed_dof_listing_is_an_error(self):
         session = mock.Mock()
         response = mock.Mock()
         response.text = "<html><title>500 error</title><body></body></html>"
         response.raise_for_status = lambda: None
         session.get.return_value = response
+
         with tempfile.TemporaryDirectory() as temporary:
             with (
                 mock.patch.object(get_word_dof, "ERROR_COUNT", 0),
                 mock.patch.object(
                     get_word_dof, "process_sidof_notices", return_value=0
-                ) as notices,
+                ),
             ):
-                downloaded = get_word_dof.process_dof_page(
+                get_word_dof.process_dof_page(
                     session, "26/08/2026", "MAT", Path(temporary), sleep_delay=0
                 )
                 self.assertEqual(get_word_dof.ERROR_COUNT, 1)
-        self.assertEqual(downloaded, 0)
-        notices.assert_called_once()
 
     def test_malformed_sidof_listing_is_an_error(self):
         session = mock.Mock()
@@ -431,361 +174,109 @@ class DailyUpdateTests(unittest.TestCase):
         response.text = "<html><title>500 error</title><body></body></html>"
         response.raise_for_status = lambda: None
         session.get.return_value = response
+
         with (
             tempfile.TemporaryDirectory() as temporary,
             mock.patch.object(get_word_dof, "ERROR_COUNT", 0),
         ):
-            downloaded = get_word_dof.process_sidof_notices(
-                session,
-                "26",
-                "08",
-                "2026",
-                "MAT",
-                Path(temporary),
-                sleep_delay=0,
+            get_word_dof.process_sidof_notices(
+                session, "26", "08", "2026", "MAT", Path(temporary), sleep_delay=0
             )
             self.assertEqual(get_word_dof.ERROR_COUNT, 1)
-        self.assertEqual(downloaded, 0)
 
-    def test_chunk_store_rejects_a_mixed_chunker_version(self):
-        with tempfile.TemporaryDirectory() as temporary:
-            root = Path(temporary)
-            corpus_db = root / "corpus.sqlite"
-            chunks_db = root / "chunks.sqlite"
-
-            setup = sqlite3.connect(corpus_db)
-            setup.executescript(SCHEMA)
-            setup.execute(
-                "INSERT INTO corpus_meta (key, value) VALUES ('corpus_version', 'v1')"
-            )
-            markdown = "# Decreto\n\n" + "contenido del decreto " * 40
-            raw = markdown.encode("utf-8")
-            setup.execute(
-                "INSERT INTO documents(path, year, publication_date, section, markdown,"
-                " byte_length, sha256, corpus_version)"
-                " VALUES ('2026/08/26082026/MAT/001.md', 2026, '2026-08-26', 'MAT',"
-                " ?, ?, ?, 'v1')",
-                (markdown, len(raw), hashlib.sha256(raw).digest()),
-            )
-            setup.commit()
-            setup.close()
-
-            stale = sqlite3.connect(chunks_db)
-            stale.executescript(chunk_index.SCHEMA)
-            stale.execute(
-                "INSERT INTO chunks (document_id, path, chunk_index, pattern,"
-                " start_offset, end_offset, spans_json, token_count, heading_path,"
-                " chunk_hash, chunker_version, corpus_version)"
-                " VALUES (1, 'x', 0, 'PLAIN', 0, 1, '[]', 1, NULL, ?, 'old-version', 'v1')",
-                (b"0" * 32,),
-            )
-            stale.commit()
-            stale.close()
-
-            argv = [
-                "chunk_index",
-                "--corpus-db", str(corpus_db),
-                "--chunks-db", str(chunks_db),
-            ]
-            with mock.patch.object(sys, "argv", argv):
-                with self.assertRaisesRegex(
-                    RuntimeError, "Rebuild the chunk, vector, and vec0 stores"
-                ):
-                    chunk_index.main()
-
-            check = sqlite3.connect(chunks_db)
-            versions = dict(
-                check.execute(
-                    "SELECT chunker_version, COUNT(*) FROM chunks GROUP BY 1"
-                ).fetchall()
-            )
-            check.close()
-            # The incompatible row is preserved, but no current-version rows
-            # or vectors can be mixed into this store.
-            self.assertEqual(versions["old-version"], 1)
-            self.assertNotIn(chunk_index.CHUNKER_VERSION, versions)
-
-    def test_repaired_document_rebuilds_chunks_below_checkpoint(self):
-        with tempfile.TemporaryDirectory() as temporary:
-            root = Path(temporary)
-            corpus_db = root / "corpus.sqlite"
-            chunks_db = root / "chunks.sqlite"
-            markdown = "repaired document content long enough to align"
-
-            corpus = sqlite3.connect(corpus_db)
-            corpus.executescript(SCHEMA)
-            corpus.execute(
-                "INSERT INTO corpus_meta(key, value) VALUES ('corpus_version', 'v1')"
-            )
-            corpus.execute(
-                "INSERT INTO documents(path, year, publication_date, section, markdown,"
-                " byte_length, sha256, corpus_version) VALUES"
-                " ('2026/08/26082026/MAT/001.md', 2026, '2026-08-26', 'MAT',"
-                " ?, ?, ?, 'v1')",
-                (
-                    markdown,
-                    len(markdown.encode()),
-                    hashlib.sha256(markdown.encode()).digest(),
-                ),
-            )
-            corpus.execute(
-                "INSERT INTO document_repairs"
-                " (document_id, repaired_sha256, previous_markdown,"
-                " fts_pending, chunks_pending) VALUES (1, ?, 'stale', 0, 1)",
-                (hashlib.sha256(markdown.encode()).digest(),),
-            )
-            corpus.commit()
-            corpus.close()
-
-            chunks = sqlite3.connect(chunks_db)
-            chunks.executescript(chunk_index.SCHEMA)
-            chunks.execute(
-                "INSERT INTO chunks (chunk_id, document_id, path, chunk_index, pattern,"
-                " start_offset, end_offset, spans_json, token_count, heading_path,"
-                " chunk_hash, chunker_version, corpus_version) VALUES"
-                " (10, 1, 'stale', 0, 'PLAIN', 0, 5, '[]', 1, '[]', ?, ?, 'v1')",
-                (b"0" * 32, chunk_index.CHUNKER_VERSION),
-            )
-            chunks.commit()
-            chunks.close()
-
-            generated = SimpleNamespace(
-                text=markdown,
-                pattern=DocPattern.PLAIN_TEXT,
-                chunk_index=0,
-                heading_path=[],
-            )
-            argv = [
-                "chunk_index",
-                "--corpus-db", str(corpus_db),
-                "--chunks-db", str(chunks_db),
-            ]
-            with (
-                mock.patch.object(sys, "argv", argv),
-                mock.patch.object(chunk_index, "split_text", return_value=[generated]),
-                mock.patch.object(chunk_index, "_count_tokens", return_value=6),
-            ):
-                chunk_index.main()
-
-            check = sqlite3.connect(chunks_db)
-            current = check.execute(
-                "SELECT chunk_id, path, chunk_hash FROM chunks WHERE document_id = 1"
-            ).fetchone()
-            self.assertGreater(current[0], 10)
-            self.assertEqual(current[1], "2026/08/26082026/MAT/001.md")
-            self.assertEqual(current[2], hashlib.sha256(markdown.encode()).digest())
-            self.assertEqual(
-                check.execute(
-                    "SELECT chunk_id FROM chunk_vector_invalidations"
-                ).fetchall(),
-                [(10,)],
-            )
-            check.close()
-            corpus = sqlite3.connect(corpus_db)
-            self.assertEqual(
-                corpus.execute(
-                    "SELECT chunks_pending FROM document_repairs WHERE document_id = 1"
-                ).fetchone()[0],
-                0,
-            )
-            corpus.close()
-
-    def test_new_chunks_are_flushed_before_repair_checkpoint_advances(self):
-        with tempfile.TemporaryDirectory() as temporary:
-            root = Path(temporary)
-            corpus_db = root / "corpus.sqlite"
-            chunks_db = root / "chunks.sqlite"
-            corpus = sqlite3.connect(corpus_db)
-            corpus.executescript(SCHEMA)
-            corpus.execute(
-                "INSERT INTO corpus_meta(key, value) VALUES ('corpus_version', 'v1')"
-            )
-            for path, text in (
-                ("old.md", "old document"),
-                ("new.md", "new document"),
-                ("repair.md", "repaired document"),
-            ):
-                raw = text.encode()
-                corpus.execute(
-                    "INSERT INTO documents(path, year, publication_date, section,"
-                    " markdown, byte_length, sha256, corpus_version)"
-                    " VALUES (?, 2026, '2026-08-26', 'MAT', ?, ?, ?, 'v1')",
-                    (path, text, len(raw), hashlib.sha256(raw).digest()),
-                )
-            corpus.execute(
-                "INSERT INTO document_repairs"
-                " (document_id, repaired_sha256, previous_markdown,"
-                " fts_pending, chunks_pending) VALUES (3, ?, 'stale', 0, 1)",
-                (hashlib.sha256(b"repaired document").digest(),),
-            )
-            corpus.commit()
-            corpus.close()
-
-            chunks = sqlite3.connect(chunks_db)
-            chunks.executescript(chunk_index.SCHEMA)
-            chunks.execute(
-                "INSERT INTO chunks (chunk_id, document_id, path, chunk_index, pattern,"
-                " start_offset, end_offset, spans_json, token_count, heading_path,"
-                " chunk_hash, chunker_version, corpus_version) VALUES"
-                " (1, 1, 'old.md', 0, 'plain_text', 0, 3, '{\"l\":\"old\"}',"
-                " 1, '[]', ?, ?, 'v1')",
-                (b"0" * 32, chunk_index.CHUNKER_VERSION),
-            )
-            chunks.commit()
-            chunks.close()
-
-            class ChunkConnectionProxy:
-                def __init__(self, connection):
-                    self.connection = connection
-                    self.chunk_inserts = 0
-
-                def __enter__(self):
-                    self.connection.__enter__()
-                    return self
-
-                def __exit__(self, *args):
-                    return self.connection.__exit__(*args)
-
-                def executemany(self, sql, parameters):
-                    rows = list(parameters)
-                    if sql.lstrip().startswith("INSERT INTO chunks"):
-                        self.chunk_inserts += 1
-                        # Before the fix, document 2 is the final flush after
-                        # repair document 3 has already advanced the checkpoint.
-                        if rows and rows[0][0] == 2 and self.chunk_inserts > 1:
-                            raise RuntimeError("simulated crash before final flush")
-                    return self.connection.executemany(sql, rows)
-
-                def __getattr__(self, name):
-                    return getattr(self.connection, name)
-
-            real_connect = sqlite3.connect
-            proxy = None
-
-            def connect_for_test(path, *args, **kwargs):
-                nonlocal proxy
-                connection = real_connect(path, *args, **kwargs)
-                if str(path) == str(chunks_db):
-                    proxy = ChunkConnectionProxy(connection)
-                    return proxy
-                return connection
-
-            def generated(text, *_):
-                return [
-                    SimpleNamespace(
-                        text=text,
-                        pattern=DocPattern.PLAIN_TEXT,
-                        chunk_index=0,
-                        heading_path=[],
-                    )
-                ]
-            argv = [
-                "chunk_index",
-                "--corpus-db", str(corpus_db),
-                "--chunks-db", str(chunks_db),
-            ]
-            with (
-                mock.patch.object(sys, "argv", argv),
-                mock.patch.object(chunk_index.sqlite3, "connect", side_effect=connect_for_test),
-                mock.patch.object(chunk_index, "split_text", side_effect=generated),
-                mock.patch.object(chunk_index, "_count_tokens", return_value=1),
-            ):
-                chunk_index.main()
-
-            self.assertEqual(proxy.chunk_inserts, 2)
-            check = sqlite3.connect(chunks_db)
-            self.assertEqual(
-                check.execute(
-                    "SELECT document_id FROM chunks ORDER BY document_id"
-                ).fetchall(),
-                [(1,), (2,), (3,)],
-            )
-            check.close()
-
-    def test_repaired_document_replaces_stale_fts_tokens(self):
-        conn = sqlite3.connect(":memory:")
-        conn.executescript(SCHEMA)
-        new_text = "newtoken repaired publication"
-        conn.execute(
-            "INSERT INTO documents(path, year, publication_date, section, markdown,"
-            " byte_length, sha256, corpus_version) VALUES"
-            " ('x.md', 2026, '2026-08-26', 'MAT', ?, ?, ?, 'v1')",
-            (new_text, len(new_text), hashlib.sha256(new_text.encode()).digest()),
-        )
-        conn.execute(
-            "INSERT INTO document_repairs"
-            " (document_id, repaired_sha256, previous_markdown,"
-            " fts_pending, chunks_pending) VALUES (1, ?, 'oldtoken stale', 1, 0)",
-            (hashlib.sha256(new_text.encode()).digest(),),
-        )
-        conn.execute(FTS_DDL)
-        conn.execute(
-            "INSERT INTO documents_fts(rowid, markdown) VALUES (1, 'oldtoken stale')"
-        )
-        conn.commit()
-
-        repaired, newly_indexed = repair_fts_documents(conn)
-
-        self.assertEqual((repaired, newly_indexed), (1, 0))
-        self.assertEqual(
-            conn.execute(
-                "SELECT COUNT(*) FROM documents_fts"
-                " WHERE documents_fts MATCH 'oldtoken'"
-            ).fetchone()[0],
-            0,
-        )
-        self.assertEqual(
-            conn.execute(
-                "SELECT COUNT(*) FROM documents_fts"
-                " WHERE documents_fts MATCH 'newtoken'"
-            ).fetchone()[0],
-            1,
-        )
-        self.assertEqual(
-            conn.execute(
-                "SELECT previous_markdown, fts_pending FROM document_repairs"
-            ).fetchone(),
-            (None, 0),
-        )
-        conn.close()
-
-    def test_chunk_and_vec0_deletion_queues_are_consumed(self):
+    def test_chunk_store_rejects_mixed_chunker_versions(self):
         chunks = sqlite3.connect(":memory:")
         chunks.executescript(chunk_index.SCHEMA)
         chunks.execute(
-            "INSERT INTO chunk_vector_invalidations(chunk_id) VALUES (7)"
-        )
-        vectors = sqlite3.connect(":memory:")
-        vectors.executescript(VECTOR_SCHEMA)
-        vectors.execute(
-            "INSERT INTO chunk_vectors(chunk_id, embedding) VALUES (7, ?)",
-            (b"x" * 128,),
+            "INSERT INTO chunks (document_id, path, chunk_index, pattern,"
+            " start_offset, end_offset, spans_json, token_count, heading_path,"
+            " chunk_hash, chunker_version, corpus_version)"
+            " VALUES (1, 'x', 0, 'plain_text', 0, 1, '[]', 1, '[]', ?, 'old', 'v1')",
+            (b"0" * 32,),
         )
 
-        self.assertEqual(apply_chunk_vector_invalidations(chunks, vectors), 1)
-        self.assertEqual(vectors.execute("SELECT COUNT(*) FROM chunk_vectors").fetchone()[0], 0)
-        self.assertEqual(vectors.execute("SELECT chunk_id FROM vector_deletions").fetchall(), [(7,)])
-        self.assertEqual(chunks.execute("SELECT COUNT(*) FROM chunk_vector_invalidations").fetchone()[0], 0)
+        with self.assertRaisesRegex(RuntimeError, "Rebuild the chunk"):
+            chunk_index.require_current_chunker_version(chunks)
 
-        vec0 = sqlite3.connect(":memory:")
-        vec0.enable_load_extension(True)
-        sqlite_vec.load(vec0)
-        vec0.execute(VEC0_DDL)
-        vec0.execute(
-            "INSERT INTO chunk_vec(rowid, embedding) VALUES (7, vec_bit(?))",
-            (b"x" * 128,),
-        )
-        vectors.execute(DELETIONS_DDL)
-        vectors.commit()
-
-        self.assertEqual(apply_vector_deletions(vec0, vectors), 1)
-        self.assertEqual(vec0.execute("SELECT COUNT(*) FROM chunk_vec").fetchone()[0], 0)
-        self.assertEqual(vectors.execute("SELECT COUNT(*) FROM vector_deletions").fetchone()[0], 0)
-        vec0.close()
-        vectors.close()
         chunks.close()
 
-    def test_launchd_renderer_preserves_spaces_and_xml_characters(self):
+    def test_chunk_scan_starts_after_existing_checkpoint(self):
+        corpus = sqlite3.connect(":memory:")
+        corpus.executescript(CORPUS_SCHEMA)
+        for path in ("one.md", "two.md", "three.md"):
+            corpus.execute(
+                "INSERT INTO documents(path, year, publication_date, section, markdown,"
+                " byte_length, sha256, corpus_version)"
+                " VALUES (?, 2026, '2026-08-26', 'MAT', ?, 4, ?, 'v1')",
+                (path, path, b"0" * 32),
+            )
+
+        rows = list(chunk_index.iter_documents(corpus, after_document_id=2))
+
+        self.assertEqual([(row[0], row[1]) for row in rows], [(3, "three.md")])
+        corpus.close()
+
+    def test_fts_appends_normal_and_segmented_documents(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            db_path = Path(temporary) / "corpus.sqlite"
+            conn = sqlite3.connect(db_path)
+            conn.executescript(CORPUS_SCHEMA)
+            conn.execute(
+                "INSERT INTO documents(path, year, publication_date, section, markdown,"
+                " byte_length, sha256, corpus_version)"
+                " VALUES ('one.md', 2026, '2026-08-26', 'MAT',"
+                " 'decreto inicial', 15, ?, 'v1')",
+                (b"0" * 32,),
+            )
+            conn.commit()
+            conn.close()
+
+            self._run_fts(db_path)
+
+            conn = sqlite3.connect(db_path)
+            conn.execute(
+                "INSERT INTO documents(path, year, publication_date, section, markdown,"
+                " byte_length, sha256, corpus_version)"
+                " VALUES ('two.md', 2026, '2026-08-27', 'MAT',"
+                " 'decreto nuevo', 13, ?, 'v1')",
+                (b"1" * 32,),
+            )
+            cursor = conn.execute(
+                "INSERT INTO documents(path, year, publication_date, section, markdown,"
+                " byte_length, sha256, corpus_version)"
+                " VALUES ('three.md', 2026, '2026-08-27', 'MAT', '', 18, ?, 'v1')",
+                (b"2" * 32,),
+            )
+            conn.execute(
+                "INSERT INTO document_segments(document_id, segment_index, start_offset,"
+                " end_offset, segment_text) VALUES (?, 0, 0, 18, 'aviso segmentado')",
+                (cursor.lastrowid,),
+            )
+            conn.commit()
+            conn.close()
+
+            self._run_fts(db_path)
+
+            conn = sqlite3.connect(db_path)
+            self.assertEqual(
+                conn.execute("SELECT COUNT(*) FROM documents_fts_docsize").fetchone()[0],
+                3,
+            )
+            self.assertEqual(
+                conn.execute(
+                    "SELECT COUNT(*) FROM documents_fts"
+                    " WHERE documents_fts MATCH 'segmentado'"
+                ).fetchone()[0],
+                1,
+            )
+            conn.close()
+
+    def _run_fts(self, db_path: Path) -> None:
+        argv = ["build_fts_full", "--corpus-db", str(db_path), "--batch", "2"]
+        with mock.patch.object(sys, "argv", argv):
+            build_fts_full.main()
+
+    def test_launchd_renderer_preserves_special_paths(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
             output = root / "rendered.plist"
@@ -804,19 +295,11 @@ class DailyUpdateTests(unittest.TestCase):
                 capture_output=True,
                 text=True,
             )
+
             with output.open("rb") as stream:
                 payload = plistlib.load(stream)
-            self.assertEqual(
-                payload["ProgramArguments"],
-                [
-                    "/usr/bin/nice",
-                    "-n",
-                    "10",
-                    "/usr/bin/caffeinate",
-                    "-i",
-                    str(runner),
-                ],
-            )
+
+            self.assertEqual(payload["ProgramArguments"][-1], str(runner))
             self.assertEqual(
                 payload["EnvironmentVariables"]["DOF_REPO_DIR"], str(repository)
             )
@@ -833,6 +316,7 @@ class DailyUpdateTests(unittest.TestCase):
                 '{"publication_date": "2026-04-24"}\n',
                 encoding="utf-8",
             )
+
             self.assertEqual(
                 completed_through(root / "missing-state.json", manifest, root / "db"),
                 date(2026, 4, 24),
@@ -840,16 +324,6 @@ class DailyUpdateTests(unittest.TestCase):
             self.assertEqual(
                 last_jsonl_record(manifest), {"publication_date": "2026-04-24"}
             )
-
-    def test_historical_window_never_moves_watermark_backward(self):
-        self.assertEqual(
-            non_regressing_watermark(date(2026, 8, 28), date(2026, 8, 27)),
-            date(2026, 8, 28),
-        )
-        self.assertEqual(
-            non_regressing_watermark(date(2026, 8, 27), date(2026, 8, 28)),
-            date(2026, 8, 28),
-        )
 
 
 if __name__ == "__main__":

--- a/tests/test_dof_update.py
+++ b/tests/test_dof_update.py
@@ -655,7 +655,17 @@ class DailyUpdateTests(unittest.TestCase):
             )
             with output.open("rb") as stream:
                 payload = plistlib.load(stream)
-            self.assertEqual(payload["ProgramArguments"][5], str(runner))
+            self.assertEqual(
+                payload["ProgramArguments"],
+                [
+                    "/usr/bin/nice",
+                    "-n",
+                    "10",
+                    "/usr/bin/caffeinate",
+                    "-i",
+                    str(runner),
+                ],
+            )
             self.assertEqual(
                 payload["EnvironmentVariables"]["DOF_REPO_DIR"], str(repository)
             )

--- a/tests/test_dof_update.py
+++ b/tests/test_dof_update.py
@@ -184,19 +184,37 @@ class DailyUpdateTests(unittest.TestCase):
             )
             self.assertEqual(get_word_dof.ERROR_COUNT, 1)
 
-    def test_chunk_store_rejects_mixed_chunker_versions(self):
+    def test_chunk_store_rejects_versions_on_either_side_of_current(self):
+        for version in ("aaa-older-version", "zzz-newer-version"):
+            with self.subTest(version=version):
+                chunks = sqlite3.connect(":memory:")
+                chunks.executescript(chunk_index.SCHEMA)
+                chunks.execute(
+                    "INSERT INTO chunks (document_id, path, chunk_index, pattern,"
+                    " start_offset, end_offset, spans_json, token_count, heading_path,"
+                    " chunk_hash, chunker_version, corpus_version)"
+                    " VALUES (1, 'x', 0, 'plain_text', 0, 1, '[]', 1, '[]',"
+                    " ?, ?, 'v1')",
+                    (b"0" * 32, version),
+                )
+
+                with self.assertRaisesRegex(RuntimeError, "Rebuild the chunk"):
+                    chunk_index.require_current_chunker_version(chunks)
+
+                chunks.close()
+
+    def test_chunk_store_accepts_only_current_version(self):
         chunks = sqlite3.connect(":memory:")
         chunks.executescript(chunk_index.SCHEMA)
         chunks.execute(
             "INSERT INTO chunks (document_id, path, chunk_index, pattern,"
             " start_offset, end_offset, spans_json, token_count, heading_path,"
             " chunk_hash, chunker_version, corpus_version)"
-            " VALUES (1, 'x', 0, 'plain_text', 0, 1, '[]', 1, '[]', ?, 'old', 'v1')",
-            (b"0" * 32,),
+            " VALUES (1, 'x', 0, 'plain_text', 0, 1, '[]', 1, '[]', ?, ?, 'v1')",
+            (b"0" * 32, chunk_index.CHUNKER_VERSION),
         )
 
-        with self.assertRaisesRegex(RuntimeError, "Rebuild the chunk"):
-            chunk_index.require_current_chunker_version(chunks)
+        chunk_index.require_current_chunker_version(chunks)
 
         chunks.close()
 

--- a/tests/test_dof_update.py
+++ b/tests/test_dof_update.py
@@ -1,10 +1,15 @@
 import hashlib
 import sqlite3
+import sys
 import tempfile
 import unittest
 from datetime import date
 from pathlib import Path
+from unittest import mock
 
+import get_word_dof
+from convert_doc_to_md import convert_single_doc
+from corpus_store import chunk_index
 from corpus_store.ingest import SCHEMA, ingest_batch
 from get_word_dof import has_valid_download, is_valid_word_payload
 from scripts.update_dof_daily import (
@@ -106,6 +111,188 @@ class DailyUpdateTests(unittest.TestCase):
                 conn.execute("SELECT document_id FROM documents").fetchone()[0], doc_id
             )
             conn.close()
+
+    def test_ingest_repairs_partial_segments(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            corpus = Path(temporary)
+            relpath = "2026/08/17082026/MAT/006_DOF_test.md"
+            source = corpus / relpath
+            source.parent.mkdir(parents=True)
+            source.write_text("á" * 40, encoding="utf-8")
+            raw = source.read_bytes()
+            conn = sqlite3.connect(":memory:")
+            conn.executescript(SCHEMA)
+            conn.execute(
+                "INSERT INTO documents(path, year, publication_date, section, markdown,"
+                " byte_length, sha256, corpus_version) VALUES (?, 2026, '2026-08-17',"
+                " 'MAT', '', ?, ?, 'dof-full-v1')",
+                (relpath, len(raw), hashlib.sha256(raw).digest()),
+            )
+            doc_id = conn.execute("SELECT document_id FROM documents").fetchone()[0]
+            # An interrupted import left only the first of three segments.
+            conn.execute(
+                "INSERT INTO document_segments (document_id, segment_index,"
+                " start_offset, end_offset, segment_text) VALUES (?, 0, 0, 16, ?)",
+                (doc_id, "á" * 16),
+            )
+
+            inserted, _ = ingest_batch(
+                conn,
+                corpus,
+                [{
+                    "relpath": relpath,
+                    "year": 2026,
+                    "publication_date": "2026-08-17",
+                    "section": "MAT",
+                }],
+                segment_threshold=16,
+                corpus_version="dof-full-v1",
+            )
+
+            self.assertEqual(inserted, 1)
+            segments = conn.execute(
+                "SELECT segment_text FROM document_segments"
+                " WHERE document_id = ? ORDER BY segment_index",
+                (doc_id,),
+            ).fetchall()
+            self.assertEqual(len(segments), 3)
+            self.assertEqual("".join(row[0] for row in segments), "á" * 40)
+            conn.close()
+
+    def test_ingest_skips_structurally_complete_segmented_doc(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            corpus = Path(temporary)
+            relpath = "2026/08/17082026/MAT/006_DOF_test.md"
+            source = corpus / relpath
+            source.parent.mkdir(parents=True)
+            source.write_text("á" * 40, encoding="utf-8")
+            raw = source.read_bytes()
+            conn = sqlite3.connect(":memory:")
+            conn.executescript(SCHEMA)
+            conn.execute(
+                "INSERT INTO documents(path, year, publication_date, section, markdown,"
+                " byte_length, sha256, corpus_version) VALUES (?, 2026, '2026-08-17',"
+                " 'MAT', '', ?, ?, 'dof-full-v1')",
+                (relpath, len(raw), hashlib.sha256(raw).digest()),
+            )
+            doc_id = conn.execute("SELECT document_id FROM documents").fetchone()[0]
+            for index, start in enumerate((0, 16, 32)):
+                segment = ("á" * 40)[start:start + 16]
+                conn.execute(
+                    "INSERT INTO document_segments (document_id, segment_index,"
+                    " start_offset, end_offset, segment_text)"
+                    " VALUES (?, ?, ?, ?, ?)",
+                    (doc_id, index, start, start + len(segment), segment),
+                )
+
+            inserted, _ = ingest_batch(
+                conn,
+                corpus,
+                [{
+                    "relpath": relpath,
+                    "year": 2026,
+                    "publication_date": "2026-08-17",
+                    "section": "MAT",
+                }],
+                segment_threshold=16,
+                corpus_version="dof-full-v1",
+            )
+
+            self.assertEqual(inserted, 0)
+            self.assertEqual(
+                conn.execute(
+                    "SELECT COUNT(*) FROM document_segments WHERE document_id = ?",
+                    (doc_id,),
+                ).fetchone()[0],
+                3,
+            )
+            conn.close()
+
+    def test_html_download_is_quarantined_for_redownload(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            doc = root / "001_DOF_20260826_MAT_12345.doc"
+            doc.write_bytes(b"<!DOCTYPE html><title>500</title>" + b"x" * 1024)
+
+            result = convert_single_doc(doc, root / "001_DOF_20260826_MAT_12345.md")
+
+            self.assertEqual(result["status"], "invalid_download")
+            self.assertFalse(doc.exists())
+            self.assertTrue((root / "001_DOF_20260826_MAT_12345.doc.invalid").exists())
+            # The quarantined file is invisible to the downloader's resume
+            # glob, so the notice is re-fetched on the next download pass.
+            self.assertFalse(has_valid_download(root, "12345"))
+
+    def test_sidof_notices_checked_when_page_has_no_word_links(self):
+        session = mock.Mock()
+        response = mock.Mock()
+        response.text = "<html><body>sin documentos</body></html>"
+        response.raise_for_status = lambda: None
+        session.get.return_value = response
+        with tempfile.TemporaryDirectory() as temporary:
+            with mock.patch.object(
+                get_word_dof, "process_sidof_notices", return_value=0
+            ) as notices:
+                downloaded = get_word_dof.process_dof_page(
+                    session, "26/08/2026", "MAT", Path(temporary), sleep_delay=0
+                )
+        self.assertEqual(downloaded, 0)
+        notices.assert_called_once()
+
+    def test_chunk_checkpoint_is_keyed_by_chunker_version(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            corpus_db = root / "corpus.sqlite"
+            chunks_db = root / "chunks.sqlite"
+
+            setup = sqlite3.connect(corpus_db)
+            setup.executescript(SCHEMA)
+            setup.execute(
+                "INSERT INTO corpus_meta (key, value) VALUES ('corpus_version', 'v1')"
+            )
+            markdown = "# Decreto\n\n" + "contenido del decreto " * 40
+            raw = markdown.encode("utf-8")
+            setup.execute(
+                "INSERT INTO documents(path, year, publication_date, section, markdown,"
+                " byte_length, sha256, corpus_version)"
+                " VALUES ('2026/08/26082026/MAT/001.md', 2026, '2026-08-26', 'MAT',"
+                " ?, ?, ?, 'v1')",
+                (markdown, len(raw), hashlib.sha256(raw).digest()),
+            )
+            setup.commit()
+            setup.close()
+
+            stale = sqlite3.connect(chunks_db)
+            stale.executescript(chunk_index.SCHEMA)
+            stale.execute(
+                "INSERT INTO chunks (document_id, path, chunk_index, pattern,"
+                " start_offset, end_offset, spans_json, token_count, heading_path,"
+                " chunk_hash, chunker_version, corpus_version)"
+                " VALUES (1, 'x', 0, 'PLAIN', 0, 1, '[]', 1, NULL, ?, 'old-version', 'v1')",
+                (b"0" * 32,),
+            )
+            stale.commit()
+            stale.close()
+
+            argv = [
+                "chunk_index",
+                "--corpus-db", str(corpus_db),
+                "--chunks-db", str(chunks_db),
+            ]
+            with mock.patch.object(sys, "argv", argv):
+                chunk_index.main()
+
+            check = sqlite3.connect(chunks_db)
+            versions = dict(
+                check.execute(
+                    "SELECT chunker_version, COUNT(*) FROM chunks GROUP BY 1"
+                ).fetchall()
+            )
+            check.close()
+            # Only an old-version chunk existed, so the checkpoint is 0 and
+            # the document is re-chunked under the current version.
+            self.assertEqual(versions["old-version"], 1)
+            self.assertGreaterEqual(versions[chunk_index.CHUNKER_VERSION], 1)
 
     def test_full_manifest_is_initial_contiguous_watermark(self):
         with tempfile.TemporaryDirectory() as temporary:

--- a/tests/test_dof_update.py
+++ b/tests/test_dof_update.py
@@ -1,22 +1,45 @@
 import hashlib
+import plistlib
 import sqlite3
+import subprocess
 import sys
 import tempfile
 import unittest
 from datetime import date
 from pathlib import Path
+from types import SimpleNamespace
 from unittest import mock
 
+import sqlite_vec
+
+import convert_doc_to_md
 import get_word_dof
 from convert_doc_to_md import convert_single_doc
 from corpus_store import chunk_index
+from corpus_store.embed import (
+    SCHEMA as VECTOR_SCHEMA,
+)
+from corpus_store.embed import (
+    apply_chunk_vector_invalidations,
+)
 from corpus_store.ingest import SCHEMA, ingest_batch
 from get_word_dof import has_valid_download, is_valid_word_payload
+from rag_poc.chunker import DocPattern
+from scripts.build_fts_full import FTS_DDL, repair_fts_documents
+from scripts.build_vec0_full import (
+    DDL as VEC0_DDL,
+)
+from scripts.build_vec0_full import (
+    DELETIONS_DDL,
+    apply_vector_deletions,
+)
 from scripts.update_dof_daily import (
     build_manifest,
     choose_start_date,
     completed_through,
+    conversion_command,
     last_jsonl_record,
+    non_regressing_watermark,
 )
 
 
@@ -63,6 +86,39 @@ class DailyUpdateTests(unittest.TestCase):
     def test_html_error_page_is_not_a_word_download(self):
         payload = b"<!DOCTYPE html><title>500 error</title>" + b"x" * 1024
         self.assertFalse(is_valid_word_payload(payload))
+
+    def test_conversion_scan_is_limited_to_active_date_window(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            old = root / "2026/04/24042026/MAT/001_DOF_old.doc"
+            active = root / "2026/08/26082026/MAT/001_DOF_active.doc"
+            future = root / "2026/08/28082026/MAT/001_DOF_future.doc"
+            for path in (old, active, future):
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(b"word")
+
+            with mock.patch.object(convert_doc_to_md, "INPUT_DIR", root):
+                files = convert_doc_to_md.find_doc_files(
+                    [2026], date(2026, 8, 25), date(2026, 8, 27)
+                )
+
+            self.assertEqual(files, [active])
+
+    def test_updater_passes_the_active_window_to_converter(self):
+        args = SimpleNamespace(
+            workers=2,
+            word_dir=Path("word"),
+            corpus=Path("markdown"),
+        )
+        command = conversion_command(
+            args, date(2025, 12, 30), date(2026, 1, 2)
+        )
+        self.assertEqual(
+            command[command.index("--years") + 1:command.index("--start-date")],
+            ["2025", "2026"],
+        )
+        self.assertEqual(command[command.index("--start-date") + 1], "2025-12-30")
+        self.assertEqual(command[command.index("--end-date") + 1], "2026-01-02")
 
     def test_ingest_repairs_oversized_row_missing_segments(self):
         with tempfile.TemporaryDirectory() as temporary:
@@ -157,6 +213,14 @@ class DailyUpdateTests(unittest.TestCase):
             ).fetchall()
             self.assertEqual(len(segments), 3)
             self.assertEqual("".join(row[0] for row in segments), "á" * 40)
+            self.assertEqual(
+                conn.execute(
+                    "SELECT previous_markdown, fts_pending, chunks_pending"
+                    " FROM document_repairs WHERE document_id = ?",
+                    (doc_id,),
+                ).fetchone(),
+                ("á" * 16, 1, 1),
+            )
             conn.close()
 
     def test_ingest_skips_structurally_complete_segmented_doc(self):
@@ -208,6 +272,65 @@ class DailyUpdateTests(unittest.TestCase):
             )
             conn.close()
 
+    def test_ingest_repairs_segments_with_wrong_offsets_and_content(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            corpus = Path(temporary)
+            relpath = "2026/08/17082026/MAT/006_DOF_test.md"
+            source = corpus / relpath
+            source.parent.mkdir(parents=True)
+            source.write_text("á" * 40, encoding="utf-8")
+            raw = source.read_bytes()
+            conn = sqlite3.connect(":memory:")
+            conn.executescript(SCHEMA)
+            conn.execute(
+                "INSERT INTO documents(path, year, publication_date, section, markdown,"
+                " byte_length, sha256, corpus_version) VALUES (?, 2026, '2026-08-17',"
+                " 'MAT', '', ?, ?, 'dof-full-v1')",
+                (relpath, len(raw), hashlib.sha256(raw).digest()),
+            )
+            doc_id = conn.execute("SELECT document_id FROM documents").fetchone()[0]
+            # Count and total text length look complete, but the second row has
+            # corrupt offsets/content. The old SUM(LENGTH) check accepted this.
+            segments = [
+                (0, 0, 16, "á" * 16),
+                (1, 99, 115, "x" * 16),
+                (2, 32, 40, "á" * 8),
+            ]
+            conn.executemany(
+                "INSERT INTO document_segments (document_id, segment_index,"
+                " start_offset, end_offset, segment_text) VALUES (?, ?, ?, ?, ?)",
+                [(doc_id, *segment) for segment in segments],
+            )
+
+            inserted, _ = ingest_batch(
+                conn,
+                corpus,
+                [{
+                    "relpath": relpath,
+                    "year": 2026,
+                    "publication_date": "2026-08-17",
+                    "section": "MAT",
+                }],
+                segment_threshold=16,
+                corpus_version="dof-full-v1",
+            )
+
+            self.assertEqual(inserted, 1)
+            repaired = conn.execute(
+                "SELECT segment_index, start_offset, end_offset, segment_text"
+                " FROM document_segments WHERE document_id = ? ORDER BY segment_index",
+                (doc_id,),
+            ).fetchall()
+            self.assertEqual(
+                repaired,
+                [
+                    (0, 0, 16, "á" * 16),
+                    (1, 16, 32, "á" * 16),
+                    (2, 32, 40, "á" * 8),
+                ],
+            )
+            conn.close()
+
     def test_html_download_is_quarantined_for_redownload(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -226,7 +349,11 @@ class DailyUpdateTests(unittest.TestCase):
     def test_sidof_notices_checked_when_page_has_no_word_links(self):
         session = mock.Mock()
         response = mock.Mock()
-        response.text = "<html><body>sin documentos</body></html>"
+        response.text = (
+            "<html><head><title>DOF - Diario Oficial de la Federación</title></head>"
+            "<body><div id='cuerpo_principal'>"
+            "No hay datos para la fecha seleccionada</div></body></html>"
+        )
         response.raise_for_status = lambda: None
         session.get.return_value = response
         with tempfile.TemporaryDirectory() as temporary:
@@ -239,7 +366,49 @@ class DailyUpdateTests(unittest.TestCase):
         self.assertEqual(downloaded, 0)
         notices.assert_called_once()
 
-    def test_chunk_checkpoint_is_keyed_by_chunker_version(self):
+    def test_malformed_empty_listing_is_an_error(self):
+        session = mock.Mock()
+        response = mock.Mock()
+        response.text = "<html><title>500 error</title><body></body></html>"
+        response.raise_for_status = lambda: None
+        session.get.return_value = response
+        with tempfile.TemporaryDirectory() as temporary:
+            with (
+                mock.patch.object(get_word_dof, "ERROR_COUNT", 0),
+                mock.patch.object(
+                    get_word_dof, "process_sidof_notices", return_value=0
+                ) as notices,
+            ):
+                downloaded = get_word_dof.process_dof_page(
+                    session, "26/08/2026", "MAT", Path(temporary), sleep_delay=0
+                )
+                self.assertEqual(get_word_dof.ERROR_COUNT, 1)
+        self.assertEqual(downloaded, 0)
+        notices.assert_called_once()
+
+    def test_malformed_sidof_listing_is_an_error(self):
+        session = mock.Mock()
+        response = mock.Mock()
+        response.text = "<html><title>500 error</title><body></body></html>"
+        response.raise_for_status = lambda: None
+        session.get.return_value = response
+        with (
+            tempfile.TemporaryDirectory() as temporary,
+            mock.patch.object(get_word_dof, "ERROR_COUNT", 0),
+        ):
+            downloaded = get_word_dof.process_sidof_notices(
+                session,
+                "26",
+                "08",
+                "2026",
+                "MAT",
+                Path(temporary),
+                sleep_delay=0,
+            )
+            self.assertEqual(get_word_dof.ERROR_COUNT, 1)
+        self.assertEqual(downloaded, 0)
+
+    def test_chunk_store_rejects_a_mixed_chunker_version(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
             corpus_db = root / "corpus.sqlite"
@@ -280,7 +449,10 @@ class DailyUpdateTests(unittest.TestCase):
                 "--chunks-db", str(chunks_db),
             ]
             with mock.patch.object(sys, "argv", argv):
-                chunk_index.main()
+                with self.assertRaisesRegex(
+                    RuntimeError, "Rebuild the chunk, vector, and vec0 stores"
+                ):
+                    chunk_index.main()
 
             check = sqlite3.connect(chunks_db)
             versions = dict(
@@ -289,10 +461,207 @@ class DailyUpdateTests(unittest.TestCase):
                 ).fetchall()
             )
             check.close()
-            # Only an old-version chunk existed, so the checkpoint is 0 and
-            # the document is re-chunked under the current version.
+            # The incompatible row is preserved, but no current-version rows
+            # or vectors can be mixed into this store.
             self.assertEqual(versions["old-version"], 1)
-            self.assertGreaterEqual(versions[chunk_index.CHUNKER_VERSION], 1)
+            self.assertNotIn(chunk_index.CHUNKER_VERSION, versions)
+
+    def test_repaired_document_rebuilds_chunks_below_checkpoint(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            corpus_db = root / "corpus.sqlite"
+            chunks_db = root / "chunks.sqlite"
+            markdown = "repaired document content long enough to align"
+
+            corpus = sqlite3.connect(corpus_db)
+            corpus.executescript(SCHEMA)
+            corpus.execute(
+                "INSERT INTO corpus_meta(key, value) VALUES ('corpus_version', 'v1')"
+            )
+            corpus.execute(
+                "INSERT INTO documents(path, year, publication_date, section, markdown,"
+                " byte_length, sha256, corpus_version) VALUES"
+                " ('2026/08/26082026/MAT/001.md', 2026, '2026-08-26', 'MAT',"
+                " ?, ?, ?, 'v1')",
+                (
+                    markdown,
+                    len(markdown.encode()),
+                    hashlib.sha256(markdown.encode()).digest(),
+                ),
+            )
+            corpus.execute(
+                "INSERT INTO document_repairs"
+                " (document_id, repaired_sha256, previous_markdown,"
+                " fts_pending, chunks_pending) VALUES (1, ?, 'stale', 0, 1)",
+                (hashlib.sha256(markdown.encode()).digest(),),
+            )
+            corpus.commit()
+            corpus.close()
+
+            chunks = sqlite3.connect(chunks_db)
+            chunks.executescript(chunk_index.SCHEMA)
+            chunks.execute(
+                "INSERT INTO chunks (chunk_id, document_id, path, chunk_index, pattern,"
+                " start_offset, end_offset, spans_json, token_count, heading_path,"
+                " chunk_hash, chunker_version, corpus_version) VALUES"
+                " (10, 1, 'stale', 0, 'PLAIN', 0, 5, '[]', 1, '[]', ?, ?, 'v1')",
+                (b"0" * 32, chunk_index.CHUNKER_VERSION),
+            )
+            chunks.commit()
+            chunks.close()
+
+            generated = SimpleNamespace(
+                text=markdown,
+                pattern=DocPattern.PLAIN_TEXT,
+                chunk_index=0,
+                heading_path=[],
+            )
+            argv = [
+                "chunk_index",
+                "--corpus-db", str(corpus_db),
+                "--chunks-db", str(chunks_db),
+            ]
+            with (
+                mock.patch.object(sys, "argv", argv),
+                mock.patch.object(chunk_index, "split_text", return_value=[generated]),
+                mock.patch.object(chunk_index, "_count_tokens", return_value=6),
+            ):
+                chunk_index.main()
+
+            check = sqlite3.connect(chunks_db)
+            current = check.execute(
+                "SELECT chunk_id, path, chunk_hash FROM chunks WHERE document_id = 1"
+            ).fetchone()
+            self.assertGreater(current[0], 10)
+            self.assertEqual(current[1], "2026/08/26082026/MAT/001.md")
+            self.assertEqual(current[2], hashlib.sha256(markdown.encode()).digest())
+            self.assertEqual(
+                check.execute(
+                    "SELECT chunk_id FROM chunk_vector_invalidations"
+                ).fetchall(),
+                [(10,)],
+            )
+            check.close()
+            corpus = sqlite3.connect(corpus_db)
+            self.assertEqual(
+                corpus.execute(
+                    "SELECT chunks_pending FROM document_repairs WHERE document_id = 1"
+                ).fetchone()[0],
+                0,
+            )
+            corpus.close()
+
+    def test_repaired_document_replaces_stale_fts_tokens(self):
+        conn = sqlite3.connect(":memory:")
+        conn.executescript(SCHEMA)
+        new_text = "newtoken repaired publication"
+        conn.execute(
+            "INSERT INTO documents(path, year, publication_date, section, markdown,"
+            " byte_length, sha256, corpus_version) VALUES"
+            " ('x.md', 2026, '2026-08-26', 'MAT', ?, ?, ?, 'v1')",
+            (new_text, len(new_text), hashlib.sha256(new_text.encode()).digest()),
+        )
+        conn.execute(
+            "INSERT INTO document_repairs"
+            " (document_id, repaired_sha256, previous_markdown,"
+            " fts_pending, chunks_pending) VALUES (1, ?, 'oldtoken stale', 1, 0)",
+            (hashlib.sha256(new_text.encode()).digest(),),
+        )
+        conn.execute(FTS_DDL)
+        conn.execute(
+            "INSERT INTO documents_fts(rowid, markdown) VALUES (1, 'oldtoken stale')"
+        )
+        conn.commit()
+
+        repaired, newly_indexed = repair_fts_documents(conn)
+
+        self.assertEqual((repaired, newly_indexed), (1, 0))
+        self.assertEqual(
+            conn.execute(
+                "SELECT COUNT(*) FROM documents_fts"
+                " WHERE documents_fts MATCH 'oldtoken'"
+            ).fetchone()[0],
+            0,
+        )
+        self.assertEqual(
+            conn.execute(
+                "SELECT COUNT(*) FROM documents_fts"
+                " WHERE documents_fts MATCH 'newtoken'"
+            ).fetchone()[0],
+            1,
+        )
+        self.assertEqual(
+            conn.execute(
+                "SELECT previous_markdown, fts_pending FROM document_repairs"
+            ).fetchone(),
+            (None, 0),
+        )
+        conn.close()
+
+    def test_chunk_and_vec0_deletion_queues_are_consumed(self):
+        chunks = sqlite3.connect(":memory:")
+        chunks.executescript(chunk_index.SCHEMA)
+        chunks.execute(
+            "INSERT INTO chunk_vector_invalidations(chunk_id) VALUES (7)"
+        )
+        vectors = sqlite3.connect(":memory:")
+        vectors.executescript(VECTOR_SCHEMA)
+        vectors.execute(
+            "INSERT INTO chunk_vectors(chunk_id, embedding) VALUES (7, ?)",
+            (b"x" * 128,),
+        )
+
+        self.assertEqual(apply_chunk_vector_invalidations(chunks, vectors), 1)
+        self.assertEqual(vectors.execute("SELECT COUNT(*) FROM chunk_vectors").fetchone()[0], 0)
+        self.assertEqual(vectors.execute("SELECT chunk_id FROM vector_deletions").fetchall(), [(7,)])
+        self.assertEqual(chunks.execute("SELECT COUNT(*) FROM chunk_vector_invalidations").fetchone()[0], 0)
+
+        vec0 = sqlite3.connect(":memory:")
+        vec0.enable_load_extension(True)
+        sqlite_vec.load(vec0)
+        vec0.execute(VEC0_DDL)
+        vec0.execute(
+            "INSERT INTO chunk_vec(rowid, embedding) VALUES (7, vec_bit(?))",
+            (b"x" * 128,),
+        )
+        vectors.execute(DELETIONS_DDL)
+        vectors.commit()
+
+        self.assertEqual(apply_vector_deletions(vec0, vectors), 1)
+        self.assertEqual(vec0.execute("SELECT COUNT(*) FROM chunk_vec").fetchone()[0], 0)
+        self.assertEqual(vectors.execute("SELECT COUNT(*) FROM vector_deletions").fetchone()[0], 0)
+        vec0.close()
+        vectors.close()
+        chunks.close()
+
+    def test_launchd_renderer_preserves_spaces_and_xml_characters(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            output = root / "rendered.plist"
+            runner = root / "Application Support/DOF & RAG/run.sh"
+            repository = root / "DOF & RAG/repo"
+            subprocess.run(
+                [
+                    "zsh",
+                    "scripts/install_dof_launchd.sh",
+                    "--render-plist",
+                    str(output),
+                    str(runner),
+                    str(repository),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            with output.open("rb") as stream:
+                payload = plistlib.load(stream)
+            self.assertEqual(payload["ProgramArguments"][5], str(runner))
+            self.assertEqual(
+                payload["EnvironmentVariables"]["DOF_REPO_DIR"], str(repository)
+            )
+            self.assertEqual(
+                payload["StandardOutPath"], str(repository / "logs/dof-daily.log")
+            )
 
     def test_full_manifest_is_initial_contiguous_watermark(self):
         with tempfile.TemporaryDirectory() as temporary:
@@ -310,6 +679,16 @@ class DailyUpdateTests(unittest.TestCase):
             self.assertEqual(
                 last_jsonl_record(manifest), {"publication_date": "2026-04-24"}
             )
+
+    def test_historical_window_never_moves_watermark_backward(self):
+        self.assertEqual(
+            non_regressing_watermark(date(2026, 8, 28), date(2026, 8, 27)),
+            date(2026, 8, 28),
+        )
+        self.assertEqual(
+            non_regressing_watermark(date(2026, 8, 27), date(2026, 8, 28)),
+            date(2026, 8, 28),
+        )
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -3102,14 +3102,14 @@ wheels = [
 
 [[package]]
 name = "sqlite-vec"
-version = "0.1.6"
+version = "0.1.9"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/ed/aabc328f29ee6814033d008ec43e44f2c595447d9cccd5f2aabe60df2933/sqlite_vec-0.1.6-py3-none-macosx_10_6_x86_64.whl", hash = "sha256:77491bcaa6d496f2acb5cc0d0ff0b8964434f141523c121e313f9a7d8088dee3", size = 164075, upload-time = "2024-11-20T16:40:29.847Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/57/05604e509a129b22e303758bfa062c19afb020557d5e19b008c64016704e/sqlite_vec-0.1.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fdca35f7ee3243668a055255d4dee4dea7eed5a06da8cad409f89facf4595361", size = 165242, upload-time = "2024-11-20T16:40:31.206Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/48/dbb2cc4e5bad88c89c7bb296e2d0a8df58aab9edc75853728c361eefc24f/sqlite_vec-0.1.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b0519d9cd96164cd2e08e8eed225197f9cd2f0be82cb04567692a0a4be02da3", size = 103704, upload-time = "2024-11-20T16:40:33.729Z" },
-    { url = "https://files.pythonhosted.org/packages/80/76/97f33b1a2446f6ae55e59b33869bed4eafaf59b7f4c662c8d9491b6a714a/sqlite_vec-0.1.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux1_x86_64.whl", hash = "sha256:823b0493add80d7fe82ab0fe25df7c0703f4752941aee1c7b2b02cec9656cb24", size = 151556, upload-time = "2024-11-20T16:40:35.387Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/98/e8bc58b178266eae2fcf4c9c7a8303a8d41164d781b32d71097924a6bebe/sqlite_vec-0.1.6-py3-none-win_amd64.whl", hash = "sha256:c65bcfd90fa2f41f9000052bcb8bb75d38240b2dae49225389eca6c3136d3f0c", size = 281540, upload-time = "2024-11-20T16:40:37.296Z" },
+    { url = "https://files.pythonhosted.org/packages/68/85/9fad0045d8e7c8df3e0fa5a56c630e8e15ad6e5ca2e6106fceb666aa6638/sqlite_vec-0.1.9-py3-none-macosx_10_6_x86_64.whl", hash = "sha256:1b62a7f0a060d9475575d4e599bbf94a13d85af896bc1ce86ee80d1b5b48e5fb", size = 131171, upload-time = "2026-03-31T08:02:31.717Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/3d/3677e0cd2f92e5ebc43cd29fbf565b75582bff1ccfa0b8327c7508e1084f/sqlite_vec-0.1.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1d52e30513bae4cc9778ddbf6145610434081be4c3afe57cd877893bad9f6b6c", size = 165434, upload-time = "2026-03-31T08:02:32.712Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d4/f2b936d3bdc38eadcbd2a87875815db36430fab0363182ba5d12cd8e0b51/sqlite_vec-0.1.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e921e592f24a5f9a18f590b6ddd530eb637e2d474e3b1972f9bbeb773aa3cb9", size = 160076, upload-time = "2026-03-31T08:02:33.796Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ad/6afd073b0f817b3e03f9e37ad626ae341805891f23c74b5292818f49ac63/sqlite_vec-0.1.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux1_x86_64.whl", hash = "sha256:1515727990b49e79bcaf75fdee2ffc7d461f8b66905013231251f1c8938e7786", size = 163388, upload-time = "2026-03-31T08:02:34.888Z" },
+    { url = "https://files.pythonhosted.org/packages/42/89/81b2907cda14e566b9bf215e2ad82fc9b349edf07d2010756ffdb902f328/sqlite_vec-0.1.9-py3-none-win_amd64.whl", hash = "sha256:4a28dc12fa4b53d7b1dced22da2488fade444e96b5d16fd2d698cd670675cf32", size = 292804, upload-time = "2026-03-31T08:02:36.035Z" },
 ]
 
 [[package]]

--- a/word_validation.py
+++ b/word_validation.py
@@ -1,0 +1,27 @@
+"""Validation helpers for downloaded Microsoft Word payloads."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+MIN_FILE_SIZE = 1024
+WORD_SIGNATURES = (
+    b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1",  # OLE Compound File (.doc)
+    b"PK\x03\x04",  # OOXML ZIP container (.docx)
+)
+
+
+def is_valid_word_payload(content: bytes) -> bool:
+    """Return whether bytes have a supported Word signature and size."""
+    return len(content) >= MIN_FILE_SIZE and content.startswith(WORD_SIGNATURES)
+
+
+def is_valid_word_file(path: Path) -> bool:
+    """Validate a Word file without reading the whole payload into memory."""
+    try:
+        if path.stat().st_size < MIN_FILE_SIZE:
+            return False
+        with path.open("rb") as stream:
+            return stream.read(8).startswith(WORD_SIGNATURES)
+    except OSError:
+        return False


### PR DESCRIPTION
## Summary
- add a resumable macOS `launchd` pipeline for downloading, converting, ingesting, and indexing newly published DOF documents
- validate DOF/SIDOF listings and Word payload signatures before a date can advance the contiguous completion watermark
- scope conversion and manifests to the active date window
- make FTS5 and chunk generation incrementally append newly ingested documents while keeping the existing resumable embedding and vec0 appenders
- reject mixed chunker versions instead of silently combining incompatible derived stores

## Scope
The daily updater is intentionally append-only. Existing same-path documents and historical corpus-row repair are outside this PR; those operations require an explicit offline migration or a separately designed derived-index reconciliation mechanism.

## Validation
- `UV_CACHE_DIR=/tmp/codex-uv-cache uv run python -m unittest discover -s tests -q` (160 passed)
- Ruff passes for `human_eval`, `tests`, and all changed Python files
- launchd plist lint and shell syntax checks pass
- updater dry-run resolves the current catch-up window successfully
- `git diff --check` passes

## Size after re-scope
12 changed files, 1,193 additions, and 83 deletions. The repair ledger, chunk/vector deletion queues, and repair-specific changes to ingestion, embeddings, and vec0 were removed from this PR.