### PR TITLE
Add shared SQLite model admission

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,9 @@ uv run python -m human_eval.app  # http://127.0.0.1:8765
 ```
 
 También se puede usar un modelo local mediante un servidor compatible con la
-API de OpenAI. La configuración probada en Apple Silicon usa Qwen3.8-27B con
+API de OpenAI. Los comandos siguientes son ejemplos de desarrollo y benchmark;
+el servidor operativo del proyecto se configura en su propia máquina. La
+configuración probada en Apple Silicon usa Qwen3.8-27B con
 llama.cpp `llama-server`: un solo slot, 32K de contexto y razonamiento
 conservado entre turnos de herramientas.
 

--- a/README.md
+++ b/README.md
@@ -226,6 +226,12 @@ uv run python -m human_eval.app
   con `uv run python -m human_eval.app --workers 4`. Todos deben usar el mismo
   `DOF_HUMAN_EVAL_DB`; SQLite en modo WAL coordina la cola y los leases, y el
   límite global sigue siendo `DOF_MODEL_CONCURRENCY`, no cuatro veces ese valor.
+- Todos los procesos web que comparten la base deben usar **la misma
+  configuración de scheduler**: `DOF_MODEL_CONCURRENCY`, `DOF_QUEUE_CAPACITY` y
+  `DOF_MODEL_LEASE_SECONDS`. El scheduler no valida que coincidan: cada proceso
+  aplica sus propios valores al reclamar slots y admitir preguntas, así que si
+  difieren, el límite efectivo global es el mayor de ellos (y las estimaciones
+  de espera y la capacidad de cola se vuelven inconsistentes entre procesos).
 - Con varios procesos web, ejecuta el servidor de embeddings una sola vez y
   configura `DOF_MANAGE_EMBED_SERVER=false` en la aplicación. Por ejemplo:
   `llama-server -m ~/dof-gguf/jina-v5-small-retrieval-F16.gguf --embedding

--- a/README.md
+++ b/README.md
@@ -186,6 +186,15 @@ llama-server -hf unsloth/Qwen3.8-27B-GGUF:UD-Q4_K_M \
   --jinja --alias qwen3.8 --reasoning-preserve -c 32768 -np 1
 ```
 
+`-np` es la capacidad de inferencia del servidor. La aplicación la refleja en
+`DOF_MODEL_CONCURRENCY`; ambos valores deben ser iguales y deben fijarse por
+equipo después de medir memoria y latencia. Por ejemplo, usa `1` en un M3 de
+32 GB y usa `3` o `4` en DGX Spark sólo si esa configuración pasa el benchmark.
+`DOF_QUEUE_CAPACITY` limita las preguntas esperando, no las que ya están en
+inferencia. La cola y los slots se coordinan en `var/human_evaluation.sqlite`,
+por lo que varias aplicaciones web en la misma máquina comparten la misma
+capacidad.
+
 Qwen3.8 usa razonamiento `xhigh` por defecto. El agente envía
 `reasoning_effort=low` en cada petición para evitar sobre-razonamiento en el
 bucle de hasta ocho turnos; se puede cambiar con `DOF_REASONING_EFFORT` a
@@ -203,6 +212,7 @@ Con el servidor escuchando en `http://127.0.0.1:8080/` (verifica el id con
 set -a; source .env; set +a
 export DOF_AGENT_PROVIDER=llama-server DOF_AGENT_MODEL=qwen3.8 \
   DOF_REASONING_EFFORT=low DOF_RETRIEVAL_MODE=hybrid \
+  DOF_MODEL_CONCURRENCY=1 DOF_QUEUE_CAPACITY=4 \
   DOF_WEB_HOST=0.0.0.0 DOF_WEB_PORT=8765
 uv run python -m human_eval.app
 ```
@@ -212,6 +222,15 @@ uv run python -m human_eval.app
   modo `hybrid` usa `DOF_EMBED_PORT` (8086 por defecto). Pueden correr a la vez,
   pero la aplicación rechaza configuraciones donde ambos intenten usar el mismo
   puerto local.
+- Para ejecutar varios procesos web en una sola máquina, inicia la aplicación
+  con `uv run python -m human_eval.app --workers 4`. Todos deben usar el mismo
+  `DOF_HUMAN_EVAL_DB`; SQLite en modo WAL coordina la cola y los leases, y el
+  límite global sigue siendo `DOF_MODEL_CONCURRENCY`, no cuatro veces ese valor.
+- Con varios procesos web, ejecuta el servidor de embeddings una sola vez y
+  configura `DOF_MANAGE_EMBED_SERVER=false` en la aplicación. Por ejemplo:
+  `llama-server -m ~/dof-gguf/jina-v5-small-retrieval-F16.gguf --embedding
+  --host 127.0.0.1 --port 8086 -c 8192`. Así cada proceso consulta el servidor
+  compartido sin intentar abrir de nuevo el puerto 8086.
 
 - Visitantes anónimos leen las respuestas publicadas. Con cuenta: 1 pregunta cada 24 h (`DOF_DAILY_QUESTION_LIMIT`) y hay que evaluar una respuesta publicada antes de cada pregunta, incluida la primera. Los administradores publican y despublican en `/admin/queue` (rol vía `public_metadata.role = "admin"` en el dashboard de Clerk).
 - Recuperación híbrida para preguntas en vivo: `DOF_RETRIEVAL_MODE=hybrid` (requiere el índice vec0 y `DOF_GGUF_MODEL`; el servidor de embeddings llama-server se levanta una sola vez por proceso, con `DOF_EMBED_PORT`, por defecto 8086).

--- a/agent_tools/retrieval.py
+++ b/agent_tools/retrieval.py
@@ -207,7 +207,14 @@ class QueryEmbedder(Protocol):
 class LlamaQueryEmbedder:
     """Keep one local llama-server alive for an interactive session."""
 
-    def __init__(self, gguf: Path, *, port: int = 8086, ctx: int = 8192):
+    def __init__(
+        self,
+        gguf: Path,
+        *,
+        port: int = 8086,
+        ctx: int = 8192,
+        manage_server: bool = True,
+    ):
         from corpus_store.embed import (
             DIMS,
             PREFIX_QUERY,
@@ -217,9 +224,10 @@ class LlamaQueryEmbedder:
         )
 
         self.port = port
+        self._manage_server = manage_server
         self._lock = threading.Lock()
         self._closed = False
-        process = start_server(gguf, ctx=ctx, port=port)
+        process = start_server(gguf, ctx=ctx, port=port) if manage_server else None
         try:
             probe = embed_batch([PREFIX_QUERY + "probe"], port)
             if probe.shape != (1, DIMS):
@@ -228,10 +236,12 @@ class LlamaQueryEmbedder:
                     f"expected (1, {DIMS})"
                 )
         except BaseException:
-            stop_server(process)
+            if process is not None:
+                stop_server(process)
             raise
         self.process = process
-        atexit.register(self.close)
+        if self._manage_server:
+            atexit.register(self.close)
 
     def embed_query(self, query: str) -> bytes:
         from corpus_store.embed import PREFIX_QUERY, embed_batch, pack_binary
@@ -249,8 +259,10 @@ class LlamaQueryEmbedder:
             if self._closed:
                 return
             self._closed = True
-            atexit.unregister(self.close)
-            stop_server(self.process)
+            if self._manage_server:
+                atexit.unregister(self.close)
+                assert self.process is not None
+                stop_server(self.process)
 
     def __enter__(self) -> "LlamaQueryEmbedder":
         return self

--- a/docs/human-evaluation-ui-plan.md
+++ b/docs/human-evaluation-ui-plan.md
@@ -9,7 +9,7 @@ deben actualizarlo en el mismo cambio de código.
 - El sitio de evaluación vive por completo en `dof-rag`; no depende de
   `dof-rag-website`, Astro, GitHub Pages ni su `base` path.
 - Se usa una aplicación Python de mismo origen con Air, HTML progresivo y una
-  cola local. Air se fija en `0.35.0`, última versión compatible con el Python
+  cola SQLite compartida entre procesos del mismo nodo. Air se fija en `0.35.0`, última versión compatible con el Python
   3.12 administrado por el proyecto; versiones posteriores requieren Python
   3.13.
 - Sí se guardan las preguntas y las respuestas. Sin ese par no sería posible
@@ -40,7 +40,9 @@ Incluye:
 - snapshot por ejecución de código, corpus, chunks, índice, modelo y
   configuración;
 - historial reciente del mismo evaluador;
-- operación inicial desde la MacBook Pro actual con un solo worker.
+- operación inicial desde la MacBook Pro actual con un worker por defecto;
+  varios procesos web en el mismo nodo son compatibles cuando comparten la
+  base SQLite de evaluación.
 
 ## Fuera del MVP
 
@@ -52,7 +54,8 @@ Incluye:
   argumentos de herramientas;
 - acceso directo del navegador a SQLite;
 - streaming token a token o de razonamiento privado, cancelación fuerte de una
-  llamada ya enviada al proveedor, múltiples workers o alta disponibilidad;
+  llamada ya enviada al proveedor, alta disponibilidad o coordinación entre
+  varios nodos;
 - búsqueda web o fuentes distintas del corpus DOF;
 - integrar la UI en Astro durante el MVP. El sitio público podría enlazar a la
   app más adelante, pero no forma parte de su ruta de ejecución.
@@ -66,7 +69,7 @@ Navegador
 Aplicación Air en dof-rag
   - UI y rutas HTTP en human_eval/app.py
   - sesión, CSRF, validación y límites
-  - EvaluationService + cola local, 1 worker
+  - EvaluationService + cola SQLite compartida, slots y leases transaccionales
   - SQLite de evaluación separado
   |
   v
@@ -88,11 +91,13 @@ no sustituyen una cola recuperable. `EvaluationService` responde rápido con un
 quedaron en cola. Una ejecución que estaba iniciada se marca fallida al
 reiniciar, porque no puede saberse si la llamada externa terminó.
 
-El MVP admite exactamente un proceso web y un worker. Dentro de ese proceso,
-un bloqueo de ciclo de vida hace atómica la decisión `has_active_run` +
-`create_run` para cada evaluador. Esa garantía no se extiende a varios procesos;
-escalar horizontalmente requerirá mover admisión y cola a una transacción o
-servicio compartido.
+El servicio admite varios procesos web en una misma máquina. La cola persistente
+y los slots de inferencia se coordinan en SQLite con WAL: una transacción de
+admisión impide exceder la cola global y una transacción de claim asigna cada
+ejecución a un único slot con lease. Los procesos web pueden multiplicarse para
+mantener responsivos HTTP y SSE, pero la concurrencia real del modelo sigue
+siendo el valor configurado en `DOF_MODEL_CONCURRENCY`. SQLite sigue siendo una
+solución de un nodo; varios nodos requerirán un servicio compartido.
 
 ## Contrato HTTP v1
 
@@ -340,8 +345,8 @@ incompleta; continúa siendo evaluable.
   fechas, enums y campos. El navegador nunca controla rutas de bases o
   parámetros arbitrarios.
 - Límites iniciales: una ejecución activa por evaluador, diez creaciones por
-  hora, cola global de veinte y un worker. Turnos y llamadas a herramientas
-  también están acotados en el backend.
+  hora, cola global de veinte y concurrencia de modelo configurable. Turnos y
+  llamadas a herramientas también están acotados en el backend.
 - Las ejecuciones solo son visibles para el hash de evaluador propietario. Los
   endpoints públicos de salud/capacidades no incluyen rutas locales ni secretos.
 - El stream exige la misma sesión y propiedad, lleva `no-store`, se puede
@@ -501,8 +506,9 @@ La procedencia separa `vector_available` (el artefacto existe en disco) de
   Python 3.13, mantener 0.35 o sustituir solo la capa web.
 - Exponer la MacBook requiere elegir túnel/proxy, dominio, supervisor y política
   de actualización antes de invitar evaluadores.
-- La cola y el rate limit son locales y se reinician con el proceso; son
-  suficientes para un piloto de un nodo, no para varios procesos.
+- La cola y los leases son persistentes y compartidos entre procesos en un
+  nodo. No se debe colocar esta base en un sistema de archivos de red ni usarla
+  como coordinador entre varios nodos.
 - Falta incorporar una verificación mínima del MVP a GitHub Actions; se mantiene
   como trabajo posterior para no mezclar infraestructura de CI con este PR.
 - Deben fijarse presupuesto por modelo, timeout efectivo y respuesta ante cuota

--- a/docs/human-evaluation-ui-plan.md
+++ b/docs/human-evaluation-ui-plan.md
@@ -358,11 +358,12 @@ incompleta; continúa siendo evaluable.
 
 ## Despliegue previsto
 
-El MVP se ejecutará en la MacBook Pro actual, ligado inicialmente a
-`127.0.0.1:8765`. La UI y el backend se publican como una sola app ASGI. Para
-pruebas humanas remotas se colocará delante un túnel o reverse proxy HTTPS que
-termine TLS, limite cuerpos, no almacene en buffer SSE y use un hostname estable;
-todavía debe elegirse el proveedor.
+La MacBook Pro actual es un entorno de desarrollo y pruebas; no es el servidor
+de producción. El despliegue operativo se hará en la máquina de servidor
+configurada para el proyecto, ligada inicialmente a `127.0.0.1:8765` detrás de
+un túnel o reverse proxy HTTPS que termine TLS, limite cuerpos, no almacene en
+buffer SSE y use un hostname estable. La UI y el backend se publican como una
+sola app ASGI.
 
 Configuración mínima, con valores de ejemplo que no deben guardarse en Git:
 
@@ -504,8 +505,8 @@ La procedencia separa `vector_available` (el artefacto existe en disco) de
 - Air sigue evolucionando y la versión compatible con Python 3.12 no es la más
   reciente. Se debe decidir después del piloto si migrar todo el proyecto a
   Python 3.13, mantener 0.35 o sustituir solo la capa web.
-- Exponer la MacBook requiere elegir túnel/proxy, dominio, supervisor y política
-  de actualización antes de invitar evaluadores.
+- Exponer el servidor de producción requiere elegir túnel/proxy, dominio,
+  supervisor y política de actualización antes de invitar evaluadores.
 - La cola y los leases son persistentes y compartidos entre procesos en un
   nodo. No se debe colocar esta base en un sistema de archivos de red ni usarla
   como coordinador entre varios nodos.

--- a/docs/production-roadmap.md
+++ b/docs/production-roadmap.md
@@ -98,11 +98,13 @@ Con 403 segundos por una pregunta, un solo slot atendería como máximo unas nue
 preguntas similares por hora, antes de considerar pausas, preguntas más
 difíciles o errores. La beta debe asumir poca concurrencia desde el principio.
 
-La aplicación ya persiste las corridas en SQLite y vuelve a encolar las que no
-habían empezado después de un reinicio. Para un solo proceso, esto nos da una
-base suficiente. Lo siguiente es:
+La aplicación persiste las corridas en SQLite. La admisión y los slots de
+inferencia ahora pueden compartirse entre varios procesos web en una misma
+máquina mediante claims y leases transaccionales; SQLite sigue siendo una
+coordinación de un solo nodo. Lo siguiente es:
 
-- fijar una capacidad global y mantener una sola pregunta activa por usuario;
+- fijar una capacidad global (`DOF_MODEL_CONCURRENCY`) independiente del número
+  de procesos web y mantener una sola pregunta activa por usuario;
 - limitar el largo de la cola y responder con `Retry-After` cuando se llene;
 - mostrar posición y espera aproximada en la interfaz;
 - distinguir tiempo en cola de tiempo de inferencia;
@@ -121,9 +123,9 @@ separa la espera en cola del tiempo de procesamiento usando las marcas de
 timeouts por turno y por corrida, la detección del modelo caído antes de admitir
 y la pausa administrativa de admisión.
 
-Leases, reclamo atómico entre procesos y una base distinta a SQLite serán
-necesarios si llegamos a operar varios workers. No hacen falta para la primera
-beta en una sola máquina.
+Para varios nodos necesitaremos un coordinador distinto a SQLite. Para varios
+workers en una sola máquina, los leases y el reclamo atómico ya mantienen una
+cola global y una capacidad de modelo global.
 
 ### 4. Preparar una beta que podamos operar
 
@@ -185,8 +187,8 @@ inferencia. Eso permite cambiar una pieza sin rehacer el proyecto.
 1. Un reporte reproducible con 10 a 20 preguntas y métricas por turno.
 2. Resultados de herramientas compactos, con comparación antes/después en
    tokens, latencia y calidad.
-3. Admisión con capacidad global, cola visible, `Retry-After` y métricas de
-   espera.
+3. Métricas de capacidad global, recuperación de leases y una línea de
+   operación para varios procesos web.
 
 Después de esos tres trabajos podremos fijar una concurrencia inicial y abrir
 una beta pequeña con datos, no con estimaciones.

--- a/docs/production-roadmap.md
+++ b/docs/production-roadmap.md
@@ -173,8 +173,7 @@ HTML que contenga identidad o CSRF.
 
 - **Air/FastAPI, Go o Elixir:** sólo si Air limita middleware, mantenimiento u
   observabilidad. La primera medición no apunta al servidor web.
-- **PostgreSQL:** cuando haya varios procesos o contención comprobada en
-  SQLite.
+- **PostgreSQL:** cuando haya varios nodos o contención comprobada en SQLite.
 - **Redis:** cuando necesitemos pub/sub o caché compartido entre procesos.
 - **Más hardware o una API externa:** cuando conozcamos la capacidad y la cola
   real del equipo disponible.

--- a/docs/production-roadmap.md
+++ b/docs/production-roadmap.md
@@ -111,6 +111,16 @@ base suficiente. Lo siguiente es:
 - conservar una forma administrativa de pausar admisión sin apagar las páginas
   publicadas.
 
+**Avance del 26 de agosto de 2026.** Ya existían la capacidad de cola (20),
+la respuesta 503 al llenarse, una sola ejecución activa por usuario y la cuota
+diaria. Ahora la respuesta 503 incluye `Retry-After` calculado con la duración
+reciente de las corridas; la interfaz muestra la posición en la cola y una
+espera aproximada mientras la pregunta está encolada; y cada respuesta terminada
+separa la espera en cola del tiempo de procesamiento usando las marcas de
+`run_events`, sin instrumentación nueva. Quedan pendientes de este apartado los
+timeouts por turno y por corrida, la detección del modelo caído antes de admitir
+y la pausa administrativa de admisión.
+
 Leases, reclamo atómico entre procesos y una base distinta a SQLite serán
 necesarios si llegamos a operar varios workers. No hacen falta para la primera
 beta en una sola máquina.

--- a/human_eval/agent_executor.py
+++ b/human_eval/agent_executor.py
@@ -56,6 +56,8 @@ class AgentExecutorConfig:
     reasoning_effort: str | None = "low"
     max_model_turns: int = 8
     max_tool_calls: int = 8
+    model_concurrency: int = 1
+    manage_embed_server: bool = True
     retrieval_mode: str = "lexical"
     base_url: str | None = None
 
@@ -100,6 +102,14 @@ class AgentExecutorConfig:
         embed_port = int(os.environ.get("DOF_EMBED_PORT", "8086"))
         if not 1 <= embed_port <= 65535:
             raise ValueError("DOF_EMBED_PORT must be between 1 and 65535")
+        model_concurrency = int(os.environ.get("DOF_MODEL_CONCURRENCY", "1"))
+        if model_concurrency < 1:
+            raise ValueError("DOF_MODEL_CONCURRENCY must be positive")
+        manage_embed_server_value = os.environ.get(
+            "DOF_MANAGE_EMBED_SERVER", "true"
+        ).lower()
+        if manage_embed_server_value not in {"1", "0", "true", "false", "yes", "no"}:
+            raise ValueError("DOF_MANAGE_EMBED_SERVER must be a boolean")
         base_url = os.environ.get("DOF_AGENT_BASE_URL")
         if provider == "llama-server" and retrieval_mode != "lexical":
             host, agent_port = _endpoint_port(
@@ -126,6 +136,8 @@ class AgentExecutorConfig:
             reasoning_effort=os.environ.get("DOF_REASONING_EFFORT", "low") or None,
             max_model_turns=int(os.environ.get("DOF_MAX_MODEL_TURNS", "8")),
             max_tool_calls=int(os.environ.get("DOF_MAX_TOOL_CALLS", "8")),
+            model_concurrency=model_concurrency,
+            manage_embed_server=manage_embed_server_value in {"1", "true", "yes"},
             retrieval_mode=retrieval_mode,
             base_url=base_url,
         )
@@ -218,8 +230,11 @@ class AgentRunExecutor:
                         "provider_unavailable",
                         "El modelo de embeddings no está disponible.",
                     )
+                embedder_kwargs: dict[str, Any] = {"port": self.config.embed_port}
+                if not self.config.manage_embed_server:
+                    embedder_kwargs["manage_server"] = False
                 self._embedder = LlamaQueryEmbedder(
-                    self.config.gguf_model, port=self.config.embed_port
+                    self.config.gguf_model, **embedder_kwargs
                 )
             return self._embedder
 
@@ -249,6 +264,8 @@ class AgentRunExecutor:
                 "retrieval_mode": self.config.retrieval_mode,
                 "max_model_turns": self.config.max_model_turns,
                 "max_tool_calls": self.config.max_tool_calls,
+                "model_concurrency": self.config.model_concurrency,
+                "manage_embed_server": self.config.manage_embed_server,
                 "reasoning_effort": self.config.reasoning_effort,
             },
         }

--- a/human_eval/app.py
+++ b/human_eval/app.py
@@ -1,4 +1,4 @@
-"""Single-process Air application for controlled human evaluation of the DOF agent.
+"""Air application for controlled human evaluation of the DOF agent.
 
 Authentication is provider-agnostic: ``create_app`` receives an
 ``auth.AuthBackend`` and never imports a provider. Production wires Clerk via
@@ -98,6 +98,9 @@ class WebSettings:
     session_max_age: int = 12 * 60 * 60
     daily_question_limit: int = 1
     queue_capacity: int = 20
+    model_concurrency: int = 1
+    scheduler_workers: int | None = None
+    model_lease_seconds: float = 120.0
 
     @classmethod
     def from_env(cls, repo_root: Path) -> "WebSettings":
@@ -128,6 +131,15 @@ class WebSettings:
             ),
             daily_question_limit=int(os.environ.get("DOF_DAILY_QUESTION_LIMIT", "1")),
             queue_capacity=int(os.environ.get("DOF_QUEUE_CAPACITY", "20")),
+            model_concurrency=int(os.environ.get("DOF_MODEL_CONCURRENCY", "1")),
+            scheduler_workers=(
+                int(os.environ["DOF_SCHEDULER_WORKERS"])
+                if os.environ.get("DOF_SCHEDULER_WORKERS")
+                else None
+            ),
+            model_lease_seconds=float(
+                os.environ.get("DOF_MODEL_LEASE_SECONDS", "120")
+            ),
         )
 
 
@@ -457,6 +469,12 @@ STREAM_SCRIPT = """
       appendProgress(list, event);
       state.textContent = 'Recibiendo actividad en vivo';
     });
+    source.addEventListener('queue', (message) => {
+      const event = JSON.parse(message.data);
+      const queueStatus = node.querySelector('[data-queue-status]');
+      if (queueStatus) queueStatus.textContent = event.message || 'Actualizando la cola…';
+      state.textContent = 'Esperando capacidad del modelo';
+    });
     source.addEventListener('terminal', async () => {
       source.close();
       state.textContent = 'Preparando el resultado…';
@@ -650,9 +668,18 @@ def _status_fragment(
                 if wait
                 else ""
             )
+            snapshot = run.get("queue_snapshot", {})
+            active = snapshot.get("active")
+            capacity = snapshot.get("capacity")
+            capacity_text = (
+                f" · {active} de {capacity} slots ocupados"
+                if active is not None and capacity is not None
+                else ""
+            )
             queue_note = (
-                f'<p class="meta">Posición en la cola: '
-                f'{_escape(run["queue_position"])}{_escape(wait_text)}</p>'
+                f'<p class="meta" data-queue-status>Posición en la cola: '
+                f'{_escape(run["queue_position"])}{_escape(wait_text)}'
+                f'{_escape(capacity_text)}</p>'
             )
         return f"""<section id="run-status" class="panel status" data-state="{state}"
 data-stream-url="/runs/{_escape(run["run_id"])}/events"
@@ -1262,7 +1289,7 @@ def create_app(
             return render_home(
                 request,
                 user,
-                error="La cola local está llena; intenta más tarde.",
+                error="La cola de preguntas está llena; intenta más tarde.",
                 values=values,
                 status_code=503,
                 headers={"Retry-After": str(service.queue_retry_after())},
@@ -1409,6 +1436,7 @@ Publicada: {_escape(run.get("published_at"))}</p></section>
         async def event_stream() -> AsyncIterator[str]:
             cursor = after
             heartbeat_at = time.monotonic()
+            last_queue_state: tuple[int, int, int] | None = None
             while True:
                 events = await asyncio.to_thread(
                     service.store.progress_for_run, run_id, after=cursor
@@ -1422,6 +1450,25 @@ Publicada: {_escape(run.get("published_at"))}</p></section>
                 run = await asyncio.to_thread(
                     service.public_run, run_id, user_id=user.id, admin=True
                 )
+                if run["status"] == "queued":
+                    snapshot = run.get("queue_snapshot", {})
+                    queue_state = (
+                        int(run.get("queue_position") or 0),
+                        int(snapshot.get("active") or 0),
+                        int(snapshot.get("capacity") or 0),
+                    )
+                    if queue_state != last_queue_state:
+                        last_queue_state = queue_state
+                        message = (
+                            f"Posición en la cola: {queue_state[0]} · "
+                            f"Espera aproximada: "
+                            f"{max(1, round((run.get('estimated_wait_seconds') or 60) / 60))} min · "
+                            f"{queue_state[1]} de {queue_state[2]} slots ocupados"
+                        )
+                        yield (
+                            "event: queue\n"
+                            f"data: {json.dumps({'message': message}, ensure_ascii=False)}\n\n"
+                        )
                 if run["status"] not in ACTIVE_STATES:
                     data = json.dumps({"status": run["status"]}, separators=(",", ":"))
                     yield f"event: terminal\ndata: {data}\n\n"
@@ -1579,6 +1626,8 @@ Publicada: {_escape(run.get("published_at"))}</p></section>
                     "required_hops": 5,
                     "questions_per_day": settings.daily_question_limit,
                     "active_runs_per_user": 1,
+                    "model_concurrency": settings.model_concurrency,
+                    "queue_capacity": settings.queue_capacity,
                 },
             }
         )
@@ -1618,12 +1667,16 @@ def build_default_app(repo_root: Path | None = None) -> tuple[Any, WebSettings]:
     from .clerk_auth import ClerkAuthBackend, clerk_login_scripts, clerk_page_scripts
 
     auth_backend = ClerkAuthBackend(secret_key=airclerk.settings.CLERK_SECRET_KEY)
-    executor = AgentRunExecutor(AgentExecutorConfig.from_env(root))
+    executor_config = AgentExecutorConfig.from_env(root)
+    executor = AgentRunExecutor(executor_config)
     service = EvaluationService(
         EvaluationStore(settings.db_path),
         executor,
         executor.provenance,
         queue_capacity=settings.queue_capacity,
+        model_concurrency=executor_config.model_concurrency,
+        scheduler_workers=settings.scheduler_workers,
+        lease_seconds=settings.model_lease_seconds,
     )
     app = create_app(
         service,
@@ -1637,12 +1690,42 @@ def build_default_app(repo_root: Path | None = None) -> tuple[Any, WebSettings]:
     return app, settings
 
 
+def create_uvicorn_app() -> Any:
+    """Uvicorn factory so every web process builds its own app lifecycle."""
+    configured_root = os.environ.get("DOF_APP_REPO_ROOT")
+    app, _ = build_default_app(Path(configured_root) if configured_root else None)
+    return app
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Serve the DOF human-evaluation site")
     parser.add_argument(
         "--repo-root", type=Path, default=Path(__file__).resolve().parent.parent
     )
+    parser.add_argument("--workers", type=int, default=1)
     args = parser.parse_args()
+    if args.workers < 1:
+        parser.error("--workers must be positive")
+    if args.workers > 1:
+        if (
+            os.environ.get("DOF_RETRIEVAL_MODE", "lexical") != "lexical"
+            and os.environ.get("DOF_MANAGE_EMBED_SERVER", "true").lower()
+            in {"1", "true", "yes"}
+        ):
+            parser.error(
+                "multiple web workers require DOF_MANAGE_EMBED_SERVER=false "
+                "and one separately managed embedding server"
+            )
+        # The factory is required for Uvicorn to create the application inside
+        # each worker process. SQLite-backed claims keep their queues shared.
+        os.environ["DOF_APP_REPO_ROOT"] = str(args.repo_root.resolve())
+        uvicorn.run(
+            "human_eval.app:create_uvicorn_app",
+            factory=True,
+            workers=args.workers,
+            access_log=False,
+        )
+        return 0
     app, settings = build_default_app(args.repo_root)
     # Questions are stored deliberately, but client IP addresses are not part
     # of the evaluation dataset. Keep Uvicorn's per-request access log off.

--- a/human_eval/app.py
+++ b/human_eval/app.py
@@ -135,6 +135,38 @@ def _escape(value: Any) -> str:
     return html.escape("" if value is None else str(value), quote=True)
 
 
+def _seconds_between(start: Any, end: Any) -> float | None:
+    """Seconds between two ISO-8601 timestamps; None when unavailable."""
+    if not isinstance(start, str) or not isinstance(end, str):
+        return None
+    try:
+        began = datetime.fromisoformat(start.replace("Z", "+00:00"))
+        finished = datetime.fromisoformat(end.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return max(0.0, (finished - began).total_seconds())
+
+
+def _fmt_duration(seconds: float) -> str:
+    total = int(round(seconds))
+    minutes, secs = divmod(total, 60)
+    if minutes:
+        return f"{minutes} min {secs} s"
+    return f"{secs} s"
+
+
+def _timing_meta(run: dict[str, Any]) -> str:
+    """Split queue wait from processing time using run event timestamps."""
+    queue_wait = _seconds_between(run.get("created_at"), run.get("started_at"))
+    processing = _seconds_between(run.get("started_at"), run.get("completed_at"))
+    parts = []
+    if queue_wait is not None:
+        parts.append(f"Espera en cola: {_fmt_duration(queue_wait)}")
+    if processing is not None:
+        parts.append(f"Procesamiento: {_fmt_duration(processing)}")
+    return " · ".join(parts)
+
+
 def _csrf(request: Request) -> str:
     token = request.session.get("csrf_token")
     if not isinstance(token, str) or len(token) < 32:
@@ -610,13 +642,25 @@ def _status_fragment(
     if state in ACTIVE_STATES:
         progress = run.get("progress", [])
         last_event_id = progress[-1]["sequence"] if progress else 0
+        queue_note = ""
+        if state == "queued" and run.get("queue_position") is not None:
+            wait = run.get("estimated_wait_seconds")
+            wait_text = (
+                f" · Espera aproximada: {max(1, round(wait / 60))} min"
+                if wait
+                else ""
+            )
+            queue_note = (
+                f'<p class="meta">Posición en la cola: '
+                f'{_escape(run["queue_position"])}{_escape(wait_text)}</p>'
+            )
         return f"""<section id="run-status" class="panel status" data-state="{state}"
 data-stream-url="/runs/{_escape(run["run_id"])}/events"
 data-status-url="/runs/{_escape(run["run_id"])}/status"
 data-last-event-id="{_escape(last_event_id)}" aria-live="polite">
 <p class="eyebrow">{_escape(STATUS_LABELS[state])}</p><h2>La ejecución sigue en progreso</h2>
 <p>Registro público de decisiones: qué intenta localizar, por qué consulta cada fuente y qué evidencia encuentra.</p>
-<p class="stream-state meta" data-stream-state>Conectando al trabajo del agente…</p>
+<p class="stream-state meta" data-stream-state>Conectando al trabajo del agente…</p>{queue_note}
 {_progress_timeline(progress)}{meta}</section>"""
     if state == "failed":
         error = run.get("error", {})
@@ -685,10 +729,12 @@ data-last-event-id="{_escape(last_event_id)}" aria-live="polite">
         if csrf_token
         else ""
     )
+    timing = _timing_meta(run)
+    timing_html = f" · {_escape(timing)}" if timing else ""
     return f"""<section id="run-status" data-state="succeeded" aria-live="polite">
 <section class="panel status"><p class="eyebrow">Respuesta terminada</p><h2>Respuesta</h2>{warning_html}
 <div class="answer">{_escape(answer.get("text", ""))}</div><p><strong>Citas:</strong> {citation_links}</p>
-<p class="meta">Premisa: {_escape(answer.get("premise_status", "unknown"))} · {_escape(result.get("elapsed_ms"))} ms</p></section>
+<p class="meta">Premisa: {_escape(answer.get("premise_status", "unknown"))}{timing_html}</p></section>
 <section class="panel"><h2>Proceso de investigación</h2>
 <p class="lede">El registro de decisiones y evidencia permanece disponible después de generar la respuesta.</p>
 {_completed_process(run.get("progress", []))}</section>
@@ -1048,6 +1094,7 @@ def create_app(
         error: str | None = None,
         values: dict[str, Any] | None = None,
         status_code: int = 200,
+        headers: dict[str, str] | None = None,
     ) -> HTMLResponse:
         published = service.store.published_runs()
         my_runs = None
@@ -1086,6 +1133,7 @@ def create_app(
                 page_scripts=page_scripts,
             ),
             status_code=status_code,
+            headers=headers,
         )
 
     @app.get("/login", response_class=HTMLResponse)
@@ -1217,6 +1265,7 @@ def create_app(
                 error="La cola local está llena; intenta más tarde.",
                 values=values,
                 status_code=503,
+                headers={"Retry-After": str(service.queue_retry_after())},
             )
         except PublicExecutionError as exc:
             return render_home(

--- a/human_eval/app.py
+++ b/human_eval/app.py
@@ -672,11 +672,7 @@ def _status_fragment(
         queue_note = ""
         if state == "queued" and run.get("queue_position") is not None:
             wait = run.get("estimated_wait_seconds")
-            wait_text = (
-                f" · Espera aproximada: {max(1, round(wait / 60))} min"
-                if wait
-                else ""
-            )
+            wait_text = f" · {_queue_wait_text(wait)}" if wait is not None else ""
             snapshot = run.get("queue_snapshot", {})
             active = snapshot.get("active")
             capacity = snapshot.get("capacity")
@@ -875,6 +871,14 @@ def _attach_chunk_html(event: dict[str, Any]) -> None:
             chunk["excerpt_html"] = render_markdown_html(excerpt)
 
 
+def _queue_wait_text(seconds: int | float | None) -> str:
+    if seconds is None:
+        return "Espera aproximada: calculando…"
+    if seconds < 60:
+        return "Espera aproximada: menos de 1 min"
+    return f"Espera aproximada: {round(seconds / 60)} min"
+
+
 def _queue_status_event(
     run: dict[str, Any],
 ) -> tuple[tuple[int, int, int], str] | None:
@@ -888,12 +892,10 @@ def _queue_status_event(
     if position is None or active is None or capacity is None:
         return None
     queue_state = (int(position), int(active), int(capacity))
-    wait_minutes = max(
-        1, round((run.get("estimated_wait_seconds") or 60) / 60)
-    )
+    wait_text = _queue_wait_text(run.get("estimated_wait_seconds"))
     message = (
         f"Posición en la cola: {queue_state[0]} · "
-        f"Espera aproximada: {wait_minutes} min · "
+        f"{wait_text} · "
         f"{queue_state[1]} de {queue_state[2]} slots ocupados"
     )
     return queue_state, message

--- a/human_eval/app.py
+++ b/human_eval/app.py
@@ -452,6 +452,10 @@ STREAM_SCRIPT = """
     if (!streamUrl) return;
     const list = node.querySelector('[data-progress-list]');
     const state = node.querySelector('[data-stream-state]');
+    const clearQueueStatus = () => {
+      const queueStatus = node.querySelector('[data-queue-status]');
+      if (queueStatus) queueStatus.remove();
+    };
     let last = Number(node.dataset.lastEventId || 0);
     if (!window.EventSource) {
       state.textContent = 'Actualizando el estado…';
@@ -466,8 +470,13 @@ STREAM_SCRIPT = """
       const event = JSON.parse(message.data);
       last = Math.max(last, Number(event.sequence || 0));
       node.dataset.lastEventId = last;
+      clearQueueStatus();
       appendProgress(list, event);
       state.textContent = 'Recibiendo actividad en vivo';
+    });
+    source.addEventListener('running', () => {
+      clearQueueStatus();
+      state.textContent = 'El modelo está procesando la pregunta';
     });
     source.addEventListener('queue', (message) => {
       const event = JSON.parse(message.data);
@@ -864,6 +873,30 @@ def _attach_chunk_html(event: dict[str, Any]) -> None:
         excerpt = chunk.get("excerpt") or chunk.get("snippet") or ""
         if excerpt:
             chunk["excerpt_html"] = render_markdown_html(excerpt)
+
+
+def _queue_status_event(
+    run: dict[str, Any],
+) -> tuple[tuple[int, int, int], str] | None:
+    """Build a queue update only from one complete public-run snapshot."""
+    if run.get("status") != "queued":
+        return None
+    position = run.get("queue_position")
+    snapshot = run.get("queue_snapshot", {})
+    active = snapshot.get("active")
+    capacity = snapshot.get("capacity")
+    if position is None or active is None or capacity is None:
+        return None
+    queue_state = (int(position), int(active), int(capacity))
+    wait_minutes = max(
+        1, round((run.get("estimated_wait_seconds") or 60) / 60)
+    )
+    message = (
+        f"Posición en la cola: {queue_state[0]} · "
+        f"Espera aproximada: {wait_minutes} min · "
+        f"{queue_state[1]} de {queue_state[2]} slots ocupados"
+    )
+    return queue_state, message
 
 
 def _feedback_form(run_id: str, csrf_token: str, *, next_url: str) -> str:
@@ -1437,6 +1470,7 @@ Publicada: {_escape(run.get("published_at"))}</p></section>
             cursor = after
             heartbeat_at = time.monotonic()
             last_queue_state: tuple[int, int, int] | None = None
+            running_announced = False
             while True:
                 events = await asyncio.to_thread(
                     service.store.progress_for_run, run_id, after=cursor
@@ -1451,24 +1485,18 @@ Publicada: {_escape(run.get("published_at"))}</p></section>
                     service.public_run, run_id, user_id=user.id, admin=True
                 )
                 if run["status"] == "queued":
-                    snapshot = run.get("queue_snapshot", {})
-                    queue_state = (
-                        int(run.get("queue_position") or 0),
-                        int(snapshot.get("active") or 0),
-                        int(snapshot.get("capacity") or 0),
-                    )
-                    if queue_state != last_queue_state:
-                        last_queue_state = queue_state
-                        message = (
-                            f"Posición en la cola: {queue_state[0]} · "
-                            f"Espera aproximada: "
-                            f"{max(1, round((run.get('estimated_wait_seconds') or 60) / 60))} min · "
-                            f"{queue_state[1]} de {queue_state[2]} slots ocupados"
-                        )
-                        yield (
-                            "event: queue\n"
-                            f"data: {json.dumps({'message': message}, ensure_ascii=False)}\n\n"
-                        )
+                    queue_event = _queue_status_event(run)
+                    if queue_event is not None:
+                        queue_state, message = queue_event
+                        if queue_state != last_queue_state:
+                            last_queue_state = queue_state
+                            yield (
+                                "event: queue\n"
+                                f"data: {json.dumps({'message': message}, ensure_ascii=False)}\n\n"
+                            )
+                elif run["status"] == "running" and not running_announced:
+                    running_announced = True
+                    yield 'event: running\ndata: {"status":"running"}\n\n'
                 if run["status"] not in ACTIVE_STATES:
                     data = json.dumps({"status": run["status"]}, separators=(",", ":"))
                     yield f"event: terminal\ndata: {data}\n\n"

--- a/human_eval/service.py
+++ b/human_eval/service.py
@@ -442,7 +442,18 @@ class EvaluationService:
         with self._write_lock:
             if self._closing.is_set():
                 return False
-            self.store.append_event(run_id, event_type, payload)
+            try:
+                self.store.append_event(run_id, event_type, payload)
+            except ValueError:
+                # Another process may have recovered this run after our lease
+                # lapsed (restart, stalled heartbeat) and written a terminal
+                # event. That terminal event wins: drop our late result and
+                # keep the worker alive instead of dying on the rejected
+                # transition.
+                LOGGER.warning(
+                    "run %s already terminal; dropping %s event", run_id, event_type
+                )
+                return False
             return True
 
     def _append_progress_if_open(

--- a/human_eval/service.py
+++ b/human_eval/service.py
@@ -13,7 +13,12 @@ from math import ceil
 from typing import Any, Protocol
 
 from .contracts import FeedbackRequest, RunRequest
-from .store import ActiveRunConflict, EvaluationStore, QueueCapacityConflict
+from .store import (
+    ActiveRunConflict,
+    DailyQuotaConflict,
+    EvaluationStore,
+    QueueCapacityConflict,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -182,19 +187,20 @@ class EvaluationService:
             # create_run remain authoritative across web processes.
             if self.store.has_active_run(user_id):
                 raise ActiveRunError("user already has an active run")
+            daily_since: str | None = None
             if not admin:
                 if not self.store.has_review_since_last_submission(user_id):
                     raise ReviewRequiredError(
                         "a published-answer review is required before asking"
                     )
                 if daily_question_limit >= 1:
-                    cutoff = (
+                    daily_since = (
                         (datetime.now(timezone.utc) - timedelta(hours=24))
                         .isoformat()
                         .replace("+00:00", "Z")
                     )
                     if (
-                        self.store.count_submissions_since(user_id, cutoff)
+                        self.store.count_submissions_since(user_id, daily_since)
                         >= daily_question_limit
                     ):
                         raise QuotaExceededError("daily question limit reached")
@@ -208,12 +214,21 @@ class EvaluationService:
                     request,
                     user_id=user_id,
                     provenance=self.provenance_factory(),
+                    enforce_active_run=True,
                     queue_capacity=self.queue.maxsize,
+                    daily_question_limit=(
+                        daily_question_limit
+                        if not admin and daily_question_limit >= 1
+                        else None
+                    ),
+                    daily_since=daily_since,
                 )
             except ActiveRunConflict as exc:
                 raise ActiveRunError("user already has an active run") from exc
             except QueueCapacityConflict as exc:
                 raise QueueFullError("execution queue is full") from exc
+            except DailyQuotaConflict as exc:
+                raise QuotaExceededError("daily question limit reached") from exc
             if created:
                 try:
                     self.queue.put_nowait(run["run_id"])

--- a/human_eval/service.py
+++ b/human_eval/service.py
@@ -18,7 +18,6 @@ from .store import (
     DailyQuotaConflict,
     EvaluationStore,
     IdempotencyPayloadConflict,
-    InvalidRunTransition,
     QueueCapacityConflict,
 )
 
@@ -137,7 +136,6 @@ class EvaluationService:
             self.store.initialize()
             self.store.initialize_model_slots(self.model_concurrency)
             recovered = self.store.recover_expired_model_slots()
-            recovered += self.store.recover_unclaimed_started_runs()
             if recovered:
                 LOGGER.warning("recovered %s interrupted executions", recovered)
             for worker in self.workers:
@@ -399,6 +397,7 @@ class EvaluationService:
                         daemon=True,
                     )
                     heartbeat.start()
+                    terminal_written = False
                     try:
                         try:
                             result = self.executor.execute(
@@ -415,15 +414,17 @@ class EvaluationService:
                                     run_id,
                                     exc.code,
                                 )
-                            self._append_event_if_open(
+                            terminal_written = self._append_event_if_open(
                                 run_id,
+                                slot_id,
                                 "failed",
                                 {"code": exc.code, "message": str(exc)},
                             )
                         except Exception:
                             LOGGER.exception("human-evaluation run %s failed", run_id)
-                            self._append_event_if_open(
+                            terminal_written = self._append_event_if_open(
                                 run_id,
+                                slot_id,
                                 "failed",
                                 {
                                     "code": "internal_error",
@@ -431,11 +432,13 @@ class EvaluationService:
                                 },
                             )
                         else:
-                            self._append_event_if_open(run_id, "succeeded", result)
+                            terminal_written = self._append_event_if_open(
+                                run_id, slot_id, "succeeded", result
+                            )
                     finally:
                         heartbeat_stop.set()
                         heartbeat.join(timeout=1)
-                        if not self._closing.is_set():
+                        if terminal_written and not self._closing.is_set():
                             self.store.release_model_slot(
                                 run_id=run_id,
                                 slot_id=slot_id,
@@ -486,22 +489,25 @@ class EvaluationService:
     def _append_event_if_open(
         self,
         run_id: str,
+        slot_id: int,
         event_type: str,
         payload: dict[str, Any] | None = None,
     ) -> bool:
         with self._write_lock:
             if self._closing.is_set():
                 return False
-            try:
-                self.store.append_event(run_id, event_type, payload)
-            except InvalidRunTransition:
-                # Another process may have recovered this run after our lease
-                # lapsed (restart, stalled heartbeat) and written a terminal
-                # event. That terminal event wins: drop our late result and
-                # keep the worker alive instead of dying on the rejected
-                # transition.
+            appended = self.store.append_terminal_event_if_claimed(
+                run_id,
+                event_type,
+                payload,
+                slot_id=slot_id,
+                worker_id=self.worker_id,
+            )
+            if not appended:
                 LOGGER.warning(
-                    "run %s already terminal; dropping %s event", run_id, event_type
+                    "run %s no longer owns a live model claim; dropping %s event",
+                    run_id,
+                    event_type,
                 )
                 return False
             return True

--- a/human_eval/service.py
+++ b/human_eval/service.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 import logging
+import os
 import queue
 import threading
+import uuid
 from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
+from math import ceil
 from typing import Any, Protocol
 
 from .contracts import FeedbackRequest, RunRequest
-from .store import EvaluationStore
+from .store import ActiveRunConflict, EvaluationStore, QueueCapacityConflict
 
 LOGGER = logging.getLogger(__name__)
 
@@ -57,6 +60,8 @@ class ReviewRequiredError(RuntimeError):
 # first local measurements (244-1,136 s per question); used only until
 # recent_durations() has real samples.
 DEFAULT_RUN_SECONDS = 480.0
+DEFAULT_LEASE_SECONDS = 120.0
+DEFAULT_POLL_SECONDS = 0.25
 
 
 class EvaluationService:
@@ -67,17 +72,44 @@ class EvaluationService:
         provenance_factory: Callable[[], dict[str, Any]],
         *,
         queue_capacity: int = 20,
+        model_concurrency: int = 1,
+        scheduler_workers: int | None = None,
+        lease_seconds: float = DEFAULT_LEASE_SECONDS,
         shutdown_timeout: float = 5.0,
     ):
+        if queue_capacity < 1:
+            raise ValueError("queue_capacity must be positive")
+        if model_concurrency < 1:
+            raise ValueError("model_concurrency must be positive")
+        if scheduler_workers is not None and scheduler_workers < 1:
+            raise ValueError("scheduler_workers must be positive")
+        if lease_seconds <= 0:
+            raise ValueError("lease_seconds must be positive")
         if shutdown_timeout < 0:
             raise ValueError("shutdown_timeout must not be negative")
         self.store = store
         self.executor = executor
         self.provenance_factory = provenance_factory
+        # This is only a local wake-up queue. SQLite is the authoritative
+        # queue, so another web process can claim work independently.
         self.queue: queue.Queue[str | None] = queue.Queue(maxsize=queue_capacity)
+        self.model_concurrency = model_concurrency
+        self.scheduler_workers = scheduler_workers or model_concurrency
+        self.lease_seconds = lease_seconds
+        self.worker_id = f"{os.getpid()}-{uuid.uuid4()}"
+        self.workers: list[threading.Thread] = []
         self.worker = threading.Thread(
-            target=self._worker_loop, name="dof-human-eval-worker", daemon=True
+            target=self._worker_loop, name="dof-human-eval-worker-1", daemon=True
         )
+        self.workers.append(self.worker)
+        for index in range(2, self.scheduler_workers + 1):
+            self.workers.append(
+                threading.Thread(
+                    target=self._worker_loop,
+                    name=f"dof-human-eval-worker-{index}",
+                    daemon=True,
+                )
+            )
         self.shutdown_timeout = shutdown_timeout
         self._closing = threading.Event()
         self._lifecycle_lock = threading.Lock()
@@ -94,29 +126,13 @@ class EvaluationService:
                 raise RuntimeError("create a new service instance after closing")
             self._closing.clear()
             self.store.initialize()
-            for run_id, state in self.store.unfinished_runs():
-                if state == "started":
-                    self.store.append_event(
-                        run_id,
-                        "failed",
-                        {
-                            "code": "service_restarted",
-                            "message": "La ejecución se interrumpió al reiniciar el servicio.",
-                        },
-                    )
-                else:
-                    try:
-                        self.queue.put_nowait(run_id)
-                    except queue.Full:
-                        self.store.append_event(
-                            run_id,
-                            "failed",
-                            {
-                                "code": "queue_full",
-                                "message": "La cola local está llena.",
-                            },
-                        )
-            self.worker.start()
+            self.store.initialize_model_slots(self.model_concurrency)
+            recovered = self.store.recover_expired_model_slots()
+            recovered += self.store.recover_unclaimed_started_runs()
+            if recovered:
+                LOGGER.warning("recovered %s interrupted executions", recovered)
+            for worker in self.workers:
+                worker.start()
             self._started = True
 
     def close(self) -> None:
@@ -128,14 +144,17 @@ class EvaluationService:
             # terminal result can be persisted after shutdown begins.
             with self._write_lock:
                 self._closing.set()
-            try:
-                self.queue.put_nowait(None)
-            except queue.Full:
-                # A full queue means the worker will wake without a sentinel;
-                # it observes _closing before taking another run.
-                pass
-        self.worker.join(timeout=self.shutdown_timeout)
-        if self.worker.is_alive():
+            for _ in self.workers:
+                try:
+                    self.queue.put_nowait(None)
+                except queue.Full:
+                    break
+        for worker in self.workers:
+            worker.join(timeout=self.shutdown_timeout)
+        if any(worker.is_alive() for worker in self.workers):
+            expired = self.store.expire_model_leases(self.worker_id)
+            if expired:
+                LOGGER.warning("expired %s model leases during shutdown", expired)
             LOGGER.warning(
                 "human-evaluation worker is still waiting for an in-flight call"
             )
@@ -150,15 +169,17 @@ class EvaluationService:
         admin: bool = False,
         daily_question_limit: int = 1,
     ) -> dict[str, Any]:
-        # This lock makes has_active_run + create_run atomic inside the one
-        # process supported by the MVP. SQLite constraints still provide
-        # idempotency, but multi-process admission would require a DB lock.
+        # create_run performs the admission checks in one SQLite transaction;
+        # this lock only serializes lifecycle and executor preparation locally.
         with self._lifecycle_lock:
             if not self._started:
                 raise RuntimeError("service has not started")
             existing = self.idempotent_run(request, user_id=user_id)
             if existing is not None:
                 return existing
+            # These checks avoid preparing an expensive executor for an
+            # obviously rejected request. The transactional checks inside
+            # create_run remain authoritative across web processes.
             if self.store.has_active_run(user_id):
                 raise ActiveRunError("user already has an active run")
             if not admin:
@@ -177,29 +198,29 @@ class EvaluationService:
                         >= daily_question_limit
                     ):
                         raise QuotaExceededError("daily question limit reached")
-            if self.queue.full():
+            if self.store.queue_depth() >= self.queue.maxsize:
                 raise QueueFullError("execution queue is full")
             prepare_executor = getattr(self.executor, "prepare", None)
             if callable(prepare_executor):
                 prepare_executor()
-            run, created = self.store.create_run(
-                request,
-                user_id=user_id,
-                provenance=self.provenance_factory(),
-            )
+            try:
+                run, created = self.store.create_run(
+                    request,
+                    user_id=user_id,
+                    provenance=self.provenance_factory(),
+                    queue_capacity=self.queue.maxsize,
+                )
+            except ActiveRunConflict as exc:
+                raise ActiveRunError("user already has an active run") from exc
+            except QueueCapacityConflict as exc:
+                raise QueueFullError("execution queue is full") from exc
             if created:
                 try:
                     self.queue.put_nowait(run["run_id"])
                 except queue.Full:
-                    self.store.append_event(
-                        run["run_id"],
-                        "failed",
-                        {
-                            "code": "queue_full",
-                            "message": "La cola local está llena.",
-                        },
-                    )
-                    raise QueueFullError("execution queue is full")
+                    # Notification loss is harmless: every worker polls the
+                    # persistent queue as a fallback.
+                    pass
             return self.public_run(run["run_id"], user_id=user_id, admin=True)
 
     def idempotent_run(
@@ -239,6 +260,9 @@ class EvaluationService:
             if position is not None:
                 run["queue_position"] = position
                 run["estimated_wait_seconds"] = self.estimated_wait_seconds(position)
+                run["queue_snapshot"] = self.queue_snapshot()
+        elif run["status"] == "running":
+            run["queue_snapshot"] = self.queue_snapshot()
         return run
 
     def estimated_wait_seconds(self, position: int) -> int:
@@ -247,7 +271,8 @@ class EvaluationService:
         average = (
             sum(durations) / len(durations) if durations else DEFAULT_RUN_SECONDS
         )
-        return max(1, int(round(position * average)))
+        batches = ceil(position / self.model_concurrency)
+        return max(1, int(round(batches * average)))
 
     def queue_retry_after(self) -> int:
         """Seconds a client should wait before retrying a full queue."""
@@ -255,8 +280,15 @@ class EvaluationService:
         average = (
             sum(durations) / len(durations) if durations else DEFAULT_RUN_SECONDS
         )
-        depth = max(self.queue.qsize(), 1)
-        return max(60, int(round(depth * average)))
+        depth = max(self.store.queue_depth(), 1)
+        batches = ceil(depth / self.model_concurrency)
+        return max(60, int(round(batches * average)))
+
+    def queue_snapshot(self) -> dict[str, int]:
+        """Return shared queue state for the status UI and health endpoints."""
+        activity = self.store.model_activity(self.model_concurrency)
+        activity["queued"] = self.store.queue_depth()
+        return activity
 
     @staticmethod
     def _is_public(run: dict[str, Any]) -> bool:
@@ -288,52 +320,104 @@ class EvaluationService:
     def _worker_loop(self) -> None:
         try:
             while not self._closing.is_set():
-                run_id = self.queue.get()
                 try:
-                    if run_id is None or self._closing.is_set():
+                    notification = self.queue.get(timeout=DEFAULT_POLL_SECONDS)
+                except queue.Empty:
+                    notification = "__poll__"
+                try:
+                    if notification is None or self._closing.is_set():
                         return
+                    claim = self.store.claim_next_run(
+                        worker_id=self.worker_id,
+                        concurrency=self.model_concurrency,
+                        lease_seconds=self.lease_seconds,
+                    )
+                    if claim is None:
+                        continue
+                    run_id, slot_id = claim
                     request = self.store.get_request(run_id)
                     if request is None:
+                        self.store.release_model_slot(
+                            run_id=run_id,
+                            slot_id=slot_id,
+                            worker_id=self.worker_id,
+                        )
                         continue
-                    if not self._append_event_if_open(run_id, "started"):
-                        return
+                    heartbeat_stop = threading.Event()
+                    heartbeat = threading.Thread(
+                        target=self._lease_heartbeat,
+                        args=(heartbeat_stop, run_id, slot_id),
+                        name=f"dof-human-eval-lease-{slot_id}",
+                        daemon=True,
+                    )
+                    heartbeat.start()
                     try:
-                        result = self.executor.execute(
-                            request,
-                            on_progress=lambda event_type,
-                            payload: self._append_progress_if_open(
-                                run_id, event_type, payload
-                            ),
-                        )
-                    except PublicExecutionError as exc:
-                        if exc.__cause__ is not None:
-                            LOGGER.exception(
-                                "human-evaluation run %s failed with %s",
-                                run_id,
-                                exc.code,
+                        try:
+                            result = self.executor.execute(
+                                request,
+                                on_progress=lambda event_type,
+                                payload: self._append_progress_if_open(
+                                    run_id, event_type, payload
+                                ),
                             )
-                        self._append_event_if_open(
-                            run_id,
-                            "failed",
-                            {"code": exc.code, "message": str(exc)},
-                        )
-                    except Exception:
-                        LOGGER.exception("human-evaluation run %s failed", run_id)
-                        self._append_event_if_open(
-                            run_id,
-                            "failed",
-                            {
-                                "code": "internal_error",
-                                "message": "La ejecución no pudo completarse.",
-                            },
-                        )
-                    else:
-                        self._append_event_if_open(run_id, "succeeded", result)
+                        except PublicExecutionError as exc:
+                            if exc.__cause__ is not None:
+                                LOGGER.exception(
+                                    "human-evaluation run %s failed with %s",
+                                    run_id,
+                                    exc.code,
+                                )
+                            self._append_event_if_open(
+                                run_id,
+                                "failed",
+                                {"code": exc.code, "message": str(exc)},
+                            )
+                        except Exception:
+                            LOGGER.exception("human-evaluation run %s failed", run_id)
+                            self._append_event_if_open(
+                                run_id,
+                                "failed",
+                                {
+                                    "code": "internal_error",
+                                    "message": "La ejecución no pudo completarse.",
+                                },
+                            )
+                        else:
+                            self._append_event_if_open(run_id, "succeeded", result)
+                    finally:
+                        heartbeat_stop.set()
+                        heartbeat.join(timeout=1)
+                        if not self._closing.is_set():
+                            self.store.release_model_slot(
+                                run_id=run_id,
+                                slot_id=slot_id,
+                                worker_id=self.worker_id,
+                            )
                 finally:
-                    self.queue.task_done()
+                    if notification != "__poll__":
+                        self.queue.task_done()
         finally:
-            if self._closing.is_set():
+            if self._closing.is_set() and not any(
+                worker.is_alive() and worker is not threading.current_thread()
+                for worker in self.workers
+            ):
                 self._close_executor()
+
+    def _lease_heartbeat(
+        self, stop: threading.Event, run_id: str, slot_id: int
+    ) -> None:
+        interval = max(self.lease_seconds / 3, 0.1)
+        while not stop.wait(interval):
+            if self._closing.is_set():
+                return
+            if not self.store.renew_model_slot(
+                run_id=run_id,
+                slot_id=slot_id,
+                worker_id=self.worker_id,
+                lease_seconds=self.lease_seconds,
+            ):
+                LOGGER.warning("lost model lease for run %s", run_id)
+                return
 
     def _close_executor(self) -> None:
         # If shutdown timed out while a run was active, the worker calls this

--- a/human_eval/service.py
+++ b/human_eval/service.py
@@ -53,6 +53,12 @@ class ReviewRequiredError(RuntimeError):
     """The user must evaluate a published answer before asking a question."""
 
 
+# Fallback per-run inference estimate when no run has finished yet. From the
+# first local measurements (244-1,136 s per question); used only until
+# recent_durations() has real samples.
+DEFAULT_RUN_SECONDS = 480.0
+
+
 class EvaluationService:
     def __init__(
         self,
@@ -228,7 +234,29 @@ class EvaluationService:
             if user_id is None or not self.store.run_belongs_to(run_id, user_id):
                 raise KeyError(run_id)
         run["events_url"] = f"/runs/{run_id}/events"
+        if run["status"] == "queued":
+            position = self.store.queue_position(run_id)
+            if position is not None:
+                run["queue_position"] = position
+                run["estimated_wait_seconds"] = self.estimated_wait_seconds(position)
         return run
+
+    def estimated_wait_seconds(self, position: int) -> int:
+        """Rough wait for a queued run at a 1-based FIFO position."""
+        durations = self.store.recent_durations(limit=10)
+        average = (
+            sum(durations) / len(durations) if durations else DEFAULT_RUN_SECONDS
+        )
+        return max(1, int(round(position * average)))
+
+    def queue_retry_after(self) -> int:
+        """Seconds a client should wait before retrying a full queue."""
+        durations = self.store.recent_durations(limit=10)
+        average = (
+            sum(durations) / len(durations) if durations else DEFAULT_RUN_SECONDS
+        )
+        depth = max(self.queue.qsize(), 1)
+        return max(60, int(round(depth * average)))
 
     @staticmethod
     def _is_public(run: dict[str, Any]) -> bool:

--- a/human_eval/service.py
+++ b/human_eval/service.py
@@ -17,6 +17,7 @@ from .store import (
     ActiveRunConflict,
     DailyQuotaConflict,
     EvaluationStore,
+    IdempotencyPayloadConflict,
     InvalidRunTransition,
     QueueCapacityConflict,
 )
@@ -122,6 +123,8 @@ class EvaluationService:
         self._write_lock = threading.Lock()
         self._executor_close_lock = threading.Lock()
         self._executor_closed = False
+        self._worker_count_lock = threading.Lock()
+        self._active_worker_count = len(self.workers)
         self._started = False
 
     def start(self) -> None:
@@ -251,6 +254,10 @@ class EvaluationService:
                 raise QueueFullError("execution queue is full") from exc
             except DailyQuotaConflict as exc:
                 raise QuotaExceededError("daily question limit reached") from exc
+            except IdempotencyPayloadConflict as exc:
+                raise IdempotencyConflictError(
+                    "client_request_id was already used for a different request"
+                ) from exc
             if created:
                 try:
                     self.queue.put_nowait(run["run_id"])
@@ -398,7 +405,7 @@ class EvaluationService:
                                 request,
                                 on_progress=lambda event_type,
                                 payload: self._append_progress_if_open(
-                                    run_id, event_type, payload
+                                    run_id, slot_id, event_type, payload
                                 ),
                             )
                         except PublicExecutionError as exc:
@@ -438,16 +445,18 @@ class EvaluationService:
                     if notification != "__poll__":
                         self.queue.task_done()
         finally:
-            if self._closing.is_set() and not any(
-                worker.is_alive() and worker is not threading.current_thread()
-                for worker in self.workers
-            ):
+            with self._worker_count_lock:
+                self._active_worker_count -= 1
+                close_executor = (
+                    self._closing.is_set() and self._active_worker_count == 0
+                )
+            if close_executor:
                 self._close_executor()
 
     def _lease_heartbeat(
         self, stop: threading.Event, run_id: str, slot_id: int
     ) -> None:
-        interval = max(self.lease_seconds / 3, 0.1)
+        interval = self.lease_seconds / 3
         while not stop.wait(interval):
             if self._closing.is_set():
                 return
@@ -498,7 +507,11 @@ class EvaluationService:
             return True
 
     def _append_progress_if_open(
-        self, run_id: str, event_type: str, payload: dict[str, Any]
+        self,
+        run_id: str,
+        slot_id: int,
+        event_type: str,
+        payload: dict[str, Any],
     ) -> None:
         with self._write_lock:
             if self._closing.is_set():
@@ -508,4 +521,17 @@ class EvaluationService:
                     run_id,
                 )
                 return
-            self.store.append_progress(run_id, event_type, payload)
+            appended = self.store.append_progress_if_claimed(
+                run_id,
+                event_type,
+                payload,
+                slot_id=slot_id,
+                worker_id=self.worker_id,
+            )
+            if appended is None:
+                LOGGER.warning(
+                    "run %s no longer owns model slot %s; dropping %s progress event",
+                    run_id,
+                    slot_id,
+                    event_type,
+                )

--- a/human_eval/service.py
+++ b/human_eval/service.py
@@ -433,7 +433,7 @@ class EvaluationService:
                                     run_id,
                                     exc.code,
                                 )
-                            terminal_written = self._append_event_if_open(
+                            terminal_written = self._append_terminal_with_retry(
                                 run_id,
                                 slot_id,
                                 "failed",
@@ -441,7 +441,7 @@ class EvaluationService:
                             )
                         except Exception:
                             LOGGER.exception("human-evaluation run %s failed", run_id)
-                            terminal_written = self._append_event_if_open(
+                            terminal_written = self._append_terminal_with_retry(
                                 run_id,
                                 slot_id,
                                 "failed",
@@ -451,7 +451,7 @@ class EvaluationService:
                                 },
                             )
                         else:
-                            terminal_written = self._append_event_if_open(
+                            terminal_written = self._append_terminal_with_retry(
                                 run_id, slot_id, "succeeded", result
                             )
                     finally:
@@ -487,7 +487,9 @@ class EvaluationService:
     ) -> None:
         interval = self.lease_seconds / 3
         deadline = time.monotonic() + self.lease_seconds
-        delay = interval
+        # Renew immediately so the claim->execution gap cannot outlive a
+        # lease that a stalled worker thread never revalidated.
+        delay = 0.0
         backoff = min(0.05, interval)
         while not stop.wait(delay):
             if self._closing.is_set():
@@ -566,6 +568,45 @@ class EvaluationService:
                 return False
             return True
 
+    def _append_terminal_with_retry(
+        self,
+        run_id: str,
+        slot_id: int,
+        event_type: str,
+        payload: dict[str, Any] | None = None,
+    ) -> bool:
+        """Persist a terminal result despite transient store contention.
+
+        The heartbeat is still renewing the model lease while this runs, so
+        a brief SQLITE_BUSY/SQLITE_LOCKED episode must not abandon an
+        already-finished execution. Retry within one heartbeat interval; the
+        fenced store write still rejects the result if the lease was lost.
+        """
+        delay = 0.05
+        deadline = time.monotonic() + max(1.0, self.lease_seconds / 3)
+        while True:
+            try:
+                return self._append_event_if_open(
+                    run_id, slot_id, event_type, payload
+                )
+            except sqlite3.OperationalError as exc:
+                if not _retryable_store_error(exc):
+                    raise
+                remaining = deadline - time.monotonic()
+                if remaining <= 0 or self._closing.is_set():
+                    LOGGER.warning(
+                        "dropping %s event for run %s after persistent "
+                        "store contention",
+                        event_type,
+                        run_id,
+                    )
+                    return False
+                LOGGER.warning(
+                    "terminal event store busy for run %s; retrying", run_id
+                )
+                self._closing.wait(min(delay, remaining))
+                delay = min(delay * 2, 1.0)
+
     def _append_progress_if_open(
         self,
         run_id: str,
@@ -581,13 +622,25 @@ class EvaluationService:
                     run_id,
                 )
                 return
-            appended = self.store.append_progress_if_claimed(
-                run_id,
-                event_type,
-                payload,
-                slot_id=slot_id,
-                worker_id=self.worker_id,
-            )
+            try:
+                appended = self.store.append_progress_if_claimed(
+                    run_id,
+                    event_type,
+                    payload,
+                    slot_id=slot_id,
+                    worker_id=self.worker_id,
+                )
+            except sqlite3.OperationalError as exc:
+                if not _retryable_store_error(exc):
+                    raise
+                # Progress is observational; never let transient contention
+                # on it abort an otherwise healthy model execution.
+                LOGGER.warning(
+                    "dropping %s progress event for run %s after store contention",
+                    event_type,
+                    run_id,
+                )
+                return
             if appended is None:
                 LOGGER.warning(
                     "run %s no longer owns model slot %s; dropping %s progress event",

--- a/human_eval/service.py
+++ b/human_eval/service.py
@@ -321,14 +321,12 @@ class EvaluationService:
         return max(1, int(round(batches * average)))
 
     def queue_retry_after(self) -> int:
-        """Seconds a client should wait before retrying a full queue."""
+        """Estimate when the next completion should free one queue place."""
         durations = self.store.recent_durations(limit=10)
         average = (
             sum(durations) / len(durations) if durations else DEFAULT_RUN_SECONDS
         )
-        depth = max(self.store.queue_depth(), 1)
-        batches = ceil(depth / self.model_concurrency)
-        return max(60, int(round(batches * average)))
+        return max(60, int(round(average)))
 
     def queue_snapshot(self) -> dict[str, int]:
         """Return shared queue state for the status UI and health endpoints."""

--- a/human_eval/service.py
+++ b/human_eval/service.py
@@ -6,6 +6,7 @@ import logging
 import os
 import queue
 import threading
+import time
 import uuid
 from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
@@ -156,8 +157,9 @@ class EvaluationService:
                     self.queue.put_nowait(None)
                 except queue.Full:
                     break
+        deadline = time.monotonic() + self.shutdown_timeout
         for worker in self.workers:
-            worker.join(timeout=self.shutdown_timeout)
+            worker.join(timeout=max(0.0, deadline - time.monotonic()))
         if any(worker.is_alive() for worker in self.workers):
             LOGGER.warning(
                 "human-evaluation worker is still waiting for an in-flight call; "
@@ -317,8 +319,9 @@ class EvaluationService:
         average = (
             sum(durations) / len(durations) if durations else DEFAULT_RUN_SECONDS
         )
-        batches = ceil(position / self.model_concurrency)
-        return max(1, int(round(batches * average)))
+        available = self.store.model_activity(self.model_concurrency)["available"]
+        batches = ceil(max(0, position - available) / self.model_concurrency)
+        return max(0, int(round(batches * average)))
 
     def queue_retry_after(self) -> int:
         """Estimate when the next completion should free one queue place."""
@@ -436,7 +439,7 @@ class EvaluationService:
                     finally:
                         heartbeat_stop.set()
                         heartbeat.join(timeout=1)
-                        if terminal_written and not self._closing.is_set():
+                        if terminal_written:
                             self.store.release_model_slot(
                                 run_id=run_id,
                                 slot_id=slot_id,

--- a/human_eval/service.py
+++ b/human_eval/service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import queue
+import sqlite3
 import threading
 import time
 import uuid
@@ -69,6 +70,14 @@ class ReviewRequiredError(RuntimeError):
 DEFAULT_RUN_SECONDS = 480.0
 DEFAULT_LEASE_SECONDS = 120.0
 DEFAULT_POLL_SECONDS = 0.25
+
+
+def _retryable_store_error(error: sqlite3.OperationalError) -> bool:
+    # Extended SQLite result codes retain the primary code in the low byte.
+    code = getattr(error, "sqlite_errorcode", None)
+    return code is not None and (code & 0xFF) in {
+        sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED
+    }
 
 
 class EvaluationService:
@@ -372,13 +381,22 @@ class EvaluationService:
                 except queue.Empty:
                     notification = "__poll__"
                 try:
-                    if notification is None or self._closing.is_set():
-                        return
-                    claim = self.store.claim_next_run(
-                        worker_id=self.worker_id,
-                        concurrency=self.model_concurrency,
-                        lease_seconds=self.lease_seconds,
-                    )
+                    with self._write_lock:
+                        if notification is None or self._closing.is_set():
+                            return
+                        claim = self.store.claim_next_run(
+                            worker_id=self.worker_id,
+                            concurrency=self.model_concurrency,
+                            lease_seconds=self.lease_seconds,
+                            # Do not hold the lifecycle write lock through a
+                            # full default SQLite busy timeout. Poll retries
+                            # let shutdown and event writes make progress.
+                            timeout=min(
+                                DEFAULT_POLL_SECONDS,
+                                self.lease_seconds / 3,
+                                self.shutdown_timeout,
+                            ),
+                        )
                     if claim is None:
                         continue
                     run_id, slot_id = claim
@@ -445,6 +463,13 @@ class EvaluationService:
                                 slot_id=slot_id,
                                 worker_id=self.worker_id,
                             )
+                except sqlite3.OperationalError as exc:
+                    if not _retryable_store_error(exc):
+                        raise
+                    LOGGER.warning("scheduler store busy; retrying", exc_info=True)
+                    # Claims remain persisted if a later operation failed;
+                    # expired claims are recovered by the next claim attempt.
+                    self._closing.wait(DEFAULT_POLL_SECONDS)
                 finally:
                     if notification != "__poll__":
                         self.queue.task_done()
@@ -461,17 +486,45 @@ class EvaluationService:
         self, stop: threading.Event, run_id: str, slot_id: int
     ) -> None:
         interval = self.lease_seconds / 3
-        while not stop.wait(interval):
+        deadline = time.monotonic() + self.lease_seconds
+        delay = interval
+        backoff = min(0.05, interval)
+        while not stop.wait(delay):
             if self._closing.is_set():
                 return
-            if not self.store.renew_model_slot(
-                run_id=run_id,
-                slot_id=slot_id,
-                worker_id=self.worker_id,
-                lease_seconds=self.lease_seconds,
-            ):
+            attempt_started = time.monotonic()
+            remaining = deadline - attempt_started
+            if remaining <= 0:
+                LOGGER.warning("model lease retry deadline reached for run %s", run_id)
+                return
+            try:
+                renewed = self.store.renew_model_slot(
+                    run_id=run_id,
+                    slot_id=slot_id,
+                    worker_id=self.worker_id,
+                    lease_seconds=self.lease_seconds,
+                    timeout=min(DEFAULT_POLL_SECONDS, remaining),
+                )
+            except sqlite3.OperationalError as exc:
+                if not _retryable_store_error(exc):
+                    raise
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    LOGGER.warning("model lease retry deadline reached for run %s", run_id)
+                    return
+                LOGGER.warning("model lease store busy for run %s; retrying", run_id)
+                delay = min(backoff, remaining)
+                backoff = min(backoff * 2, interval, 1.0)
+                continue
+            if not renewed:
                 LOGGER.warning("lost model lease for run %s", run_id)
                 return
+            # Start the local budget before renewal, conservatively excluding
+            # time spent acquiring SQLite's lock. The store also fences every
+            # renewal by the authoritative, unexpired database deadline.
+            deadline = attempt_started + self.lease_seconds
+            delay = interval
+            backoff = min(0.05, interval)
 
     def _close_executor(self) -> None:
         # If shutdown timed out while a run was active, the worker calls this

--- a/human_eval/store.py
+++ b/human_eval/store.py
@@ -35,6 +35,11 @@ class ActiveRunConflict(RuntimeError):
 class QueueCapacityConflict(RuntimeError):
     """The shared persistent queue has reached its configured capacity."""
 
+
+class DailyQuotaConflict(RuntimeError):
+    """The user has reached the configured rolling question limit."""
+
+
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS schema_meta (
     key TEXT PRIMARY KEY,
@@ -186,8 +191,15 @@ class EvaluationStore:
         *,
         user_id: str,
         provenance: dict[str, Any],
+        enforce_active_run: bool = False,
         queue_capacity: int | None = None,
+        daily_question_limit: int | None = None,
+        daily_since: str | None = None,
     ) -> tuple[dict[str, Any], bool]:
+        if daily_question_limit is not None and daily_question_limit < 1:
+            raise ValueError("daily_question_limit must be positive")
+        if daily_question_limit is not None and daily_since is None:
+            raise ValueError("daily_since is required with daily_question_limit")
         if queue_capacity is not None and queue_capacity < 1:
             raise ValueError("queue_capacity must be positive")
         created_at = utc_now()
@@ -205,7 +217,7 @@ class EvaluationStore:
                     found = self.get_run(existing[0])
                     assert found is not None
                     return found, False
-            if queue_capacity is not None:
+            if enforce_active_run:
                 active = connection.execute(
                     "SELECT 1 FROM runs r JOIN run_events e ON e.run_id = r.run_id "
                     "WHERE r.user_id = ? AND e.sequence = "
@@ -216,6 +228,14 @@ class EvaluationStore:
                 ).fetchone()
                 if active:
                     raise ActiveRunConflict(user_id)
+            if daily_question_limit is not None:
+                submissions = connection.execute(
+                    "SELECT COUNT(*) FROM runs WHERE user_id = ? AND created_at >= ?",
+                    (user_id, daily_since),
+                ).fetchone()[0]
+                if int(submissions) >= daily_question_limit:
+                    raise DailyQuotaConflict(daily_question_limit)
+            if queue_capacity is not None:
                 queued = connection.execute(
                     "SELECT COUNT(*) FROM runs r JOIN run_events e ON e.run_id = r.run_id "
                     "WHERE e.sequence = (SELECT MAX(e2.sequence) FROM run_events e2 "

--- a/human_eval/store.py
+++ b/human_eval/store.py
@@ -7,13 +7,13 @@ import sqlite3
 import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
 from .contracts import FeedbackRequest, RunRequest, utc_now
 
-SCHEMA_VERSION = "3"
+SCHEMA_VERSION = "4"
 TERMINAL_STATES = frozenset({"succeeded", "failed"})
 EVENT_STATES = frozenset({"queued", "started", *TERMINAL_STATES})
 PROGRESS_EVENT_TYPES = frozenset(
@@ -26,6 +26,14 @@ PROGRESS_EVENT_TYPES = frozenset(
         "verification_completed",
     }
 )
+
+
+class ActiveRunConflict(RuntimeError):
+    """The user already has a queued or running execution."""
+
+
+class QueueCapacityConflict(RuntimeError):
+    """The shared persistent queue has reached its configured capacity."""
 
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS schema_meta (
@@ -86,6 +94,13 @@ CREATE TABLE IF NOT EXISTS feedback (
     comment TEXT NOT NULL
 );
 CREATE INDEX IF NOT EXISTS feedback_run_id ON feedback(run_id, created_at);
+CREATE TABLE IF NOT EXISTS model_slots (
+    slot_id INTEGER PRIMARY KEY,
+    run_id TEXT REFERENCES runs(run_id),
+    worker_id TEXT,
+    lease_until TEXT
+);
+CREATE INDEX IF NOT EXISTS model_slots_run_id ON model_slots(run_id);
 """
 
 
@@ -123,7 +138,7 @@ class EvaluationStore:
             current = connection.execute(
                 "SELECT value FROM schema_meta WHERE key = 'schema_version'"
             ).fetchone()
-            if current and current[0] not in {"1", "2", SCHEMA_VERSION}:
+            if current and current[0] not in {"1", "2", "3", SCHEMA_VERSION}:
                 raise RuntimeError(
                     f"unsupported evaluation schema {current[0]!r}; expected {SCHEMA_VERSION}"
                 )
@@ -171,7 +186,10 @@ class EvaluationStore:
         *,
         user_id: str,
         provenance: dict[str, Any],
+        queue_capacity: int | None = None,
     ) -> tuple[dict[str, Any], bool]:
+        if queue_capacity is not None and queue_capacity < 1:
+            raise ValueError("queue_capacity must be positive")
         created_at = utc_now()
         run_id = str(uuid.uuid4())
         with self._connect() as connection:
@@ -187,6 +205,24 @@ class EvaluationStore:
                     found = self.get_run(existing[0])
                     assert found is not None
                     return found, False
+            if queue_capacity is not None:
+                active = connection.execute(
+                    "SELECT 1 FROM runs r JOIN run_events e ON e.run_id = r.run_id "
+                    "WHERE r.user_id = ? AND e.sequence = "
+                    "(SELECT MAX(e2.sequence) FROM run_events e2 "
+                    "WHERE e2.run_id = r.run_id) "
+                    "AND e.event_type IN ('queued', 'started') LIMIT 1",
+                    (user_id,),
+                ).fetchone()
+                if active:
+                    raise ActiveRunConflict(user_id)
+                queued = connection.execute(
+                    "SELECT COUNT(*) FROM runs r JOIN run_events e ON e.run_id = r.run_id "
+                    "WHERE e.sequence = (SELECT MAX(e2.sequence) FROM run_events e2 "
+                    "WHERE e2.run_id = r.run_id) AND e.event_type = 'queued'"
+                ).fetchone()[0]
+                if int(queued) >= queue_capacity:
+                    raise QueueCapacityConflict(queue_capacity)
             connection.execute(
                 "INSERT INTO runs(run_id, created_at, question, as_of, required_hops, "
                 "user_id, client_request_id, provenance_json) "
@@ -210,6 +246,202 @@ class EvaluationStore:
         found = self.get_run(run_id)
         assert found is not None
         return found, True
+
+    def initialize_model_slots(self, concurrency: int) -> None:
+        """Ensure the shared SQLite scheduler has slots for this process."""
+        if concurrency < 1:
+            raise ValueError("model concurrency must be positive")
+        with self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            connection.executemany(
+                "INSERT OR IGNORE INTO model_slots(slot_id) VALUES (?)",
+                ((slot_id,) for slot_id in range(1, concurrency + 1)),
+            )
+
+    @staticmethod
+    def _lease_until(seconds: float) -> str:
+        return (
+            datetime.now(timezone.utc) + timedelta(seconds=seconds)
+        ).isoformat().replace("+00:00", "Z")
+
+    def queue_depth(self) -> int:
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT COUNT(*) FROM runs r JOIN run_events e ON e.run_id = r.run_id "
+                "WHERE e.sequence = (SELECT MAX(e2.sequence) FROM run_events e2 "
+                "WHERE e2.run_id = r.run_id) AND e.event_type = 'queued'"
+            ).fetchone()
+        return int(row[0])
+
+    def model_activity(self, concurrency: int) -> dict[str, int]:
+        if concurrency < 1:
+            raise ValueError("model concurrency must be positive")
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT COUNT(*) FROM model_slots WHERE slot_id <= ? AND run_id IS NOT NULL",
+                (concurrency,),
+            ).fetchone()
+        active = int(row[0])
+        return {"active": active, "capacity": concurrency, "available": concurrency - active}
+
+    def claim_next_run(
+        self,
+        *,
+        worker_id: str,
+        concurrency: int,
+        lease_seconds: float,
+    ) -> tuple[str, int] | None:
+        """Atomically claim the oldest queued run and one model slot."""
+        if concurrency < 1 or lease_seconds <= 0:
+            raise ValueError("invalid scheduler limits")
+        now = utc_now()
+        lease_until = self._lease_until(lease_seconds)
+        with self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            slot = connection.execute(
+                "SELECT slot_id FROM model_slots "
+                "WHERE slot_id <= ? AND run_id IS NULL ORDER BY slot_id LIMIT 1",
+                (concurrency,),
+            ).fetchone()
+            if slot is None:
+                return None
+            run = connection.execute(
+                "SELECT r.run_id FROM runs r JOIN run_events e ON e.run_id = r.run_id "
+                "WHERE e.sequence = (SELECT MAX(e2.sequence) FROM run_events e2 "
+                "WHERE e2.run_id = r.run_id) AND e.event_type = 'queued' "
+                "ORDER BY r.created_at, r.run_id LIMIT 1"
+            ).fetchone()
+            if run is None:
+                return None
+            run_id = str(run[0])
+            slot_id = int(slot[0])
+            connection.execute(
+                "UPDATE model_slots SET run_id = ?, worker_id = ?, lease_until = ? "
+                "WHERE slot_id = ? AND run_id IS NULL",
+                (run_id, worker_id, lease_until, slot_id),
+            )
+            current = connection.execute(
+                "SELECT sequence FROM run_events WHERE run_id = ? "
+                "ORDER BY sequence DESC LIMIT 1",
+                (run_id,),
+            ).fetchone()
+            if current is None:
+                raise KeyError(run_id)
+            connection.execute(
+                "INSERT INTO run_events(run_id, sequence, event_type, created_at, payload_json) "
+                "VALUES (?, ?, 'started', ?, '{}')",
+                (run_id, int(current[0]) + 1, now),
+            )
+        return run_id, slot_id
+
+    def renew_model_slot(
+        self,
+        *,
+        run_id: str,
+        slot_id: int,
+        worker_id: str,
+        lease_seconds: float,
+    ) -> bool:
+        if lease_seconds <= 0:
+            raise ValueError("lease_seconds must be positive")
+        with self._connect() as connection:
+            cursor = connection.execute(
+                "UPDATE model_slots SET lease_until = ? WHERE slot_id = ? "
+                "AND run_id = ? AND worker_id = ?",
+                (self._lease_until(lease_seconds), slot_id, run_id, worker_id),
+            )
+        return cursor.rowcount == 1
+
+    def release_model_slot(self, *, run_id: str, slot_id: int, worker_id: str) -> bool:
+        with self._connect() as connection:
+            cursor = connection.execute(
+                "UPDATE model_slots SET run_id = NULL, worker_id = NULL, lease_until = NULL "
+                "WHERE slot_id = ? AND run_id = ? AND worker_id = ?",
+                (slot_id, run_id, worker_id),
+            )
+        return cursor.rowcount == 1
+
+    def expire_model_leases(self, worker_id: str) -> int:
+        """Make this process's unfinished claims recoverable after shutdown."""
+        with self._connect() as connection:
+            cursor = connection.execute(
+                "UPDATE model_slots SET lease_until = ? WHERE worker_id = ? "
+                "AND run_id IS NOT NULL",
+                (utc_now(), worker_id),
+            )
+        return cursor.rowcount
+
+    def recover_expired_model_slots(self) -> int:
+        """Fail runs whose scheduler lease expired without a heartbeat."""
+        now = utc_now()
+        recovered = 0
+        with self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            slots = connection.execute(
+                "SELECT slot_id, run_id FROM model_slots WHERE run_id IS NOT NULL "
+                "AND lease_until IS NOT NULL AND lease_until <= ?",
+                (now,),
+            ).fetchall()
+            for slot in slots:
+                run_id = str(slot[1])
+                current = connection.execute(
+                    "SELECT event_type, sequence FROM run_events WHERE run_id = ? "
+                    "ORDER BY sequence DESC LIMIT 1",
+                    (run_id,),
+                ).fetchone()
+                if current is not None and current[0] == "started":
+                    connection.execute(
+                        "INSERT INTO run_events(run_id, sequence, event_type, created_at, payload_json) "
+                        "VALUES (?, ?, 'failed', ?, ?)",
+                        (
+                            run_id,
+                            int(current[1]) + 1,
+                            now,
+                            _json({
+                                "code": "service_restarted",
+                                "message": "La ejecución se interrumpió antes de terminar.",
+                            }),
+                        ),
+                    )
+                    recovered += 1
+                connection.execute(
+                    "UPDATE model_slots SET run_id = NULL, worker_id = NULL, lease_until = NULL "
+                    "WHERE slot_id = ?",
+                    (int(slot[0]),),
+                )
+        return recovered
+
+    def recover_unclaimed_started_runs(self) -> int:
+        """Recover pre-v4 started runs that have no scheduler lease."""
+        now = utc_now()
+        recovered = 0
+        with self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            runs = connection.execute(
+                "SELECT r.run_id, e.sequence FROM runs r JOIN run_events e "
+                "ON e.run_id = r.run_id WHERE e.sequence = (SELECT MAX(e2.sequence) "
+                "FROM run_events e2 WHERE e2.run_id = r.run_id) "
+                "AND e.event_type = 'started' AND NOT EXISTS ("
+                "SELECT 1 FROM model_slots s WHERE s.run_id = r.run_id)"
+            ).fetchall()
+            for run in runs:
+                connection.execute(
+                    "INSERT INTO run_events(run_id, sequence, event_type, created_at, payload_json) "
+                    "VALUES (?, ?, 'failed', ?, ?)",
+                    (
+                        str(run[0]),
+                        int(run[1]) + 1,
+                        now,
+                        _json(
+                            {
+                                "code": "service_restarted",
+                                "message": "La ejecución se interrumpió antes de terminar.",
+                            }
+                        ),
+                    ),
+                )
+                recovered += 1
+        return recovered
 
     def find_idempotent_run(
         self, user_id: str, client_request_id: str | None
@@ -434,6 +666,11 @@ class EvaluationStore:
             ).fetchone()
             if latest is not None and latest[0] in ("queued", "started"):
                 raise ValueError("active runs cannot be deleted")
+            connection.execute(
+                "UPDATE model_slots SET run_id = NULL, worker_id = NULL, "
+                "lease_until = NULL WHERE run_id = ?",
+                (run_id,),
+            )
             for table in ("run_progress", "run_events", "feedback", "runs"):
                 connection.execute(f"DELETE FROM {table} WHERE run_id = ?", (run_id,))
 
@@ -696,6 +933,11 @@ class EvaluationStore:
             run_ids = [row[0] for row in rows]
             if run_ids:
                 placeholders = ",".join("?" for _ in run_ids)
+                connection.execute(
+                    f"UPDATE model_slots SET run_id = NULL, worker_id = NULL, "
+                    f"lease_until = NULL WHERE run_id IN ({placeholders})",
+                    run_ids,
+                )
                 for table in ("run_progress", "run_events", "feedback", "runs"):
                     connection.execute(
                         f"DELETE FROM {table} WHERE run_id IN ({placeholders})",
@@ -715,6 +957,11 @@ class EvaluationStore:
             ).fetchone()
             if exists is None:
                 return False
+            connection.execute(
+                "UPDATE model_slots SET run_id = NULL, worker_id = NULL, "
+                "lease_until = NULL WHERE run_id = ?",
+                (run_id,),
+            )
             for table in ("run_progress", "run_events", "feedback", "runs"):
                 connection.execute(f"DELETE FROM {table} WHERE run_id = ?", (run_id,))
         return True

--- a/human_eval/store.py
+++ b/human_eval/store.py
@@ -157,11 +157,26 @@ class EvaluationStore:
                 )
             connection.executescript(SCHEMA)
             self._migrate_columns(connection)
+            # executescript may commit while creating missing tables. Re-enter
+            # a write transaction and re-read the version so only one process
+            # performs v4 orphan recovery during a concurrent deployment.
+            connection.commit()
+            connection.execute("BEGIN IMMEDIATE")
+            migration_version = connection.execute(
+                "SELECT value FROM schema_meta WHERE key = 'schema_version'"
+            ).fetchone()
+            if migration_version and migration_version[0] != SCHEMA_VERSION:
+                # Only schema migration can identify these as pre-v4 runs.
+                # In schema v4, supported maintenance jobs may intentionally
+                # execute a started run without participating in model_slots.
+                self._recover_unclaimed_started_runs_in_connection(
+                    connection, utc_now()
+                )
             connection.execute(
                 "INSERT OR IGNORE INTO schema_meta(key, value) VALUES (?, ?)",
                 ("schema_version", SCHEMA_VERSION),
             )
-            if current and current[0] != SCHEMA_VERSION:
+            if migration_version and migration_version[0] != SCHEMA_VERSION:
                 connection.execute(
                     "UPDATE schema_meta SET value = ? WHERE key = 'schema_version'",
                     (SCHEMA_VERSION,),
@@ -391,11 +406,12 @@ class EvaluationStore:
             connection.execute("BEGIN IMMEDIATE")
             # Calculate under the write lock so lock contention cannot consume
             # some or all of the renewed lease before the UPDATE commits.
+            now = utc_now()
             lease_until = self._lease_until(lease_seconds)
             cursor = connection.execute(
                 "UPDATE model_slots SET lease_until = ? WHERE slot_id = ? "
-                "AND run_id = ? AND worker_id = ?",
-                (lease_until, slot_id, run_id, worker_id),
+                "AND run_id = ? AND worker_id = ? AND lease_until > ?",
+                (lease_until, slot_id, run_id, worker_id, now),
             )
         return cursor.rowcount == 1
 
@@ -467,36 +483,36 @@ class EvaluationStore:
                 connection, utc_now()
             )
 
-    def recover_unclaimed_started_runs(self) -> int:
-        """Recover pre-v4 started runs that have no scheduler lease."""
-        now = utc_now()
+    @staticmethod
+    def _recover_unclaimed_started_runs_in_connection(
+        connection: sqlite3.Connection, now: str
+    ) -> int:
+        """Fail legacy started runs while upgrading a pre-v4 database."""
         recovered = 0
-        with self._connect() as connection:
-            connection.execute("BEGIN IMMEDIATE")
-            runs = connection.execute(
-                "SELECT r.run_id, e.sequence FROM runs r JOIN run_events e "
-                "ON e.run_id = r.run_id WHERE e.sequence = (SELECT MAX(e2.sequence) "
-                "FROM run_events e2 WHERE e2.run_id = r.run_id) "
-                "AND e.event_type = 'started' AND NOT EXISTS ("
-                "SELECT 1 FROM model_slots s WHERE s.run_id = r.run_id)"
-            ).fetchall()
-            for run in runs:
-                connection.execute(
-                    "INSERT INTO run_events(run_id, sequence, event_type, created_at, payload_json) "
-                    "VALUES (?, ?, 'failed', ?, ?)",
-                    (
-                        str(run[0]),
-                        int(run[1]) + 1,
-                        now,
-                        _json(
-                            {
-                                "code": "service_restarted",
-                                "message": "La ejecución se interrumpió antes de terminar.",
-                            }
-                        ),
+        runs = connection.execute(
+            "SELECT r.run_id, e.sequence FROM runs r JOIN run_events e "
+            "ON e.run_id = r.run_id WHERE e.sequence = (SELECT MAX(e2.sequence) "
+            "FROM run_events e2 WHERE e2.run_id = r.run_id) "
+            "AND e.event_type = 'started' AND NOT EXISTS ("
+            "SELECT 1 FROM model_slots s WHERE s.run_id = r.run_id)"
+        ).fetchall()
+        for run in runs:
+            connection.execute(
+                "INSERT INTO run_events(run_id, sequence, event_type, created_at, payload_json) "
+                "VALUES (?, ?, 'failed', ?, ?)",
+                (
+                    str(run[0]),
+                    int(run[1]) + 1,
+                    now,
+                    _json(
+                        {
+                            "code": "service_restarted",
+                            "message": "La ejecución se interrumpió antes de terminar.",
+                        }
                     ),
-                )
-                recovered += 1
+                ),
+            )
+            recovered += 1
         return recovered
 
     def find_idempotent_run(
@@ -820,6 +836,48 @@ class EvaluationStore:
                     _json(payload or {}),
                 ),
             )
+
+    def append_terminal_event_if_claimed(
+        self,
+        run_id: str,
+        event_type: str,
+        payload: dict[str, Any] | None,
+        *,
+        slot_id: int,
+        worker_id: str,
+    ) -> bool:
+        """Persist a terminal result only for a live, owned model claim."""
+        if event_type not in TERMINAL_STATES:
+            raise ValueError(f"invalid terminal event type: {event_type}")
+        with self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            created_at = utc_now()
+            current = connection.execute(
+                "SELECT event_type, sequence FROM run_events WHERE run_id = ? "
+                "ORDER BY sequence DESC LIMIT 1",
+                (run_id,),
+            ).fetchone()
+            if current is None:
+                raise KeyError(run_id)
+            claimed = connection.execute(
+                "SELECT 1 FROM model_slots WHERE slot_id = ? AND run_id = ? "
+                "AND worker_id = ? AND lease_until > ?",
+                (slot_id, run_id, worker_id, created_at),
+            ).fetchone()
+            if current["event_type"] != "started" or claimed is None:
+                return False
+            connection.execute(
+                "INSERT INTO run_events(run_id, sequence, event_type, created_at, payload_json) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (
+                    run_id,
+                    int(current["sequence"]) + 1,
+                    event_type,
+                    created_at,
+                    _json(payload or {}),
+                ),
+            )
+        return True
 
     def append_progress(
         self, run_id: str, event_type: str, payload: dict[str, Any]

--- a/human_eval/store.py
+++ b/human_eval/store.py
@@ -40,6 +40,10 @@ class DailyQuotaConflict(RuntimeError):
     """The user has reached the configured rolling question limit."""
 
 
+class IdempotencyPayloadConflict(RuntimeError):
+    """An idempotency key was reused for a different request payload."""
+
+
 class InvalidRunTransition(ValueError):
     """A run event lost a race with an already-written terminal event."""
 
@@ -212,13 +216,22 @@ class EvaluationStore:
             connection.execute("BEGIN IMMEDIATE")
             if request.client_request_id:
                 existing = connection.execute(
-                    "SELECT run_id FROM runs WHERE user_id = ? "
+                    "SELECT run_id, question, as_of, required_hops FROM runs "
+                    "WHERE user_id = ? "
                     "AND client_request_id = ?",
                     (user_id, request.client_request_id),
                 ).fetchone()
                 if existing:
+                    if any(
+                        (
+                            existing["question"] != request.question,
+                            existing["as_of"] != request.as_of,
+                            existing["required_hops"] != request.required_hops,
+                        )
+                    ):
+                        raise IdempotencyPayloadConflict(request.client_request_id)
                     connection.commit()
-                    found = self.get_run(existing[0])
+                    found = self.get_run(existing["run_id"])
                     assert found is not None
                     return found, False
             if enforce_active_run:
@@ -318,10 +331,12 @@ class EvaluationStore:
         """Atomically claim the oldest queued run and one model slot."""
         if concurrency < 1 or lease_seconds <= 0:
             raise ValueError("invalid scheduler limits")
-        now = utc_now()
-        lease_until = self._lease_until(lease_seconds)
         with self._connect() as connection:
             connection.execute("BEGIN IMMEDIATE")
+            # A busy SQLite writer may have delayed this transaction. Start
+            # the lease only after the write lock is actually ours.
+            now = utc_now()
+            lease_until = self._lease_until(lease_seconds)
             # A replacement worker often starts before the dead worker's lease
             # expires. Reap on every claim attempt as well as at startup so the
             # slot becomes available once its deadline actually passes.
@@ -373,10 +388,14 @@ class EvaluationStore:
         if lease_seconds <= 0:
             raise ValueError("lease_seconds must be positive")
         with self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            # Calculate under the write lock so lock contention cannot consume
+            # some or all of the renewed lease before the UPDATE commits.
+            lease_until = self._lease_until(lease_seconds)
             cursor = connection.execute(
                 "UPDATE model_slots SET lease_until = ? WHERE slot_id = ? "
                 "AND run_id = ? AND worker_id = ?",
-                (self._lease_until(lease_seconds), slot_id, run_id, worker_id),
+                (lease_until, slot_id, run_id, worker_id),
             )
         return cursor.rowcount == 1
 
@@ -815,6 +834,49 @@ class EvaluationStore:
             ).fetchone()
             if exists is None:
                 raise KeyError(run_id)
+            row = connection.execute(
+                "SELECT COALESCE(MAX(sequence), 0) + 1 FROM run_progress "
+                "WHERE run_id = ?",
+                (run_id,),
+            ).fetchone()
+            sequence = int(row[0])
+            connection.execute(
+                "INSERT INTO run_progress(run_id, sequence, event_type, created_at, "
+                "payload_json) VALUES (?, ?, ?, ?, ?)",
+                (run_id, sequence, event_type, created_at, _json(payload)),
+            )
+        return {
+            "sequence": sequence,
+            "event_type": event_type,
+            "created_at": created_at,
+            "payload": payload,
+        }
+
+    def append_progress_if_claimed(
+        self,
+        run_id: str,
+        event_type: str,
+        payload: dict[str, Any],
+        *,
+        slot_id: int,
+        worker_id: str,
+    ) -> dict[str, Any] | None:
+        """Append progress only while this worker owns a live started claim."""
+        if event_type not in PROGRESS_EVENT_TYPES:
+            raise ValueError(f"invalid progress event type: {event_type}")
+        with self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            created_at = utc_now()
+            claimed = connection.execute(
+                "SELECT 1 FROM model_slots s WHERE s.slot_id = ? "
+                "AND s.run_id = ? AND s.worker_id = ? AND s.lease_until > ? "
+                "AND EXISTS (SELECT 1 FROM run_events e WHERE e.run_id = ? "
+                "AND e.sequence = (SELECT MAX(e2.sequence) FROM run_events e2 "
+                "WHERE e2.run_id = e.run_id) AND e.event_type = 'started')",
+                (slot_id, run_id, worker_id, created_at, run_id),
+            ).fetchone()
+            if claimed is None:
+                return None
             row = connection.execute(
                 "SELECT COALESCE(MAX(sequence), 0) + 1 FROM run_progress "
                 "WHERE run_id = ?",

--- a/human_eval/store.py
+++ b/human_eval/store.py
@@ -7,6 +7,7 @@ import sqlite3
 import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -442,6 +443,54 @@ class EvaluationStore:
                 return connection.execute("SELECT 1").fetchone()[0] == 1
         except sqlite3.Error:
             return False
+
+    def queue_position(self, run_id: str) -> int | None:
+        """1-based FIFO position among queued runs; None when not queued."""
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT r.created_at FROM runs r WHERE r.run_id = ? AND "
+                "(SELECT e.event_type FROM run_events e WHERE e.run_id = r.run_id "
+                "ORDER BY e.sequence DESC LIMIT 1) = 'queued'",
+                (run_id,),
+            ).fetchone()
+            if row is None:
+                return None
+            ahead = connection.execute(
+                "SELECT COUNT(*) FROM runs r WHERE "
+                "(SELECT e.event_type FROM run_events e WHERE e.run_id = r.run_id "
+                "ORDER BY e.sequence DESC LIMIT 1) = 'queued' AND "
+                "(r.created_at < ? OR (r.created_at = ? AND r.run_id < ?))",
+                (row["created_at"], row["created_at"], run_id),
+            ).fetchone()
+        return int(ahead[0]) + 1
+
+    def recent_durations(self, *, limit: int = 10) -> list[float]:
+        """Inference seconds (started -> terminal) of recent finished runs."""
+        if not 1 <= limit <= 100:
+            raise ValueError("limit must be between 1 and 100")
+        with self._connect() as connection:
+            rows = connection.execute(
+                "SELECT started.created_at AS started_at, "
+                "finished.created_at AS finished_at "
+                "FROM run_events started "
+                "JOIN run_events finished ON finished.run_id = started.run_id "
+                "AND finished.sequence = started.sequence + 1 "
+                "WHERE started.event_type = 'started' "
+                "AND finished.event_type IN ('succeeded', 'failed') "
+                "ORDER BY finished.created_at DESC, finished.run_id DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
+        durations: list[float] = []
+        for row in rows:
+            try:
+                began = datetime.fromisoformat(row["started_at"].replace("Z", "+00:00"))
+                ended = datetime.fromisoformat(
+                    row["finished_at"].replace("Z", "+00:00")
+                )
+            except (TypeError, ValueError):
+                continue
+            durations.append(max(0.0, (ended - began).total_seconds()))
+        return durations
 
     def append_event(
         self, run_id: str, event_type: str, payload: dict[str, Any] | None = None

--- a/human_eval/store.py
+++ b/human_eval/store.py
@@ -228,6 +228,7 @@ class EvaluationStore:
         queue_capacity: int | None = None,
         daily_question_limit: int | None = None,
         daily_since: str | None = None,
+        start_immediately: bool = False,
     ) -> tuple[dict[str, Any], bool]:
         if daily_question_limit is not None and daily_question_limit < 1:
             raise ValueError("daily_question_limit must be positive")
@@ -305,6 +306,14 @@ class EvaluationStore:
                 "VALUES (?, 1, 'queued', ?, '{}')",
                 (run_id, created_at),
             )
+            if start_immediately:
+                # Maintenance executions must not be visible to schedulers
+                # between creation and their independently managed start.
+                connection.execute(
+                    "INSERT INTO run_events(run_id, sequence, event_type, created_at, payload_json) "
+                    "VALUES (?, 2, 'started', ?, '{}')",
+                    (run_id, utc_now()),
+                )
         found = self.get_run(run_id)
         assert found is not None
         return found, True
@@ -868,7 +877,9 @@ class EvaluationStore:
                 (run_id,),
             ).fetchone()
             if current is None:
-                raise KeyError(run_id)
+                # Recovery can make a run deletable before its executor
+                # returns. A deleted run is another rejected stale result.
+                return False
             claimed = connection.execute(
                 "SELECT 1 FROM model_slots WHERE slot_id = ? AND run_id = ? "
                 "AND worker_id = ? AND lease_until > ?",

--- a/human_eval/store.py
+++ b/human_eval/store.py
@@ -128,14 +128,14 @@ class EvaluationStore:
         self.path = Path(path)
 
     @contextmanager
-    def _connect(self) -> Iterator[sqlite3.Connection]:
+    def _connect(self, *, timeout: float = 30) -> Iterator[sqlite3.Connection]:
         """Open one connection for an operation and always close it."""
-        connection = sqlite3.connect(self.path, timeout=30)
+        connection = sqlite3.connect(self.path, timeout=timeout)
         try:
             with connection:
                 connection.row_factory = sqlite3.Row
                 connection.execute("PRAGMA foreign_keys = ON")
-                connection.execute("PRAGMA busy_timeout = 30000")
+                connection.execute(f"PRAGMA busy_timeout = {max(0, int(timeout * 1000))}")
                 yield connection
         finally:
             connection.close()
@@ -361,11 +361,12 @@ class EvaluationStore:
         worker_id: str,
         concurrency: int,
         lease_seconds: float,
+        timeout: float = 30,
     ) -> tuple[str, int] | None:
         """Atomically claim the oldest queued run and one model slot."""
         if concurrency < 1 or lease_seconds <= 0:
             raise ValueError("invalid scheduler limits")
-        with self._connect() as connection:
+        with self._connect(timeout=timeout) as connection:
             connection.execute("BEGIN IMMEDIATE")
             # A busy SQLite writer may have delayed this transaction. Start
             # the lease only after the write lock is actually ours.
@@ -418,10 +419,11 @@ class EvaluationStore:
         slot_id: int,
         worker_id: str,
         lease_seconds: float,
+        timeout: float = 30,
     ) -> bool:
         if lease_seconds <= 0:
             raise ValueError("lease_seconds must be positive")
-        with self._connect() as connection:
+        with self._connect(timeout=timeout) as connection:
             connection.execute("BEGIN IMMEDIATE")
             # Calculate under the write lock so lock contention cannot consume
             # some or all of the renewed lease before the UPDATE commits.

--- a/human_eval/store.py
+++ b/human_eval/store.py
@@ -148,6 +148,11 @@ class EvaluationStore:
                 "CREATE TABLE IF NOT EXISTS schema_meta ("
                 "key TEXT PRIMARY KEY, value TEXT NOT NULL)"
             )
+            connection.commit()
+            # Uvicorn factory workers can initialize concurrently. Hold the
+            # write lock from version inspection through every schema change
+            # so no worker acts on stale pre-migration column metadata.
+            connection.execute("BEGIN IMMEDIATE")
             current = connection.execute(
                 "SELECT value FROM schema_meta WHERE key = 'schema_version'"
             ).fetchone()
@@ -155,17 +160,9 @@ class EvaluationStore:
                 raise RuntimeError(
                     f"unsupported evaluation schema {current[0]!r}; expected {SCHEMA_VERSION}"
                 )
-            connection.executescript(SCHEMA)
+            self._execute_schema(connection)
             self._migrate_columns(connection)
-            # executescript may commit while creating missing tables. Re-enter
-            # a write transaction and re-read the version so only one process
-            # performs v4 orphan recovery during a concurrent deployment.
-            connection.commit()
-            connection.execute("BEGIN IMMEDIATE")
-            migration_version = connection.execute(
-                "SELECT value FROM schema_meta WHERE key = 'schema_version'"
-            ).fetchone()
-            if migration_version and migration_version[0] != SCHEMA_VERSION:
+            if current and current[0] != SCHEMA_VERSION:
                 # Only schema migration can identify these as pre-v4 runs.
                 # In schema v4, supported maintenance jobs may intentionally
                 # execute a started run without participating in model_slots.
@@ -176,12 +173,25 @@ class EvaluationStore:
                 "INSERT OR IGNORE INTO schema_meta(key, value) VALUES (?, ?)",
                 ("schema_version", SCHEMA_VERSION),
             )
-            if migration_version and migration_version[0] != SCHEMA_VERSION:
+            if current and current[0] != SCHEMA_VERSION:
                 connection.execute(
                     "UPDATE schema_meta SET value = ? WHERE key = 'schema_version'",
                     (SCHEMA_VERSION,),
                 )
             connection.execute("PRAGMA optimize")
+
+    @staticmethod
+    def _execute_schema(connection: sqlite3.Connection) -> None:
+        """Execute the schema without the implicit commit from executescript."""
+        statement = ""
+        for line in SCHEMA.splitlines(keepends=True):
+            statement += line
+            if sqlite3.complete_statement(statement):
+                if statement.strip():
+                    connection.execute(statement)
+                statement = ""
+        if statement.strip():
+            raise RuntimeError("incomplete SQLite schema statement")
 
     @staticmethod
     def _migrate_columns(connection: sqlite3.Connection) -> None:

--- a/scripts/seed_human_eval_v4_hybrid.py
+++ b/scripts/seed_human_eval_v4_hybrid.py
@@ -66,12 +66,14 @@ def seed_live_run(
             # Do not delete a queued/running run owned by another process.
             return "pending"
     record, created = store.create_run(
-        request, user_id=SEED_USER, provenance=executor.provenance()
+        request,
+        user_id=SEED_USER,
+        provenance=executor.provenance(),
+        start_immediately=True,
     )
     if not created:
         return "skipped"
     run_id = record["run_id"]
-    store.append_event(run_id, "started")
     try:
         result = executor.execute(
             request,

--- a/tests/test_embedding_server.py
+++ b/tests/test_embedding_server.py
@@ -72,6 +72,24 @@ class EmbeddingServerTests(unittest.TestCase):
         unregister.assert_called_once()
         stop.assert_called_once_with(process)
 
+    def test_external_embedder_does_not_start_or_stop_server(self):
+        with (
+            mock.patch("corpus_store.embed.start_server") as start_server,
+            mock.patch(
+                "corpus_store.embed.embed_batch",
+                return_value=np.zeros((1, DIMS), dtype=np.float32),
+            ) as embed_batch,
+            mock.patch("corpus_store.embed.stop_server") as stop_server,
+            mock.patch("agent_tools.retrieval.atexit.register") as register,
+        ):
+            embedder = LlamaQueryEmbedder(Path("model.gguf"), manage_server=False)
+            embedder.close()
+
+        embed_batch.assert_called_once_with(["Query: probe"], 8086)
+        start_server.assert_not_called()
+        stop_server.assert_not_called()
+        register.assert_not_called()
+
     def test_close_waits_for_an_in_flight_embedding(self):
         process = mock.Mock()
         process.poll.return_value = None

--- a/tests/test_human_eval.py
+++ b/tests/test_human_eval.py
@@ -1069,6 +1069,44 @@ class ServiceTests(unittest.TestCase):
         finally:
             replacement.close()
 
+    def test_worker_survives_when_recovery_wins_the_lease_race(self):
+        executor = BlockingExecutor()
+        service = EvaluationService(
+            self.store,
+            executor,
+            executor.provenance,
+            lease_seconds=30,
+        )
+        service.start()
+        try:
+            run = service.submit(RunRequest("primera"), user_id="one", admin=True)
+            self.assertTrue(executor.started.wait(timeout=1))
+            # Another process recovers the run while this worker is still
+            # executing it (lease expired during a stalled heartbeat).
+            self.assertEqual(self.store.expire_model_leases(service.worker_id), 1)
+            self.assertEqual(self.store.recover_expired_model_slots(), 1)
+            executor.release.set()
+            # The worker finishes, drops its late 'succeeded' result and
+            # keeps serving: the terminal recovery event wins.
+            deadline = time.monotonic() + 3
+            while time.monotonic() < deadline:
+                if self.store.model_activity(1)["active"] == 0:
+                    break
+                time.sleep(0.01)
+            else:
+                self.fail("worker did not release the recovered run's slot")
+            recovered = service.public_run(run["run_id"], admin=True)
+            self.assertEqual(recovered["status"], "failed")
+            self.assertEqual(recovered["error"]["code"], "service_restarted")
+            self.assertTrue(service.worker.is_alive())
+            follow_up = service.submit(RunRequest("segunda"), user_id="one", admin=True)
+            self.assertEqual(
+                wait_for_terminal(service, follow_up["run_id"])["status"],
+                "succeeded",
+            )
+        finally:
+            service.close()
+
 
 class AirAppTestCase(unittest.TestCase):
     daily_question_limit = 50

--- a/tests/test_human_eval.py
+++ b/tests/test_human_eval.py
@@ -34,7 +34,13 @@ from human_eval.service import (
     IdempotencyConflictError,
     PublicExecutionError,
 )
-from human_eval.store import SCHEMA_VERSION, EvaluationStore
+from human_eval.store import (
+    SCHEMA_VERSION,
+    ActiveRunConflict,
+    DailyQuotaConflict,
+    EvaluationStore,
+    QueueCapacityConflict,
+)
 from scripts.seed_human_eval_v4_hybrid import SEED_USER, seed_live_run
 
 PROVENANCE = {
@@ -105,6 +111,31 @@ class BlockingExecutor(FakeExecutor):
         if not self.release.wait(timeout=3):
             raise RuntimeError("test timed out")
         return super().execute(request, on_progress=on_progress)
+
+
+class ConcurrentBlockingExecutor(FakeExecutor):
+    def __init__(self):
+        self.release = threading.Event()
+        self.started = threading.Event()
+        self._lock = threading.Lock()
+        self.active = 0
+        self.max_active = 0
+        self.started_count = 0
+
+    def execute(self, request: RunRequest, *, on_progress=None):
+        with self._lock:
+            self.active += 1
+            self.max_active = max(self.max_active, self.active)
+            self.started_count += 1
+            if self.started_count >= 2:
+                self.started.set()
+        try:
+            if not self.release.wait(timeout=3):
+                raise RuntimeError("test timed out")
+            return super().execute(request, on_progress=on_progress)
+        finally:
+            with self._lock:
+                self.active -= 1
 
 
 def wait_for_terminal(service: EvaluationService, run_id: str) -> dict:
@@ -778,6 +809,39 @@ class StoreTests(unittest.TestCase):
         self.assertEqual(first["run_id"], second["run_id"])
         self.assertNotEqual(first["run_id"], third["run_id"])
 
+    def test_admission_constraints_are_independent(self):
+        first, _ = self.store.create_run(
+            RunRequest("primera"), user_id="one", provenance=PROVENANCE
+        )
+        with self.assertRaises(ActiveRunConflict):
+            self.store.create_run(
+                RunRequest("segunda"),
+                user_id="one",
+                provenance=PROVENANCE,
+                enforce_active_run=True,
+            )
+        with self.assertRaises(QueueCapacityConflict):
+            self.store.create_run(
+                RunRequest("tercera"),
+                user_id="two",
+                provenance=PROVENANCE,
+                queue_capacity=1,
+            )
+        self.store.create_run(
+            RunRequest("cuarta"),
+            user_id="three",
+            provenance=PROVENANCE,
+        )
+        with self.assertRaises(DailyQuotaConflict):
+            self.store.create_run(
+                RunRequest("quinta"),
+                user_id="three",
+                provenance=PROVENANCE,
+                daily_question_limit=1,
+                daily_since="",
+            )
+        self.assertEqual(self.store.get_run(first["run_id"])["status"], "queued")
+
 
 class ServiceTests(unittest.TestCase):
     def setUp(self):
@@ -988,6 +1052,33 @@ class ServiceTests(unittest.TestCase):
             second_executor.release.set()
             first_service.close()
             second_service.close()
+
+    def test_one_service_runs_configured_parallel_workers(self):
+        executor = ConcurrentBlockingExecutor()
+        service = EvaluationService(
+            self.store,
+            executor,
+            executor.provenance,
+            model_concurrency=2,
+            scheduler_workers=2,
+        )
+        service.start()
+        try:
+            first = service.submit(RunRequest("primera"), user_id="one", admin=True)
+            second = service.submit(RunRequest("segunda"), user_id="two", admin=True)
+            self.assertTrue(executor.started.wait(timeout=1))
+            self.assertEqual(executor.max_active, 2)
+            self.assertEqual(self.store.model_activity(2)["active"], 2)
+            executor.release.set()
+            self.assertEqual(
+                wait_for_terminal(service, first["run_id"])["status"], "succeeded"
+            )
+            self.assertEqual(
+                wait_for_terminal(service, second["run_id"])["status"], "succeeded"
+            )
+        finally:
+            executor.release.set()
+            service.close()
 
     def test_close_runs_the_executor_shutdown_hook(self):
         class ClosingExecutor(FakeExecutor):

--- a/tests/test_human_eval.py
+++ b/tests/test_human_eval.py
@@ -270,6 +270,8 @@ class AgentExecutorConfigTests(unittest.TestCase):
             Path("~/dof-gguf/jina-v5-small-retrieval-F16.gguf").expanduser(),
         )
         self.assertEqual(config.embed_port, 8086)
+        self.assertEqual(config.model_concurrency, 1)
+        self.assertTrue(config.manage_embed_server)
 
     def test_lexical_mode_does_not_default_to_vector_database(self):
         vec0_dir = self.root.resolve() / "dof_db"
@@ -339,6 +341,13 @@ class AgentExecutorConfigTests(unittest.TestCase):
             DOF_AGENT_PROVIDER="llama-server", DOF_REASONING_EFFORT=""
         )
         self.assertIsNone(config.reasoning_effort)
+
+    def test_accepts_shared_model_and_external_embedding_server(self):
+        config = self._config(
+            DOF_MODEL_CONCURRENCY="4", DOF_MANAGE_EMBED_SERVER="false"
+        )
+        self.assertEqual(config.model_concurrency, 4)
+        self.assertFalse(config.manage_embed_server)
 
     def test_non_lexical_mode_requires_existing_vector_index(self):
         with self.assertRaisesRegex(ValueError, "vector index"):
@@ -935,6 +944,50 @@ class ServiceTests(unittest.TestCase):
         finally:
             executor.release.set()
             service.close()
+
+    def test_two_services_share_one_sqlite_model_slot(self):
+        first_executor = BlockingExecutor()
+        second_executor = BlockingExecutor()
+        first_service = EvaluationService(
+            self.store,
+            first_executor,
+            first_executor.provenance,
+            model_concurrency=1,
+            lease_seconds=1,
+        )
+        second_service = EvaluationService(
+            self.store,
+            second_executor,
+            second_executor.provenance,
+            model_concurrency=1,
+            lease_seconds=1,
+        )
+        first_service.start()
+        second_service.start()
+        try:
+            first = first_service.submit(
+                RunRequest("primera", client_request_id="shared-1"),
+                user_id="shared-u1",
+                admin=True,
+            )
+            self.assertTrue(first_executor.started.wait(timeout=1))
+            second = second_service.submit(
+                RunRequest("segunda", client_request_id="shared-2"),
+                user_id="shared-u2",
+                admin=True,
+            )
+            time.sleep(0.3)
+            self.assertEqual(self.store.model_activity(1)["active"], 1)
+            self.assertEqual(self.store.get_run(second["run_id"])["status"], "queued")
+            first_executor.release.set()
+            second_executor.release.set()
+            wait_for_terminal(first_service, first["run_id"])
+            wait_for_terminal(first_service, second["run_id"])
+        finally:
+            first_executor.release.set()
+            second_executor.release.set()
+            first_service.close()
+            second_service.close()
 
     def test_close_runs_the_executor_shutdown_hook(self):
         class ClosingExecutor(FakeExecutor):
@@ -1815,7 +1868,7 @@ class QueueAdmissionTests(AirAppTestCase):
             self.as_user("u3", admin=True)
             response = self.post_run("pregunta tres")
             self.assertEqual(response.status_code, 503)
-            self.assertIn("La cola local está llena", response.text)
+            self.assertIn("La cola de preguntas está llena", response.text)
             retry_after = int(response.headers["Retry-After"])
             self.assertGreaterEqual(retry_after, 60)
         finally:

--- a/tests/test_human_eval.py
+++ b/tests/test_human_eval.py
@@ -893,6 +893,49 @@ class ServiceTests(unittest.TestCase):
             executor.release.set()
             service.close()
 
+    def test_queue_position_wait_estimate_and_durations(self):
+        executor = BlockingExecutor()
+        service = EvaluationService(self.store, executor, executor.provenance)
+        service.start()
+        try:
+            first = service.submit(
+                RunRequest("primera", client_request_id="q1"),
+                user_id="u1",
+                admin=True,
+            )
+            self.assertTrue(executor.started.wait(timeout=3))
+            second = service.submit(
+                RunRequest("segunda", client_request_id="q2"),
+                user_id="u2",
+                admin=True,
+            )
+            third = service.submit(
+                RunRequest("tercera", client_request_id="q3"),
+                user_id="u3",
+                admin=True,
+            )
+            queued = service.public_run(second["run_id"], admin=True)
+            self.assertEqual(queued["queue_position"], 1)
+            self.assertEqual(queued["estimated_wait_seconds"], 480)
+            behind = service.public_run(third["run_id"], admin=True)
+            self.assertEqual(behind["queue_position"], 2)
+            self.assertEqual(behind["estimated_wait_seconds"], 960)
+            # A started run has no queue position.
+            self.assertIsNone(self.store.queue_position(first["run_id"]))
+            executor.release.set()
+            wait_for_terminal(service, first["run_id"])
+            wait_for_terminal(service, second["run_id"])
+            wait_for_terminal(service, third["run_id"])
+            finished = service.public_run(second["run_id"], admin=True)
+            self.assertNotIn("queue_position", finished)
+            durations = self.store.recent_durations()
+            self.assertEqual(len(durations), 3)
+            self.assertTrue(all(value >= 0 for value in durations))
+            self.assertGreaterEqual(service.queue_retry_after(), 60)
+        finally:
+            executor.release.set()
+            service.close()
+
     def test_close_runs_the_executor_shutdown_hook(self):
         class ClosingExecutor(FakeExecutor):
             def __init__(self):
@@ -976,13 +1019,22 @@ class ServiceTests(unittest.TestCase):
 
 class AirAppTestCase(unittest.TestCase):
     daily_question_limit = 50
+    queue_capacity = 20
+
+    def make_executor(self) -> FakeExecutor:
+        return FakeExecutor()
 
     def setUp(self):
         self.tempdir = tempfile.TemporaryDirectory()
         self.db_path = Path(self.tempdir.name) / "evaluation.sqlite"
         store = EvaluationStore(self.db_path)
-        self.executor = FakeExecutor()
-        self.service = EvaluationService(store, self.executor, self.executor.provenance)
+        self.executor = self.make_executor()
+        self.service = EvaluationService(
+            store,
+            self.executor,
+            self.executor.provenance,
+            queue_capacity=self.queue_capacity,
+        )
         self.settings = WebSettings(
             host="127.0.0.1",
             port=0,
@@ -1262,6 +1314,15 @@ class AirAppTests(AirAppTestCase):
         feedback = self.service.store.feedback_for_run(run_id)
         self.assertEqual(feedback[0]["rating"], "partially_helpful")
         self.assertEqual(feedback[0]["user_id"], "alice")
+
+    def test_finished_run_splits_queue_wait_from_processing(self):
+        self.seed_and_unlock("alice")
+        run_id = self.create_run()
+        wait_for_terminal(self.service, run_id)
+        page = self.client.get(f"/runs/{run_id}")
+        self.assertEqual(page.status_code, 200)
+        self.assertIn("Espera en cola:", page.text)
+        self.assertIn("Procesamiento:", page.text)
 
     def test_progress_timeline_shows_decisions_and_expandable_chunks(self):
         rendered = _progress_timeline(
@@ -1720,6 +1781,65 @@ class DailyQuotaTests(AirAppTestCase):
         self.as_user("root", admin=True)
         admin_run = self.create_run("pregunta de administración")
         self.assertTrue(admin_run)
+
+
+class QueueAdmissionTests(AirAppTestCase):
+    queue_capacity = 1
+
+    def make_executor(self) -> BlockingExecutor:
+        return BlockingExecutor()
+
+    def post_run(self, question: str):
+        page = self.client.get("/")
+        return self.client.post(
+            "/runs",
+            data={
+                "csrf_token": self.hidden(page, "csrf_token"),
+                "client_request_id": self.hidden(page, "client_request_id"),
+                "question": question,
+                "as_of": "2026-08-17",
+                "required_hops": "1",
+            },
+            follow_redirects=False,
+        )
+
+    def test_queue_full_returns_retry_after_header(self):
+        executor = self.executor
+        assert isinstance(executor, BlockingExecutor)
+        try:
+            self.as_user("u1", admin=True)
+            self.assertEqual(self.post_run("pregunta uno").status_code, 303)
+            self.assertTrue(executor.started.wait(timeout=3))
+            self.as_user("u2", admin=True)
+            self.assertEqual(self.post_run("pregunta dos").status_code, 303)
+            self.as_user("u3", admin=True)
+            response = self.post_run("pregunta tres")
+            self.assertEqual(response.status_code, 503)
+            self.assertIn("La cola local está llena", response.text)
+            retry_after = int(response.headers["Retry-After"])
+            self.assertGreaterEqual(retry_after, 60)
+        finally:
+            executor.release.set()
+
+    def test_queued_run_shows_position_and_estimated_wait(self):
+        executor = self.executor
+        assert isinstance(executor, BlockingExecutor)
+        try:
+            self.as_user("u1", admin=True)
+            self.assertEqual(self.post_run("pregunta uno").status_code, 303)
+            self.assertTrue(executor.started.wait(timeout=3))
+            self.as_user("u2", admin=True)
+            response = self.post_run("pregunta dos")
+            self.assertEqual(response.status_code, 303)
+            run_id = response.headers["location"].split("/")[-1]
+            page = self.client.get(f"/runs/{run_id}")
+            self.assertEqual(page.status_code, 200)
+            self.assertIn("Posición en la cola: 1", page.text)
+            self.assertIn("Espera aproximada: 8 min", page.text)
+            polled = self.client.get(f"/runs/{run_id}/status")
+            self.assertIn("Posición en la cola: 1", polled.text)
+        finally:
+            executor.release.set()
 
 
 if __name__ == "__main__":

--- a/tests/test_human_eval.py
+++ b/tests/test_human_eval.py
@@ -8,6 +8,7 @@ import tempfile
 import threading
 import time
 import unittest
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest import mock
 
@@ -44,6 +45,7 @@ from human_eval.store import (
     ActiveRunConflict,
     DailyQuotaConflict,
     EvaluationStore,
+    IdempotencyPayloadConflict,
     QueueCapacityConflict,
 )
 from scripts.seed_human_eval_v4_hybrid import SEED_USER, seed_live_run
@@ -601,6 +603,38 @@ class StoreTests(unittest.TestCase):
             "model_turn_started",
         )
 
+    def test_claimed_progress_requires_a_live_owned_slot(self):
+        self.store.initialize_model_slots(1)
+        run, _ = self.store.create_run(
+            RunRequest("pregunta válida"),
+            user_id="evaluator",
+            provenance=PROVENANCE,
+        )
+        claim = self.store.claim_next_run(
+            worker_id="worker-one", concurrency=1, lease_seconds=60
+        )
+        self.assertEqual(claim, (run["run_id"], 1))
+        appended = self.store.append_progress_if_claimed(
+            run["run_id"],
+            "agent_started",
+            {"message": "inicio"},
+            slot_id=1,
+            worker_id="worker-one",
+        )
+        self.assertIsNotNone(appended)
+
+        self.assertEqual(self.store.expire_model_leases("worker-one"), 1)
+        self.assertEqual(self.store.recover_expired_model_slots(), 1)
+        dropped = self.store.append_progress_if_claimed(
+            run["run_id"],
+            "model_turn_started",
+            {"turn": 2},
+            slot_id=1,
+            worker_id="worker-one",
+        )
+        self.assertIsNone(dropped)
+        self.assertEqual(len(self.store.progress_for_run(run["run_id"])), 1)
+
     def test_schema_one_is_migrated_without_losing_runs(self):
         run, _ = self.store.create_run(
             RunRequest("pregunta conservada"),
@@ -854,6 +888,95 @@ class StoreTests(unittest.TestCase):
         self.assertEqual(first["run_id"], second["run_id"])
         self.assertNotEqual(first["run_id"], third["run_id"])
 
+    def test_idempotency_payload_is_validated_inside_create_transaction(self):
+        self.store.create_run(
+            RunRequest("pregunta original", client_request_id="same-request"),
+            user_id="one",
+            provenance=PROVENANCE,
+        )
+        with self.assertRaises(IdempotencyPayloadConflict):
+            self.store.create_run(
+                RunRequest("pregunta diferente", client_request_id="same-request"),
+                user_id="one",
+                provenance=PROVENANCE,
+            )
+
+    def test_claim_lease_starts_after_waiting_for_sqlite_write_lock(self):
+        self.store.initialize_model_slots(1)
+        run, _ = self.store.create_run(
+            RunRequest("pregunta válida"), user_id="one", provenance=PROVENANCE
+        )
+        blocker = sqlite3.connect(self.path)
+        blocker.execute("BEGIN IMMEDIATE")
+        result: list[tuple[str, int] | None] = []
+        started = threading.Event()
+
+        def claim() -> None:
+            started.set()
+            result.append(
+                self.store.claim_next_run(
+                    worker_id="worker-one", concurrency=1, lease_seconds=0.1
+                )
+            )
+
+        thread = threading.Thread(target=claim)
+        thread.start()
+        self.assertTrue(started.wait(timeout=1))
+        time.sleep(0.2)
+        lock_released_at = datetime.now(timezone.utc)
+        blocker.commit()
+        blocker.close()
+        thread.join(timeout=2)
+        self.assertFalse(thread.is_alive())
+        self.assertEqual(result, [(run["run_id"], 1)])
+        with sqlite3.connect(self.path) as connection:
+            lease_until = connection.execute(
+                "SELECT lease_until FROM model_slots WHERE slot_id = 1"
+            ).fetchone()[0]
+        deadline = datetime.fromisoformat(lease_until.replace("Z", "+00:00"))
+        self.assertGreater(deadline, lock_released_at)
+
+    def test_renewed_lease_starts_after_waiting_for_sqlite_write_lock(self):
+        self.store.initialize_model_slots(1)
+        run, _ = self.store.create_run(
+            RunRequest("pregunta válida"), user_id="one", provenance=PROVENANCE
+        )
+        self.store.claim_next_run(
+            worker_id="worker-one", concurrency=1, lease_seconds=60
+        )
+        blocker = sqlite3.connect(self.path)
+        blocker.execute("BEGIN IMMEDIATE")
+        result: list[bool] = []
+        started = threading.Event()
+
+        def renew() -> None:
+            started.set()
+            result.append(
+                self.store.renew_model_slot(
+                    run_id=run["run_id"],
+                    slot_id=1,
+                    worker_id="worker-one",
+                    lease_seconds=0.1,
+                )
+            )
+
+        thread = threading.Thread(target=renew)
+        thread.start()
+        self.assertTrue(started.wait(timeout=1))
+        time.sleep(0.2)
+        lock_released_at = datetime.now(timezone.utc)
+        blocker.commit()
+        blocker.close()
+        thread.join(timeout=2)
+        self.assertFalse(thread.is_alive())
+        self.assertEqual(result, [True])
+        with sqlite3.connect(self.path) as connection:
+            lease_until = connection.execute(
+                "SELECT lease_until FROM model_slots WHERE slot_id = 1"
+            ).fetchone()[0]
+        deadline = datetime.fromisoformat(lease_until.replace("Z", "+00:00"))
+        self.assertGreater(deadline, lock_released_at)
+
     def test_admission_constraints_are_independent(self):
         first, _ = self.store.create_run(
             RunRequest("primera"), user_id="one", provenance=PROVENANCE
@@ -931,6 +1054,32 @@ class ServiceTests(unittest.TestCase):
                     user_id="evaluator",
                     admin=True,
                 )
+        finally:
+            service.close()
+
+    def test_submit_maps_transactional_idempotency_payload_conflict(self):
+        self.store.initialize()
+        existing, _ = self.store.create_run(
+            RunRequest("pregunta original", client_request_id="request-race"),
+            user_id="evaluator",
+            provenance=PROVENANCE,
+        )
+        self.store.append_event(existing["run_id"], "failed", {"code": "test"})
+        executor = FakeExecutor()
+        service = EvaluationService(self.store, executor, executor.provenance)
+        service.start()
+        try:
+            # Simulate two processes both missing their preliminary read. The
+            # create transaction must still reject the loser's changed body.
+            with mock.patch.object(service, "idempotent_run", return_value=None):
+                with self.assertRaises(IdempotencyConflictError):
+                    service.submit(
+                        RunRequest(
+                            "pregunta diferente", client_request_id="request-race"
+                        ),
+                        user_id="evaluator",
+                        admin=True,
+                    )
         finally:
             service.close()
 
@@ -1103,7 +1252,6 @@ class ServiceTests(unittest.TestCase):
             lease_seconds=1,
         )
         first_service.start()
-        second_service.start()
         try:
             first = first_service.submit(
                 RunRequest("primera", client_request_id="shared-1"),
@@ -1111,6 +1259,9 @@ class ServiceTests(unittest.TestCase):
                 admin=True,
             )
             self.assertTrue(first_executor.started.wait(timeout=1))
+            # Start the competing process only after the first process owns
+            # the slot; either service is otherwise allowed to claim first.
+            second_service.start()
             second = second_service.submit(
                 RunRequest("segunda", client_request_id="shared-2"),
                 user_id="shared-u2",
@@ -1258,6 +1409,49 @@ class ServiceTests(unittest.TestCase):
         service.worker.join(timeout=1)
         self.assertTrue(executor.closed)
 
+    def test_last_of_multiple_workers_closes_executor_after_timed_out_shutdown(self):
+        class ClosingConcurrentExecutor(ConcurrentBlockingExecutor):
+            def __init__(self):
+                super().__init__()
+                self.closed = False
+
+            def close(self):
+                self.closed = True
+
+        executor = ClosingConcurrentExecutor()
+        service = EvaluationService(
+            self.store,
+            executor,
+            executor.provenance,
+            model_concurrency=2,
+            scheduler_workers=2,
+            shutdown_timeout=0.01,
+        )
+        service.start()
+        service.submit(RunRequest("primera"), user_id="one", admin=True)
+        service.submit(RunRequest("segunda"), user_id="two", admin=True)
+        self.assertTrue(executor.started.wait(timeout=1))
+        service.close()
+        self.assertFalse(executor.closed)
+        executor.release.set()
+        for worker in service.workers:
+            worker.join(timeout=1)
+        self.assertTrue(executor.closed)
+
+    def test_heartbeat_interval_remains_shorter_than_tiny_lease(self):
+        service = EvaluationService(
+            self.store,
+            FakeExecutor(),
+            lambda: dict(PROVENANCE),
+            lease_seconds=0.03,
+        )
+        stop = mock.Mock()
+        stop.wait.return_value = True
+        service._lease_heartbeat(stop, "run-id", 1)
+        interval = stop.wait.call_args.args[0]
+        self.assertAlmostEqual(interval, 0.01)
+        self.assertLess(interval, service.lease_seconds)
+
     def test_close_never_blocks_on_full_queue_or_writes_late_results(self):
         executor = BlockingExecutor()
         service = EvaluationService(
@@ -1344,6 +1538,7 @@ class ServiceTests(unittest.TestCase):
             recovered = service.public_run(run["run_id"], admin=True)
             self.assertEqual(recovered["status"], "failed")
             self.assertEqual(recovered["error"]["code"], "service_restarted")
+            self.assertEqual(self.store.progress_for_run(run["run_id"]), [])
             self.assertTrue(service.worker.is_alive())
             follow_up = service.submit(RunRequest("segunda"), user_id="one", admin=True)
             self.assertEqual(

--- a/tests/test_human_eval.py
+++ b/tests/test_human_eval.py
@@ -660,6 +660,24 @@ class StoreTests(unittest.TestCase):
             self.store.get_run(run["run_id"])["question"], "pregunta conservada"
         )
 
+    def test_schema_three_migration_recovers_unclaimed_started_runs(self):
+        run, _ = self.store.create_run(
+            RunRequest("pregunta interrumpida"),
+            user_id="evaluator",
+            provenance=PROVENANCE,
+        )
+        self.store.append_event(run["run_id"], "started")
+        with sqlite3.connect(self.path) as connection:
+            connection.execute(
+                "UPDATE schema_meta SET value = '3' WHERE key = 'schema_version'"
+            )
+
+        self.store.initialize()
+
+        recovered = self.store.get_run(run["run_id"])
+        self.assertEqual(recovered["status"], "failed")
+        self.assertEqual(recovered["error"]["code"], "service_restarted")
+
     def test_schema_two_is_migrated_with_user_ids_and_publish_columns(self):
         with sqlite3.connect(self.path) as connection:
             connection.executescript(
@@ -871,6 +889,50 @@ class StoreTests(unittest.TestCase):
         self.assertEqual(record["status"], "succeeded")
         self.assertEqual(executor.calls, 2)
 
+    def test_service_start_does_not_recover_a_live_current_schema_seed(self):
+        executor = BlockingExecutor()
+        outcomes: list[str] = []
+        errors: list[BaseException] = []
+
+        def seed() -> None:
+            try:
+                outcomes.append(
+                    seed_live_run(
+                        self.store,
+                        executor,
+                        {"id": "LI-LIVE", "question": "pregunta semilla"},
+                        publish=False,
+                    )
+                )
+            except BaseException as exc:
+                errors.append(exc)
+
+        thread = threading.Thread(target=seed)
+        thread.start()
+        self.assertTrue(executor.started.wait(timeout=1))
+        service = EvaluationService(
+            self.store, FakeExecutor(), lambda: dict(PROVENANCE)
+        )
+        service.start()
+        try:
+            record = self.store.find_idempotent_run(
+                SEED_USER, "eval-v4-hybrid:LI-LIVE"
+            )
+            self.assertEqual(record["status"], "running")
+            executor.release.set()
+            thread.join(timeout=2)
+            self.assertFalse(thread.is_alive())
+            self.assertEqual(errors, [])
+            self.assertEqual(outcomes, ["created"])
+            finished = self.store.find_idempotent_run(
+                SEED_USER, "eval-v4-hybrid:LI-LIVE"
+            )
+            self.assertEqual(finished["status"], "succeeded")
+        finally:
+            executor.release.set()
+            thread.join(timeout=1)
+            service.close()
+
     def test_client_request_id_is_idempotent_per_evaluator(self):
         request = RunRequest("pregunta válida", client_request_id="same-request")
         first, first_created = self.store.create_run(
@@ -976,6 +1038,27 @@ class StoreTests(unittest.TestCase):
             ).fetchone()[0]
         deadline = datetime.fromisoformat(lease_until.replace("Z", "+00:00"))
         self.assertGreater(deadline, lock_released_at)
+
+    def test_expired_lease_cannot_be_resurrected_by_heartbeat(self):
+        self.store.initialize_model_slots(1)
+        run, _ = self.store.create_run(
+            RunRequest("pregunta válida"), user_id="one", provenance=PROVENANCE
+        )
+        self.store.claim_next_run(
+            worker_id="worker-one", concurrency=1, lease_seconds=0.01
+        )
+        time.sleep(0.02)
+
+        renewed = self.store.renew_model_slot(
+            run_id=run["run_id"],
+            slot_id=1,
+            worker_id="worker-one",
+            lease_seconds=60,
+        )
+
+        self.assertFalse(renewed)
+        self.assertEqual(self.store.recover_expired_model_slots(), 1)
+        self.assertEqual(self.store.get_run(run["run_id"])["status"], "failed")
 
     def test_admission_constraints_are_independent(self):
         first, _ = self.store.create_run(
@@ -1501,12 +1584,38 @@ class ServiceTests(unittest.TestCase):
         try:
             with mock.patch.object(
                 self.store,
-                "append_event",
+                "append_terminal_event_if_claimed",
                 side_effect=ValueError("serialization failed"),
             ):
                 with self.assertRaisesRegex(ValueError, "serialization failed"):
-                    service._append_event_if_open("run-id", "succeeded", {})
+                    service._append_event_if_open("run-id", 1, "succeeded", {})
         finally:
+            service.close()
+
+    def test_expired_unreaped_lease_cannot_commit_success(self):
+        executor = BlockingExecutor()
+        service = EvaluationService(
+            self.store,
+            executor,
+            executor.provenance,
+            lease_seconds=0.05,
+        )
+        service.start()
+        try:
+            with mock.patch.object(
+                self.store, "renew_model_slot", return_value=False
+            ):
+                run = service.submit(
+                    RunRequest("pregunta lenta"), user_id="one", admin=True
+                )
+                self.assertTrue(executor.started.wait(timeout=1))
+                time.sleep(0.1)
+                executor.release.set()
+                finished = wait_for_terminal(service, run["run_id"])
+            self.assertEqual(finished["status"], "failed")
+            self.assertEqual(finished["error"]["code"], "service_restarted")
+        finally:
+            executor.release.set()
             service.close()
 
     def test_worker_survives_when_recovery_wins_the_lease_race(self):

--- a/tests/test_human_eval.py
+++ b/tests/test_human_eval.py
@@ -20,10 +20,12 @@ from human_eval.agent_executor import (
     _public_result,
 )
 from human_eval.app import (
+    STREAM_SCRIPT,
     WebSettings,
     _attach_chunk_html,
     _progress_chunk_html,
     _progress_timeline,
+    _queue_status_event,
     _sanitize_login_next,
     create_app,
 )
@@ -678,6 +680,27 @@ class StoreTests(unittest.TestCase):
         self.assertEqual(recovered["status"], "failed")
         self.assertEqual(recovered["error"]["code"], "service_restarted")
 
+    def test_schema_migration_holds_the_sqlite_write_lock(self):
+        original = EvaluationStore._migrate_columns
+        observed_transaction: list[bool] = []
+
+        def inspect_lock(connection: sqlite3.Connection) -> None:
+            observed_transaction.append(connection.in_transaction)
+            probe = sqlite3.connect(self.path, timeout=0)
+            try:
+                with self.assertRaises(sqlite3.OperationalError):
+                    probe.execute("BEGIN IMMEDIATE")
+            finally:
+                probe.close()
+            original(connection)
+
+        with mock.patch.object(
+            EvaluationStore, "_migrate_columns", side_effect=inspect_lock
+        ):
+            self.store.initialize()
+
+        self.assertEqual(observed_transaction, [True])
+
     def test_schema_two_is_migrated_with_user_ids_and_publish_columns(self):
         with sqlite3.connect(self.path) as connection:
             connection.executescript(
@@ -1286,6 +1309,19 @@ class ServiceTests(unittest.TestCase):
             executor.release.set()
             service.close()
 
+    def test_queue_retry_after_estimates_the_next_completion(self):
+        service = EvaluationService(
+            self.store, FakeExecutor(), lambda: dict(PROVENANCE)
+        )
+        with (
+            mock.patch.object(
+                self.store, "recent_durations", return_value=[120.0, 180.0]
+            ),
+            mock.patch.object(self.store, "queue_depth", return_value=20) as depth,
+        ):
+            self.assertEqual(service.queue_retry_after(), 150)
+        depth.assert_not_called()
+
     def test_queue_full_rejection_is_logged(self):
         executor = BlockingExecutor()
         service = EvaluationService(
@@ -1659,6 +1695,24 @@ class ServiceTests(unittest.TestCase):
 
 
 class AppMainTests(unittest.TestCase):
+    def test_queue_status_event_requires_one_complete_snapshot(self):
+        self.assertIsNone(_queue_status_event({"status": "queued"}))
+        queue_event = _queue_status_event(
+            {
+                "status": "queued",
+                "queue_position": 2,
+                "estimated_wait_seconds": 600,
+                "queue_snapshot": {"active": 1, "capacity": 2},
+            }
+        )
+        self.assertEqual(queue_event[0], (2, 1, 2))
+        self.assertIn("Posición en la cola: 2", queue_event[1])
+        self.assertNotIn("Posición en la cola: 0", queue_event[1])
+
+    def test_stream_clears_stale_queue_status_when_work_starts(self):
+        self.assertIn("if (queueStatus) queueStatus.remove();", STREAM_SCRIPT)
+        self.assertIn("source.addEventListener('running'", STREAM_SCRIPT)
+
     def test_multi_worker_server_honors_configured_host_and_port(self):
         env = {
             "DOF_SESSION_SECRET": "test-session-secret-that-is-at-least-32-bytes",

--- a/tests/test_human_eval.py
+++ b/tests/test_human_eval.py
@@ -1565,9 +1565,15 @@ class ServiceTests(unittest.TestCase):
             lease_seconds=0.03,
         )
         stop = mock.Mock()
-        stop.wait.return_value = True
-        service._lease_heartbeat(stop, "run-id", 1)
-        interval = stop.wait.call_args.args[0]
+        # Run two iterations: an immediate renewal, then one interval wait.
+        stop.wait.side_effect = [False, True]
+        with mock.patch.object(
+            self.store, "renew_model_slot", return_value=True
+        ) as renewal:
+            service._lease_heartbeat(stop, "run-id", 1)
+        self.assertEqual(renewal.call_count, 1)
+        first_delay, interval = (call.args[0] for call in stop.wait.call_args_list)
+        self.assertEqual(first_delay, 0.0)
         self.assertAlmostEqual(interval, 0.01)
         self.assertLess(interval, service.lease_seconds)
 

--- a/tests/test_model_scheduler_regressions.py
+++ b/tests/test_model_scheduler_regressions.py
@@ -302,7 +302,10 @@ class SchedulerRegressionTests(unittest.TestCase):
         self.assertAlmostEqual(clock[0], 1.0)
         self.assertGreater(renew.call_count, 1)
         self.assertLess(renew.call_count, 10)
-        self.assertTrue(all(0 < value <= 1 / 3 for value in waits))
+        # The first renewal happens immediately after the claim; later
+        # retries stay bounded by the heartbeat interval.
+        self.assertEqual(waits[0], 0.0)
+        self.assertTrue(all(0 < value <= 1 / 3 for value in waits[1:]))
 
     def test_heartbeat_does_not_retry_non_transient_errors(self):
         service = EvaluationService(self.store, BlockingExecutor(), lambda: {})
@@ -339,3 +342,94 @@ class SchedulerRegressionTests(unittest.TestCase):
                 run_id=run["run_id"], slot_id=1, worker_id="owner", lease_seconds=60
             )
         )
+
+    def test_heartbeat_renews_lease_immediately_after_claim(self):
+        service, executor = self.make_service(lease_seconds=30)
+        renewed = threading.Event()
+        renew = self.store.renew_model_slot
+
+        def tracking(**kwargs):
+            renewed.set()
+            return renew(**kwargs)
+
+        with mock.patch.object(self.store, "renew_model_slot", side_effect=tracking):
+            service.submit(RunRequest("question"), user_id="one", admin=True)
+            self.assertTrue(executor.started.wait(1))
+            # The first renewal must not wait a full 10 s heartbeat interval,
+            # so a stalled claim->execution gap cannot outlive the lease.
+            self.assertTrue(renewed.wait(3))
+
+    def test_progress_contention_drops_event_without_failing_run(self):
+        service, executor = self.make_service()
+        executor.release.set()
+        progress = self.store.append_progress_if_claimed
+        busy = sqlite3.OperationalError("database is locked")
+        busy.sqlite_errorcode = sqlite3.SQLITE_BUSY
+        attempts = []
+
+        def fail_once(*args, **kwargs):
+            attempts.append(1)
+            if len(attempts) == 1:
+                raise busy
+            return progress(*args, **kwargs)
+
+        with mock.patch.object(
+            self.store, "append_progress_if_claimed", side_effect=fail_once
+        ):
+            run = service.submit(RunRequest("question"), user_id="one", admin=True)
+            deadline = time.monotonic() + 3
+            while time.monotonic() < deadline:
+                if self.store.get_run(run["run_id"])["status"] == "succeeded":
+                    break
+                time.sleep(0.01)
+        self.assertEqual(self.store.get_run(run["run_id"])["status"], "succeeded")
+        self.assertEqual(len(attempts), 1)
+
+    def test_progress_non_transient_error_still_fails_run(self):
+        service, executor = self.make_service()
+        executor.release.set()
+        error = sqlite3.OperationalError("no such table: run_progress")
+        error.sqlite_errorcode = sqlite3.SQLITE_ERROR
+
+        with mock.patch.object(
+            self.store, "append_progress_if_claimed", side_effect=error
+        ):
+            run = service.submit(RunRequest("question"), user_id="one", admin=True)
+            deadline = time.monotonic() + 3
+            while time.monotonic() < deadline:
+                if self.store.get_run(run["run_id"])["status"] == "failed":
+                    break
+                time.sleep(0.01)
+        record = self.store.get_run(run["run_id"])
+        self.assertEqual(record["status"], "failed")
+        self.assertEqual(record["error"]["code"], "internal_error")
+
+    def test_terminal_write_retries_transient_busy_error(self):
+        service, executor = self.make_service()
+        executor.release.set()
+        append = self.store.append_terminal_event_if_claimed
+        busy = sqlite3.OperationalError("database is locked")
+        busy.sqlite_errorcode = sqlite3.SQLITE_BUSY
+        attempts = []
+
+        def fail_once(*args, **kwargs):
+            attempts.append(1)
+            if len(attempts) == 1:
+                raise busy
+            return append(*args, **kwargs)
+
+        with mock.patch.object(
+            self.store, "append_terminal_event_if_claimed", side_effect=fail_once
+        ):
+            run = service.submit(RunRequest("question"), user_id="one", admin=True)
+            deadline = time.monotonic() + 3
+            while time.monotonic() < deadline:
+                if (
+                    self.store.get_run(run["run_id"])["status"] == "succeeded"
+                    and self.store.model_activity(1)["available"] == 1
+                ):
+                    break
+                time.sleep(0.01)
+        self.assertEqual(self.store.get_run(run["run_id"])["status"], "succeeded")
+        self.assertEqual(len(attempts), 2)
+        self.assertEqual(self.store.model_activity(1)["available"], 1)

--- a/tests/test_model_scheduler_regressions.py
+++ b/tests/test_model_scheduler_regressions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 import tempfile
 import threading
 import time
@@ -177,3 +178,164 @@ class SchedulerRegressionTests(unittest.TestCase):
                 self.assertIn("Espera aproximada: menos de 1 min", event[1])
                 html = _status_fragment(run)
                 self.assertIn("Espera aproximada: menos de 1 min", html)
+
+    def test_claim_is_serialized_with_shutdown(self):
+        executor = BlockingExecutor()
+        service = EvaluationService(
+            self.store, executor, lambda: {}, shutdown_timeout=0.01
+        )
+        entered = threading.Event()
+        release = threading.Event()
+        observed = []
+        original = self.store.claim_next_run
+
+        def claim(**kwargs):
+            acquired = service._write_lock.acquire(blocking=False)
+            observed.append(acquired)
+            self.assertLessEqual(kwargs["timeout"], service.shutdown_timeout)
+            if acquired:
+                service._write_lock.release()
+            entered.set()
+            if not release.wait(3):
+                raise RuntimeError("claim barrier timed out")
+            return original(**kwargs)
+
+        with mock.patch.object(self.store, "claim_next_run", side_effect=claim):
+            service.start()
+            service.queue.put_nowait("wake")
+            try:
+                self.assertTrue(entered.wait(1))
+                self.assertEqual(observed, [False])
+            finally:
+                release.set()
+                service.close()
+        # Once the shutdown transition holds the lock, no later claim is made.
+        with mock.patch.object(self.store, "claim_next_run") as later_claim:
+            service._worker_loop()
+        later_claim.assert_not_called()
+
+    def test_scheduler_retries_busy_claim_and_completes_queued_work(self):
+        executor = BlockingExecutor()
+        executor.release.set()
+        service = EvaluationService(self.store, executor, lambda: {})
+        claim = self.store.claim_next_run
+        busy = sqlite3.OperationalError("database is locked")
+        busy.sqlite_errorcode = sqlite3.SQLITE_BUSY
+        attempts = []
+
+        def fail_once(**kwargs):
+            attempts.append(1)
+            if len(attempts) == 1:
+                raise busy
+            return claim(**kwargs)
+
+        with mock.patch.object(self.store, "claim_next_run", side_effect=fail_once):
+            service.start()
+            try:
+                run = service.submit(RunRequest("question"), user_id="one", admin=True)
+                deadline = time.monotonic() + 3
+                while time.monotonic() < deadline:
+                    if self.store.get_run(run["run_id"])["status"] == "succeeded":
+                        break
+                    time.sleep(0.01)
+                self.assertEqual(
+                    self.store.get_run(run["run_id"])["status"], "succeeded"
+                )
+                self.assertTrue(service.worker.is_alive())
+                self.assertGreaterEqual(len(attempts), 2)
+            finally:
+                service.close()
+
+    def test_heartbeat_retries_busy_renewal_while_execution_continues(self):
+        service, executor = self.make_service(lease_seconds=1)
+        renew = self.store.renew_model_slot
+        renewed = threading.Event()
+        busy = sqlite3.OperationalError("database is locked")
+        busy.sqlite_errorcode = sqlite3.SQLITE_BUSY
+        attempts = []
+
+        def fail_once(**kwargs):
+            attempts.append(1)
+            if len(attempts) == 1:
+                raise busy
+            result = renew(**kwargs)
+            if result:
+                renewed.set()
+            return result
+
+        with mock.patch.object(self.store, "renew_model_slot", side_effect=fail_once):
+            run = service.submit(RunRequest("question"), user_id="one", admin=True)
+            self.assertTrue(renewed.wait(2))
+            executor.release.set()
+            deadline = time.monotonic() + 2
+            while time.monotonic() < deadline:
+                if self.store.get_run(run["run_id"])["status"] == "succeeded":
+                    break
+                time.sleep(0.01)
+            self.assertEqual(self.store.get_run(run["run_id"])["status"], "succeeded")
+
+    def test_heartbeat_stops_retrying_at_deadline(self):
+        service = EvaluationService(
+            self.store, BlockingExecutor(), lambda: {}, lease_seconds=1
+        )
+        clock = [0.0]
+        waits = []
+        stop = mock.Mock()
+
+        def wait(seconds):
+            waits.append(seconds)
+            clock[0] += seconds
+            return False
+
+        stop.wait.side_effect = wait
+        busy = sqlite3.OperationalError("database is locked")
+        busy.sqlite_errorcode = sqlite3.SQLITE_LOCKED
+        with (
+            mock.patch(
+                "human_eval.service.time.monotonic", side_effect=lambda: clock[0]
+            ),
+            mock.patch.object(
+                self.store, "renew_model_slot", side_effect=busy
+            ) as renew,
+        ):
+            service._lease_heartbeat(stop, "run", 1)
+        self.assertAlmostEqual(clock[0], 1.0)
+        self.assertGreater(renew.call_count, 1)
+        self.assertLess(renew.call_count, 10)
+        self.assertTrue(all(0 < value <= 1 / 3 for value in waits))
+
+    def test_heartbeat_does_not_retry_non_transient_errors(self):
+        service = EvaluationService(self.store, BlockingExecutor(), lambda: {})
+        stop = mock.Mock()
+        stop.wait.return_value = False
+        error = sqlite3.OperationalError("no such table: model_slots")
+        error.sqlite_errorcode = sqlite3.SQLITE_ERROR
+        with mock.patch.object(
+            self.store, "renew_model_slot", side_effect=error
+        ) as renew:
+            with self.assertRaises(sqlite3.OperationalError):
+                service._lease_heartbeat(stop, "run", 1)
+        self.assertEqual(renew.call_count, 1)
+
+    def test_renewal_respects_short_sqlite_busy_timeout(self):
+        self.store.initialize_model_slots(1)
+        run, _ = self.store.create_run(
+            RunRequest("question"), user_id="one", provenance={}
+        )
+        self.store.claim_next_run(worker_id="owner", concurrency=1, lease_seconds=60)
+        with self.store._connect() as locked:
+            locked.execute("BEGIN IMMEDIATE")
+            with self.assertRaises(sqlite3.OperationalError) as raised:
+                self.store.renew_model_slot(
+                    run_id=run["run_id"],
+                    slot_id=1,
+                    worker_id="owner",
+                    lease_seconds=60,
+                    timeout=0,
+                )
+            self.assertEqual(raised.exception.sqlite_errorcode, sqlite3.SQLITE_BUSY)
+        self.assertTrue(
+            self.store.renew_model_slot(
+                run_id=run["run_id"], slot_id=1, worker_id="owner", lease_seconds=60
+            )
+        )

--- a/tests/test_model_scheduler_regressions.py
+++ b/tests/test_model_scheduler_regressions.py
@@ -1,0 +1,179 @@
+"""Regression coverage for shared scheduler lifecycle and maintenance races."""
+
+from __future__ import annotations
+
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from human_eval.app import _queue_status_event, _status_fragment
+from human_eval.contracts import RunRequest
+from human_eval.service import EvaluationService
+from human_eval.store import EvaluationStore
+from scripts.seed_human_eval_v4_hybrid import seed_live_run
+
+
+class BlockingExecutor:
+    def __init__(self):
+        self.started = threading.Event()
+        self.release = threading.Event()
+
+    def provenance(self):
+        return {}
+
+    def execute(self, request, *, on_progress=None):
+        self.started.set()
+        if not self.release.wait(3):
+            raise RuntimeError("test executor timed out")
+        if on_progress:
+            on_progress("agent_started", {})
+        return {}
+
+
+class SchedulerRegressionTests(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.store = EvaluationStore(Path(self.directory.name) / "evaluation.sqlite")
+        self.store.initialize()
+
+    def make_service(self, **kwargs):
+        executor = BlockingExecutor()
+        service = EvaluationService(self.store, executor, executor.provenance, **kwargs)
+        service.start()
+        self.addCleanup(service.close)
+        self.addCleanup(executor.release.set)
+        return service, executor
+
+    def test_deleted_recovered_run_does_not_kill_worker(self):
+        service, executor = self.make_service()
+        run = service.submit(RunRequest("first question"), user_id="one", admin=True)
+        self.assertTrue(executor.started.wait(1))
+        self.store.expire_model_leases(service.worker_id)
+        self.assertEqual(self.store.recover_expired_model_slots(), 1)
+        self.store.delete_run(run["run_id"])
+        executor.release.set()
+        following = service.submit(
+            RunRequest("next question"), user_id="one", admin=True
+        )
+        deadline = time.monotonic() + 3
+        while time.monotonic() < deadline:
+            if self.store.get_run(following["run_id"])["status"] == "succeeded":
+                break
+            time.sleep(0.01)
+        self.assertTrue(service.worker.is_alive())
+        self.assertEqual(self.store.get_run(following["run_id"])["status"], "succeeded")
+
+    def test_terminal_commit_before_close_releases_slot(self):
+        service, executor = self.make_service(shutdown_timeout=0.01)
+        committed = threading.Event()
+        finish = threading.Event()
+        self.addCleanup(finish.set)
+        append = service._append_event_if_open
+
+        def pause_after_commit(*args, **kwargs):
+            written = append(*args, **kwargs)
+            committed.set()
+            if not finish.wait(3):
+                raise RuntimeError("test commit barrier timed out")
+            return written
+
+        with mock.patch.object(
+            service, "_append_event_if_open", side_effect=pause_after_commit
+        ):
+            run = service.submit(RunRequest("question"), user_id="one", admin=True)
+            executor.release.set()
+            self.assertTrue(committed.wait(1))
+            service.close()
+            finish.set()
+            service.worker.join(2)
+        self.assertFalse(service.worker.is_alive())
+        self.assertEqual(self.store.get_run(run["run_id"])["status"], "succeeded")
+        self.assertEqual(self.store.model_activity(1)["available"], 1)
+
+    def test_shutdown_workers_share_one_deadline(self):
+        service = EvaluationService(
+            self.store, BlockingExecutor(), lambda: {}, shutdown_timeout=5
+        )
+        service._started = True
+        clock = [100.0]
+        waits = []
+
+        def join(*, timeout):
+            waits.append(timeout)
+            clock[0] += timeout
+
+        service.workers = [
+            mock.Mock(join=mock.Mock(side_effect=join)) for _ in range(3)
+        ]
+        with mock.patch(
+            "human_eval.service.time.monotonic", side_effect=lambda: clock[0]
+        ):
+            service.close()
+        self.assertEqual(waits, [5.0, 0.0, 0.0])
+
+    def test_seed_cannot_be_claimed_between_creation_and_execution(self):
+        self.store.initialize_model_slots(1)
+        competitor = EvaluationStore(self.store.path)
+        create = self.store.create_run
+        claims = []
+
+        def create_and_compete(*args, **kwargs):
+            record = create(*args, **kwargs)
+            claims.append(
+                competitor.claim_next_run(
+                    worker_id="web", concurrency=1, lease_seconds=60
+                )
+            )
+            return record
+
+        executor = BlockingExecutor()
+        executor.release.set()
+        with mock.patch.object(
+            self.store, "create_run", side_effect=create_and_compete
+        ):
+            outcome = seed_live_run(
+                self.store,
+                executor,
+                {"id": "seed-race", "question": "question"},
+                publish=False,
+            )
+        self.assertEqual(claims, [None])
+        self.assertEqual(outcome, "created")
+
+    def test_wait_estimate_accounts_for_idle_and_partial_capacity(self):
+        self.store.initialize_model_slots(4)
+        service = EvaluationService(
+            self.store, BlockingExecutor(), lambda: {}, model_concurrency=4
+        )
+        self.assertEqual(
+            [service.estimated_wait_seconds(p) for p in range(1, 6)], [0, 0, 0, 0, 480]
+        )
+        for i in range(2):
+            self.store.create_run(RunRequest("question"), user_id=str(i), provenance={})
+            self.store.claim_next_run(
+                worker_id="other", concurrency=4, lease_seconds=60
+            )
+        self.assertEqual(
+            [service.estimated_wait_seconds(p) for p in range(1, 8)],
+            [0, 0, 480, 480, 480, 480, 960],
+        )
+
+    def test_near_zero_wait_has_consistent_html_and_stream_text(self):
+        for wait in (0, 1, 59):
+            with self.subTest(wait=wait):
+                run = {
+                    "created_at": "2026-09-05T00:00:00Z",
+                    "run_id": "test",
+                    "status": "queued",
+                    "queue_position": 1,
+                    "estimated_wait_seconds": wait,
+                    "queue_snapshot": {"active": 0, "capacity": 4},
+                }
+                event = _queue_status_event(run)
+                self.assertIn("Espera aproximada: menos de 1 min", event[1])
+                html = _status_fragment(run)
+                self.assertIn("Espera aproximada: menos de 1 min", html)


### PR DESCRIPTION
## Summary
- coordinate global model slots and queue admission through SQLite WAL
- support multiple web workers without multiplying model concurrency
- add leases and restart recovery for interrupted executions
- expose queue position, wait estimates, and active slot status in the UI
- make hybrid embedding-server lifecycle safe for multiple web workers

## Validation
- `UV_CACHE_DIR=/tmp/codex-uv-cache uv run python -m unittest discover -s tests -q` (141 passed)
- `UV_CACHE_DIR=/tmp/codex-uv-cache uv run ruff check human_eval tests`
- `git diff --check`

The implementation is based on the existing admission-queue visibility work and is isolated from the unrelated local checkout.