### PR TITLE
Split execution into a singleton scheduler process

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,20 @@ posición en la cola y una espera aproximada mientras la pregunta espera.
   y `dof-human-eval-web.service` (`Restart=always`; al detenerse, systemd acota
   el drenaje con `TimeoutStopSec` y, si hace falta, termina todo el grupo de
   procesos con SIGKILL, incluido el servidor de embeddings).
+  Ante un error interno fatal, el scheduler permite hasta 30 segundos de
+  drenaje y limpieza antes de forzar una salida con error: así systemd puede
+  limpiar los procesos hijos y reiniciar aunque una llamada al modelo no termine.
+  Esta salida forzada requiere supervisión externa para limpiar hijos cuando
+  se ejecuta fuera de systemd.
+- Reejecutar el instalador no reinicia servicios activos. Después de actualizar
+  código o unidades, aplica los cambios explícitamente, deteniendo primero la
+  admisión web:
+
+  ```bash
+  systemctl --user stop dof-human-eval-web.service
+  systemctl --user restart dof-human-eval-scheduler.service
+  systemctl --user start dof-human-eval-web.service
+  ```
 
 - Visitantes anónimos leen las respuestas publicadas. Con cuenta: 1 pregunta cada 24 h (`DOF_DAILY_QUESTION_LIMIT`) y hay que evaluar una respuesta publicada antes de cada pregunta, incluida la primera. Los administradores publican y despublican en `/admin/queue` (rol vía `public_metadata.role = "admin"` en el dashboard de Clerk).
 - Recuperación híbrida para preguntas en vivo: `DOF_RETRIEVAL_MODE=hybrid` (requiere el índice vec0 y `DOF_GGUF_MODEL`; el servidor de embeddings llama-server lo levanta una sola vez el scheduler, con `DOF_EMBED_PORT`, por defecto 8086).

--- a/README.md
+++ b/README.md
@@ -183,8 +183,16 @@ embeddings GGUF, configura `DOF_RETRIEVAL_MODE=hybrid`.
 set -a; source .env; set +a  # CLERK_* y DOF_SESSION_SECRET (nunca imprimir valores)
 export DOF_AGENT_PROVIDER=kimi-code DOF_AGENT_MODEL=kimi-for-coding \
   DOF_RETRIEVAL_MODE=hybrid DOF_WEB_HOST=0.0.0.0 DOF_WEB_PORT=8765
-uv run python -m human_eval.app  # http://127.0.0.1:8765
+uv run python -m human_eval.scheduler &  # ejecutor único (cola SQLite)
+uv run python -m human_eval.app          # http://127.0.0.1:8765
 ```
+
+La aplicación se divide en dos procesos: los **procesos web** sólo admiten
+preguntas a la cola persistente y sirven la UI, y un **scheduler único**
+ejecuta las corridas del agente. El scheduler protege su exclusividad con un
+seguro `flock` junto a la base de evaluación, registra la procedencia real
+(proveedor, modelo, índices) al iniciar cada corrida y, al arrancar, marca
+como interrumpidas las ejecuciones que haya dejado un proceso anterior.
 
 También se puede usar un modelo local mediante un servidor compatible con la
 API de OpenAI. La configuración probada en Apple Silicon usa Qwen3.8-27B con
@@ -213,22 +221,46 @@ Con el servidor escuchando en `http://127.0.0.1:8080/` (verifica el id con
 set -a; source .env; set +a
 export DOF_AGENT_PROVIDER=llama-server DOF_AGENT_MODEL=qwen3.8 \
   DOF_REASONING_EFFORT=low DOF_RETRIEVAL_MODE=hybrid \
+  DOF_MODEL_CONCURRENCY=1 DOF_QUEUE_CAPACITY=4 \
   DOF_WEB_HOST=0.0.0.0 DOF_WEB_PORT=8765
-uv run python -m human_eval.app
+uv run python -m human_eval.scheduler &
+uv run python -m human_eval.app --workers 2
 ```
+
+`-np` es la capacidad de inferencia del servidor. El scheduler la refleja en
+`DOF_MODEL_CONCURRENCY`; ambos valores deben ser iguales y deben fijarse por
+equipo después de medir memoria y latencia. Por ejemplo, usa `1` en un M3 de
+32 GB y usa `3` o `4` en DGX Spark sólo si esa configuración pasa el benchmark.
+`DOF_QUEUE_CAPACITY` limita las preguntas esperando, no las que ya están en
+inferencia. La cola se coordina en `var/human_evaluation.sqlite`, por lo que
+todos los procesos web comparten la misma capacidad; el sitio muestra la
+posición en la cola y una espera aproximada mientras la pregunta espera.
 
 - `DOF_AGENT_PROVIDER=llama-server` usa el endpoint de Chat Completions de `DOF_AGENT_BASE_URL` (por defecto `http://127.0.0.1:8080/v1`). No requiere API key; si la sirves con autenticación, pásala por `DOF_AGENT_API_KEY`.
 - El modelo de chat local usa el puerto 8080 y el servidor de embeddings del
   modo `hybrid` usa `DOF_EMBED_PORT` (8086 por defecto). Pueden correr a la vez,
   pero la aplicación rechaza configuraciones donde ambos intenten usar el mismo
   puerto local.
+- Sólo el scheduler construye el ejecutor del agente y levanta el servidor de
+  embeddings; los procesos web nunca los crean, por lo que pueden multiplicarse
+  con `--workers N` sin duplicar modelos.
+- Los procesos web validan el esquema de la base pero nunca lo migran: el
+  scheduler (o la semilla, bajo el mismo seguro) es el único migrador. Arranca
+  el scheduler antes que los procesos web.
+- En producción ambos procesos corren como servicios systemd de usuario:
+  `scripts/install_human_eval_systemd.sh` instala `dof-human-eval-scheduler.service`
+  y `dof-human-eval-web.service` (`Restart=always`; al detenerse, systemd acota
+  el drenaje con `TimeoutStopSec` y termina todo el grupo de procesos, incluido
+  el servidor de embeddings).
 
 - Visitantes anónimos leen las respuestas publicadas. Con cuenta: 1 pregunta cada 24 h (`DOF_DAILY_QUESTION_LIMIT`) y hay que evaluar una respuesta publicada antes de cada pregunta, incluida la primera. Los administradores publican y despublican en `/admin/queue` (rol vía `public_metadata.role = "admin"` en el dashboard de Clerk).
-- Recuperación híbrida para preguntas en vivo: `DOF_RETRIEVAL_MODE=hybrid` (requiere el índice vec0 y `DOF_GGUF_MODEL`; el servidor de embeddings llama-server se levanta una sola vez por proceso, con `DOF_EMBED_PORT`, por defecto 8086).
-- Sembrar respuestas publicadas con corridas reales del agente (incluye la línea de tiempo de progreso):
+- Recuperación híbrida para preguntas en vivo: `DOF_RETRIEVAL_MODE=hybrid` (requiere el índice vec0 y `DOF_GGUF_MODEL`; el servidor de embeddings llama-server lo levanta una sola vez el scheduler, con `DOF_EMBED_PORT`, por defecto 8086).
+- Sembrar respuestas publicadas con corridas reales del agente (incluye la línea de tiempo de progreso). La semilla ejecuta corridas ella misma, así que toma el mismo seguro de ejecución que el scheduler: detén primero el servicio del scheduler.
 
   ```bash
+  systemctl --user stop dof-human-eval-scheduler  # libera el seguro de ejecución
   uv run python scripts/seed_human_eval_v4_hybrid.py --replace
+  systemctl --user start dof-human-eval-scheduler
   ```
 
 - HTTPS dentro de la tailnet (necesario para OAuth de Google/GitHub fuera de localhost): `tailscale serve --bg 8765`.

--- a/README.md
+++ b/README.md
@@ -250,8 +250,8 @@ posición en la cola y una espera aproximada mientras la pregunta espera.
 - En producción ambos procesos corren como servicios systemd de usuario:
   `scripts/install_human_eval_systemd.sh` instala `dof-human-eval-scheduler.service`
   y `dof-human-eval-web.service` (`Restart=always`; al detenerse, systemd acota
-  el drenaje con `TimeoutStopSec` y termina todo el grupo de procesos, incluido
-  el servidor de embeddings).
+  el drenaje con `TimeoutStopSec` y, si hace falta, termina todo el grupo de
+  procesos con SIGKILL, incluido el servidor de embeddings).
 
 - Visitantes anónimos leen las respuestas publicadas. Con cuenta: 1 pregunta cada 24 h (`DOF_DAILY_QUESTION_LIMIT`) y hay que evaluar una respuesta publicada antes de cada pregunta, incluida la primera. Los administradores publican y despublican en `/admin/queue` (rol vía `public_metadata.role = "admin"` en el dashboard de Clerk).
 - Recuperación híbrida para preguntas en vivo: `DOF_RETRIEVAL_MODE=hybrid` (requiere el índice vec0 y `DOF_GGUF_MODEL`; el servidor de embeddings llama-server lo levanta una sola vez el scheduler, con `DOF_EMBED_PORT`, por defecto 8086).

--- a/README.md
+++ b/README.md
@@ -246,7 +246,8 @@ posición en la cola y una espera aproximada mientras la pregunta espera.
   con `--workers N` sin duplicar modelos.
 - Los procesos web validan el esquema de la base pero nunca lo migran: el
   scheduler (o la semilla, bajo el mismo seguro) es el único migrador. Arranca
-  el scheduler antes que los procesos web.
+  el scheduler antes que los procesos web; éstos esperan hasta 30 segundos por
+  defecto (`DOF_SCHEMA_WAIT_SECONDS`) mientras termina la preparación inicial.
 - En producción ambos procesos corren como servicios systemd de usuario:
   `scripts/install_human_eval_systemd.sh` instala `dof-human-eval-scheduler.service`
   y `dof-human-eval-web.service` (`Restart=always`; al detenerse, systemd acota

--- a/docs/human-evaluation-ui-plan.md
+++ b/docs/human-evaluation-ui-plan.md
@@ -9,7 +9,7 @@ deben actualizarlo en el mismo cambio de código.
 - El sitio de evaluación vive por completo en `dof-rag`; no depende de
   `dof-rag-website`, Astro, GitHub Pages ni su `base` path.
 - Se usa una aplicación Python de mismo origen con Air, HTML progresivo y una
-  cola local. Air se fija en `0.35.0`, última versión compatible con el Python
+  cola SQLite compartida entre los procesos web y el scheduler. Air se fija en `0.35.0`, última versión compatible con el Python
   3.12 administrado por el proyecto; versiones posteriores requieren Python
   3.13.
 - Sí se guardan las preguntas y las respuestas. Sin ese par no sería posible
@@ -40,7 +40,7 @@ Incluye:
 - snapshot por ejecución de código, corpus, chunks, índice, modelo y
   configuración;
 - historial reciente del mismo evaluador;
-- operación inicial desde la MacBook Pro actual con un solo worker.
+- operación inicial desde la MacBook Pro actual con un scheduler único.
 
 ## Fuera del MVP
 
@@ -52,7 +52,7 @@ Incluye:
   argumentos de herramientas;
 - acceso directo del navegador a SQLite;
 - streaming token a token o de razonamiento privado, cancelación fuerte de una
-  llamada ya enviada al proveedor, múltiples workers o alta disponibilidad;
+  llamada ya enviada al proveedor, varios schedulers o alta disponibilidad;
 - búsqueda web o fuentes distintas del corpus DOF;
 - integrar la UI en Astro durante el MVP. El sitio público podría enlazar a la
   app más adelante, pero no forma parte de su ruta de ejecución.
@@ -63,13 +63,21 @@ Incluye:
 Navegador
   | HTTPS, HTML/forms + Server-Sent Events, cookie de mismo origen
   v
-Aplicación Air en dof-rag
+Aplicación Air en dof-rag (uno o varios procesos web)
   - UI y rutas HTTP en human_eval/app.py
   - sesión, CSRF, validación y límites
-  - EvaluationService + cola local, 1 worker
-  - SQLite de evaluación separado
+  - EvaluationService: admisión transaccional y lecturas, sin ejecutor
   |
   v
+SQLite de evaluación separado (cola persistente compartida)
+  |
+  v
+Scheduler singleton en human_eval/scheduler.py
+  - seguro flock exclusivo junto a la base; el kernel lo libera si muere
+  - al arrancar falla las ejecuciones `started` de la vida anterior
+  - estampa procedencia real y `started` en una sola transacción
+  - pool local acotado por DOF_MODEL_CONCURRENCY; dueño del servidor de
+    embeddings
 AgentRunner + DofToolbox
   - corpus/chunks SQLite abiertos de solo lectura
   - recuperación léxica completa
@@ -84,15 +92,16 @@ API, todavía joven, resulta inestable.
 
 No se usan `BackgroundTasks` para ejecutar al agente: son trabajo en proceso y
 no sustituyen una cola recuperable. `EvaluationService` responde rápido con un
-`run_id`, procesa en su hilo worker y recupera al arrancar las ejecuciones que
-quedaron en cola. Una ejecución que estaba iniciada se marca fallida al
-reiniciar, porque no puede saberse si la llamada externa terminó.
+`run_id` y deja la ejecución al scheduler, un proceso único que protege su
+exclusividad con un seguro `flock` junto a la base. Al arrancar, el scheduler
+marca como interrumpidas las ejecuciones que quedaron iniciadas, porque sólo
+él puede iniciarlas y no puede saberse si la llamada externa terminó.
 
-El MVP admite exactamente un proceso web y un worker. Dentro de ese proceso,
-un bloqueo de ciclo de vida hace atómica la decisión `has_active_run` +
-`create_run` para cada evaluador. Esa garantía no se extiende a varios procesos;
-escalar horizontalmente requerirá mover admisión y cola a una transacción o
-servicio compartido.
+El servicio admite varios procesos web en una misma máquina. La admisión
+(una ejecución activa por evaluador, cuota diaria, capacidad de cola e
+idempotencia con validación de payload) ocurre en una transacción SQLite, así
+que la garantía se extiende a todos los procesos web. La ejecución sigue
+siendo de un solo scheduler; varios nodos requerirían un servicio compartido.
 
 ## Contrato HTTP v1
 
@@ -339,9 +348,10 @@ incompleta; continúa siendo evaluable.
 - Los cuerpos tienen un límite inicial de 16 KiB; contratos validan longitud,
   fechas, enums y campos. El navegador nunca controla rutas de bases o
   parámetros arbitrarios.
-- Límites iniciales: una ejecución activa por evaluador, diez creaciones por
-  hora, cola global de veinte y un worker. Turnos y llamadas a herramientas
-  también están acotados en el backend.
+- Límites iniciales: una ejecución activa por evaluador, una pregunta cada
+  24 h, cola global de veinte y un scheduler con concurrencia de modelo
+  configurable. Turnos y llamadas a herramientas también están acotados en el
+  backend.
 - Las ejecuciones solo son visibles para el hash de evaluador propietario. Los
   endpoints públicos de salud/capacidades no incluyen rutas locales ni secretos.
 - El stream exige la misma sesión y propiedad, lleva `no-store`, se puede
@@ -372,7 +382,7 @@ export OPENAI_API_KEY='...'
 uv run python -m human_eval.app
 ```
 
-La recuperación por defecto es léxica. El worker único evita competir
+La recuperación por defecto es léxica. El scheduler único evita competir
 agresivamente con la indexación en curso. Antes del piloto externo faltan el
 supervisor local, el túnel HTTPS y un procedimiento de backup de
 `var/human_evaluation.sqlite`; el corpus y los índices siguen siendo

--- a/docs/human-evaluation-ui-plan.md
+++ b/docs/human-evaluation-ui-plan.md
@@ -377,19 +377,25 @@ proveedor.
 Configuración mínima, con valores de ejemplo que no deben guardarse en Git:
 
 ```bash
-export DOF_EVALUATOR_TOKENS='token-individual-1,token-individual-2'
+export CLERK_SECRET_KEY='sk_test_...'  # y CLERK_PUBLISHABLE_KEY para airclerk
 export DOF_SESSION_SECRET='valor-aleatorio-de-al-menos-32-caracteres'
 export DOF_ALLOWED_HOSTS='localhost,127.0.0.1,piloto.example'
 export DOF_SECURE_COOKIE='true'
 export DOF_AGENT_PROVIDER='openai-responses'
 export DOF_AGENT_MODEL='modelo-configurado-en-backend'
 export OPENAI_API_KEY='...'
-uv run python -m human_eval.app
+# Dos procesos: el scheduler ejecuta y los procesos web admiten y sirven la UI.
+uv run python -m human_eval.scheduler &
+uv run python -m human_eval.app --workers 2
 ```
+
+En el servidor de producción ambos procesos se instalan como servicios
+systemd de usuario con `scripts/install_human_eval_systemd.sh` (el scheduler
+arranca primero: migra la base antes de que los procesos web la validen).
 
 La recuperación por defecto es léxica. El scheduler único evita competir
 agresivamente con la indexación en curso. Antes del piloto externo faltan el
-supervisor local, el túnel HTTPS y un procedimiento de backup de
+túnel HTTPS y un procedimiento de backup de
 `var/human_evaluation.sqlite`; el corpus y los índices siguen siendo
 dependencias de solo lectura con su propio ciclo de respaldo.
 

--- a/docs/human-evaluation-ui-plan.md
+++ b/docs/human-evaluation-ui-plan.md
@@ -391,7 +391,8 @@ uv run python -m human_eval.app --workers 2
 
 En el servidor de producción ambos procesos se instalan como servicios
 systemd de usuario con `scripts/install_human_eval_systemd.sh` (el scheduler
-arranca primero: migra la base antes de que los procesos web la validen).
+arranca primero y los procesos web esperan hasta `DOF_SCHEMA_WAIT_SECONDS`, 30
+segundos por defecto, a que termine de preparar el esquema).
 
 La recuperación por defecto es léxica. El scheduler único evita competir
 agresivamente con la indexación en curso. Antes del piloto externo faltan el

--- a/docs/human-evaluation-ui-plan.md
+++ b/docs/human-evaluation-ui-plan.md
@@ -40,7 +40,9 @@ Incluye:
 - snapshot por ejecución de código, corpus, chunks, índice, modelo y
   configuración;
 - historial reciente del mismo evaluador;
-- operación inicial desde la MacBook Pro actual con un scheduler único.
+- operación inicial desde el servidor de producción del proyecto con un
+  scheduler único; la MacBook Pro actual queda como entorno de desarrollo y
+  benchmark.
 
 ## Fuera del MVP
 
@@ -363,11 +365,14 @@ incompleta; continúa siendo evaluable.
 
 ## Despliegue previsto
 
-El MVP se ejecutará en la MacBook Pro actual, ligado inicialmente a
-`127.0.0.1:8765`. La UI y el backend se publican como una sola app ASGI. Para
-pruebas humanas remotas se colocará delante un túnel o reverse proxy HTTPS que
-termine TLS, limite cuerpos, no almacene en buffer SSE y use un hostname estable;
-todavía debe elegirse el proveedor.
+La MacBook Pro actual es un entorno de desarrollo y benchmark; el despliegue
+operativo corre en la máquina de servidor configurada para el proyecto. La UI
+vive en uno o varios procesos web y la ejecución en un scheduler singleton,
+ambos supervisados como servicios systemd de usuario (`ops/systemd/`), ligados
+inicialmente a `127.0.0.1:8765`. Para pruebas humanas remotas se colocará
+delante un túnel o reverse proxy HTTPS que termine TLS, limite cuerpos, no
+almacene en buffer SSE y use un hostname estable; todavía debe elegirse el
+proveedor.
 
 Configuración mínima, con valores de ejemplo que no deben guardarse en Git:
 
@@ -509,10 +514,11 @@ La procedencia separa `vector_available` (el artefacto existe en disco) de
 - Air sigue evolucionando y la versión compatible con Python 3.12 no es la más
   reciente. Se debe decidir después del piloto si migrar todo el proyecto a
   Python 3.13, mantener 0.35 o sustituir solo la capa web.
-- Exponer la MacBook requiere elegir túnel/proxy, dominio, supervisor y política
-  de actualización antes de invitar evaluadores.
-- La cola y el rate limit son locales y se reinician con el proceso; son
-  suficientes para un piloto de un nodo, no para varios procesos.
+- Exponer el servidor de producción requiere elegir túnel/proxy, dominio y
+  política de actualización antes de invitar evaluadores.
+- La cola y el rate limit viven en el SQLite de evaluación compartido y
+  sobreviven reinicios de cualquier proceso; siguen siendo de un solo nodo,
+  no de varias máquinas.
 - Falta incorporar una verificación mínima del MVP a GitHub Actions; se mantiene
   como trabajo posterior para no mezclar infraestructura de CI con este PR.
 - Deben fijarse presupuesto por modelo, timeout efectivo y respuesta ante cuota

--- a/docs/production-roadmap.md
+++ b/docs/production-roadmap.md
@@ -157,9 +157,27 @@ se rechazan admisiones antes de construir esa maquinaria. Quedan pendientes de
 este apartado los timeouts por turno y por corrida, la detección del modelo
 caído antes de admitir y la pausa administrativa de admisión.
 
-Leases, reclamo atómico entre procesos y una base distinta a SQLite serán
-necesarios si llegamos a operar varios workers. No hacen falta para la primera
-beta en una sola máquina.
+**Avance de septiembre de 2026.** La admisión quedó dividida en dos procesos:
+los procesos web sólo encolan y leen, y un scheduler singleton ejecuta. La
+admisión (una ejecución activa por evaluador, cuota diaria, capacidad de cola
+e idempotencia con validación de payload) ocurre en una transacción SQLite
+compartida por todos los procesos web. El scheduler protege su exclusividad
+con un seguro `flock`, estampa la procedencia real al iniciar cada corrida,
+acota la concurrencia del modelo con un pool local (`DOF_MODEL_CONCURRENCY`) y,
+al arrancar, marca como interrumpidas las ejecuciones `started` de la vida
+anterior. La interfaz ya muestra posición en cola, espera aproximada y slots
+ocupados, y el 503 de cola llena incluye `Retry-After`. Los procesos web pueden
+multiplicarse (`--workers N`) sin multiplicar la concurrencia del modelo, y la
+semilla toma el mismo seguro del scheduler para no violar el singleton.
+Siguen pendientes los timeouts por turno y por corrida, la detección del
+modelo caído antes de admitir y la pausa administrativa.
+
+Descartamos los leases entre procesos tras una primera implementación: el
+protocolo de liveness distribuido (heartbeats, fencing, recuperación por
+expiración) resultó desproporcionado para una sola máquina y concentraba todos
+los casos borde. El scheduler singleton con reinicio supervisado obtiene la
+misma recuperación sin esa maquinaria. Una base distinta a SQLite sólo haría
+falta para varios nodos.
 
 ### 4. Preparar una beta que podamos operar
 

--- a/human_eval/agent_executor.py
+++ b/human_eval/agent_executor.py
@@ -56,6 +56,7 @@ class AgentExecutorConfig:
     reasoning_effort: str | None = "low"
     max_model_turns: int = 8
     max_tool_calls: int = 8
+    model_concurrency: int = 1
     retrieval_mode: str = "lexical"
     base_url: str | None = None
 
@@ -100,6 +101,9 @@ class AgentExecutorConfig:
         embed_port = int(os.environ.get("DOF_EMBED_PORT", "8086"))
         if not 1 <= embed_port <= 65535:
             raise ValueError("DOF_EMBED_PORT must be between 1 and 65535")
+        model_concurrency = int(os.environ.get("DOF_MODEL_CONCURRENCY", "1"))
+        if model_concurrency < 1:
+            raise ValueError("DOF_MODEL_CONCURRENCY must be positive")
         base_url = os.environ.get("DOF_AGENT_BASE_URL")
         if provider == "llama-server" and retrieval_mode != "lexical":
             host, agent_port = _endpoint_port(
@@ -126,6 +130,7 @@ class AgentExecutorConfig:
             reasoning_effort=os.environ.get("DOF_REASONING_EFFORT", "low") or None,
             max_model_turns=int(os.environ.get("DOF_MAX_MODEL_TURNS", "8")),
             max_tool_calls=int(os.environ.get("DOF_MAX_TOOL_CALLS", "8")),
+            model_concurrency=model_concurrency,
             retrieval_mode=retrieval_mode,
             base_url=base_url,
         )
@@ -186,6 +191,34 @@ def _read_index_versions(config: AgentExecutorConfig) -> dict[str, Any]:
     }
 
 
+def provenance_for_config(
+    config: AgentExecutorConfig, *, vector_used: bool = False
+) -> dict[str, Any]:
+    """Provenance derivable from configuration alone (no executor needed).
+
+    Web processes use this for the capabilities endpoint; the scheduler's
+    executor delegates with the live embedder state when stamping runs.
+    """
+    revision, dirty = _git_snapshot(config.repo_root)
+    return {
+        "code_revision": revision,
+        "code_dirty": dirty,
+        **_read_index_versions(config),
+        # vector_available describes the on-disk asset; vector_used records
+        # whether the executor could actually query it (embedder is live).
+        "vector_used": vector_used,
+        "provider": config.provider,
+        "model": config.model,
+        "configuration": {
+            "retrieval_mode": config.retrieval_mode,
+            "max_model_turns": config.max_model_turns,
+            "max_tool_calls": config.max_tool_calls,
+            "model_concurrency": config.model_concurrency,
+            "reasoning_effort": config.reasoning_effort,
+        },
+    }
+
+
 class AgentRunExecutor:
     """Run the agent, sharing one llama-server for query embeddings.
 
@@ -235,23 +268,9 @@ class AgentRunExecutor:
                 self._embedder = None
 
     def provenance(self) -> dict[str, Any]:
-        revision, dirty = _git_snapshot(self.config.repo_root)
-        return {
-            "code_revision": revision,
-            "code_dirty": dirty,
-            **_read_index_versions(self.config),
-            # vector_available describes the on-disk asset; vector_used records
-            # whether this executor can actually query it (embedder is live).
-            "vector_used": self._embedder is not None,
-            "provider": self.config.provider,
-            "model": self.config.model,
-            "configuration": {
-                "retrieval_mode": self.config.retrieval_mode,
-                "max_model_turns": self.config.max_model_turns,
-                "max_tool_calls": self.config.max_tool_calls,
-                "reasoning_effort": self.config.reasoning_effort,
-            },
-        }
+        return provenance_for_config(
+            self.config, vector_used=self._embedder is not None
+        )
 
     def _backend(self) -> Any:
         if self.config.provider == "llama-server":

--- a/human_eval/app.py
+++ b/human_eval/app.py
@@ -45,7 +45,7 @@ from starlette.responses import (
     StreamingResponse,
 )
 
-from .agent_executor import AgentExecutorConfig, AgentRunExecutor
+from .agent_executor import AgentExecutorConfig, provenance_for_config
 from .auth import AuthBackend, User
 from .contracts import ContractError, FeedbackRequest, RunRequest
 from .markdown_render import render_markdown_html
@@ -53,7 +53,6 @@ from .service import (
     ActiveRunError,
     EvaluationService,
     IdempotencyConflictError,
-    PublicExecutionError,
     QueueFullError,
     QuotaExceededError,
     ReviewRequiredError,
@@ -98,6 +97,7 @@ class WebSettings:
     session_max_age: int = 12 * 60 * 60
     daily_question_limit: int = 1
     queue_capacity: int = 20
+    model_concurrency: int = 1
 
     @classmethod
     def from_env(cls, repo_root: Path) -> "WebSettings":
@@ -128,6 +128,9 @@ class WebSettings:
             ),
             daily_question_limit=int(os.environ.get("DOF_DAILY_QUESTION_LIMIT", "1")),
             queue_capacity=int(os.environ.get("DOF_QUEUE_CAPACITY", "20")),
+            # Display-only mirror of the scheduler's real limit; share one
+            # environment file so both sides normally agree.
+            model_concurrency=int(os.environ.get("DOF_MODEL_CONCURRENCY", "1")),
         )
 
 
@@ -440,6 +443,10 @@ STREAM_SCRIPT = """
     if (!streamUrl) return;
     const list = node.querySelector('[data-progress-list]');
     const state = node.querySelector('[data-stream-state]');
+    const clearQueueStatus = () => {
+      const queueStatus = node.querySelector('[data-queue-status]');
+      if (queueStatus) queueStatus.remove();
+    };
     let last = Number(node.dataset.lastEventId || 0);
     if (!window.EventSource) {
       state.textContent = 'Actualizando el estado…';
@@ -454,8 +461,19 @@ STREAM_SCRIPT = """
       const event = JSON.parse(message.data);
       last = Math.max(last, Number(event.sequence || 0));
       node.dataset.lastEventId = last;
+      clearQueueStatus();
       appendProgress(list, event);
       state.textContent = 'Recibiendo actividad en vivo';
+    });
+    source.addEventListener('running', () => {
+      clearQueueStatus();
+      state.textContent = 'El modelo está procesando la pregunta';
+    });
+    source.addEventListener('queue', (message) => {
+      const event = JSON.parse(message.data);
+      const queueStatus = node.querySelector('[data-queue-status]');
+      if (queueStatus) queueStatus.textContent = event.message || 'Actualizando la cola…';
+      state.textContent = 'Esperando capacidad del modelo';
     });
     source.addEventListener('terminal', async () => {
       source.close();
@@ -642,13 +660,30 @@ def _status_fragment(
     if state in ACTIVE_STATES:
         progress = run.get("progress", [])
         last_event_id = progress[-1]["sequence"] if progress else 0
+        queue_note = ""
+        if state == "queued" and run.get("queue_position") is not None:
+            wait = run.get("estimated_wait_seconds")
+            wait_text = f" · {_queue_wait_text(wait)}" if wait is not None else ""
+            snapshot = run.get("queue_snapshot", {})
+            active = snapshot.get("active")
+            capacity = snapshot.get("capacity")
+            capacity_text = (
+                f" · {active} de {capacity} slots ocupados"
+                if active is not None and capacity is not None
+                else ""
+            )
+            queue_note = (
+                f'<p class="meta" data-queue-status>Posición en la cola: '
+                f'{_escape(run["queue_position"])}{_escape(wait_text)}'
+                f'{_escape(capacity_text)}</p>'
+            )
         return f"""<section id="run-status" class="panel status" data-state="{state}"
 data-stream-url="/runs/{_escape(run["run_id"])}/events"
 data-status-url="/runs/{_escape(run["run_id"])}/status"
 data-last-event-id="{_escape(last_event_id)}" aria-live="polite">
 <p class="eyebrow">{_escape(STATUS_LABELS[state])}</p><h2>La ejecución sigue en progreso</h2>
 <p>Registro público de decisiones: qué intenta localizar, por qué consulta cada fuente y qué evidencia encuentra.</p>
-<p class="stream-state meta" data-stream-state>Conectando al trabajo del agente…</p>
+<p class="stream-state meta" data-stream-state>Conectando al trabajo del agente…</p>{queue_note}
 {_progress_timeline(progress)}{meta}</section>"""
     if state == "failed":
         error = run.get("error", {})
@@ -825,6 +860,36 @@ def _attach_chunk_html(event: dict[str, Any]) -> None:
         excerpt = chunk.get("excerpt") or chunk.get("snippet") or ""
         if excerpt:
             chunk["excerpt_html"] = render_markdown_html(excerpt)
+
+
+def _queue_wait_text(seconds: int | float | None) -> str:
+    if seconds is None:
+        return "Espera aproximada: calculando…"
+    if seconds < 60:
+        return "Espera aproximada: menos de 1 min"
+    return f"Espera aproximada: {round(seconds / 60)} min"
+
+
+def _queue_status_event(
+    run: dict[str, Any],
+) -> tuple[tuple[int, int, int], str] | None:
+    """Build a queue update only from one complete public-run snapshot."""
+    if run.get("status") != "queued":
+        return None
+    position = run.get("queue_position")
+    snapshot = run.get("queue_snapshot", {})
+    active = snapshot.get("active")
+    capacity = snapshot.get("capacity")
+    if position is None or active is None or capacity is None:
+        return None
+    queue_state = (int(position), int(active), int(capacity))
+    wait_text = _queue_wait_text(run.get("estimated_wait_seconds"))
+    message = (
+        f"Posición en la cola: {queue_state[0]} · "
+        f"{wait_text} · "
+        f"{queue_state[1]} de {queue_state[2]} slots ocupados"
+    )
+    return queue_state, message
 
 
 def _feedback_form(run_id: str, csrf_token: str, *, next_url: str) -> str:
@@ -1082,6 +1147,7 @@ def create_app(
         error: str | None = None,
         values: dict[str, Any] | None = None,
         status_code: int = 200,
+        headers: dict[str, str] | None = None,
     ) -> HTMLResponse:
         published = service.store.published_runs()
         my_runs = None
@@ -1120,6 +1186,7 @@ def create_app(
                 page_scripts=page_scripts,
             ),
             status_code=status_code,
+            headers=headers,
         )
 
     @app.get("/login", response_class=HTMLResponse)
@@ -1248,17 +1315,10 @@ def create_app(
             return render_home(
                 request,
                 user,
-                error="La cola local está llena; intenta más tarde.",
+                error="La cola de preguntas está llena; intenta más tarde.",
                 values=values,
                 status_code=503,
-            )
-        except PublicExecutionError as exc:
-            return render_home(
-                request,
-                user,
-                error=str(exc),
-                values=values,
-                status_code=503,
+                headers={"Retry-After": str(service.queue_retry_after())},
             )
         return RedirectResponse(f"/runs/{run['run_id']}", status_code=303)
 
@@ -1394,6 +1454,8 @@ Publicada: {_escape(run.get("published_at"))}</p></section>
         async def event_stream() -> AsyncIterator[str]:
             cursor = after
             heartbeat_at = time.monotonic()
+            last_queue_state: tuple[int, int, int] | None = None
+            running_announced = False
             while True:
                 events = await asyncio.to_thread(
                     service.store.progress_for_run, run_id, after=cursor
@@ -1407,6 +1469,19 @@ Publicada: {_escape(run.get("published_at"))}</p></section>
                 run = await asyncio.to_thread(
                     service.public_run, run_id, user_id=user.id, admin=True
                 )
+                if run["status"] == "queued":
+                    queue_event = _queue_status_event(run)
+                    if queue_event is not None:
+                        queue_state, message = queue_event
+                        if queue_state != last_queue_state:
+                            last_queue_state = queue_state
+                            yield (
+                                "event: queue\n"
+                                f"data: {json.dumps({'message': message}, ensure_ascii=False)}\n\n"
+                            )
+                elif run["status"] == "running" and not running_announced:
+                    running_announced = True
+                    yield 'event: running\ndata: {"status":"running"}\n\n'
                 if run["status"] not in ACTIVE_STATES:
                     data = json.dumps({"status": run["status"]}, separators=(",", ":"))
                     yield f"event: terminal\ndata: {data}\n\n"
@@ -1564,6 +1639,8 @@ Publicada: {_escape(run.get("published_at"))}</p></section>
                     "required_hops": 5,
                     "questions_per_day": settings.daily_question_limit,
                     "active_runs_per_user": 1,
+                    "model_concurrency": settings.model_concurrency,
+                    "queue_capacity": settings.queue_capacity,
                 },
             }
         )
@@ -1603,17 +1680,19 @@ def build_default_app(repo_root: Path | None = None) -> tuple[Any, WebSettings]:
     from .clerk_auth import ClerkAuthBackend, clerk_login_scripts, clerk_page_scripts
 
     auth_backend = ClerkAuthBackend(secret_key=airclerk.settings.CLERK_SECRET_KEY)
-    executor = AgentRunExecutor(AgentExecutorConfig.from_env(root))
+    # Web workers never build an executor: provenance comes from the shared
+    # configuration, and the scheduler stamps the authoritative per-run
+    # provenance when it starts each execution.
+    config = AgentExecutorConfig.from_env(root)
     service = EvaluationService(
         EvaluationStore(settings.db_path),
-        executor,
-        executor.provenance,
         queue_capacity=settings.queue_capacity,
+        model_concurrency=settings.model_concurrency,
     )
     app = create_app(
         service,
         settings,
-        executor.provenance,
+        lambda: provenance_for_config(config),
         auth_backend=auth_backend,
         page_scripts=clerk_page_scripts,
         login_scripts=clerk_login_scripts,
@@ -1622,12 +1701,38 @@ def build_default_app(repo_root: Path | None = None) -> tuple[Any, WebSettings]:
     return app, settings
 
 
+def create_uvicorn_app() -> Any:
+    """Uvicorn factory so every web process builds its own app lifecycle."""
+    configured_root = os.environ.get("DOF_APP_REPO_ROOT")
+    app, _ = build_default_app(Path(configured_root) if configured_root else None)
+    return app
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Serve the DOF human-evaluation site")
     parser.add_argument(
         "--repo-root", type=Path, default=Path(__file__).resolve().parent.parent
     )
+    parser.add_argument("--workers", type=int, default=1)
     args = parser.parse_args()
+    if args.workers < 1:
+        parser.error("--workers must be positive")
+    if args.workers > 1:
+        # The factory is required for Uvicorn to create the application inside
+        # each worker process. Web workers only admit and read runs; the
+        # singleton scheduler process executes them.
+        repo_root = args.repo_root.resolve()
+        settings = WebSettings.from_env(repo_root)
+        os.environ["DOF_APP_REPO_ROOT"] = str(repo_root)
+        uvicorn.run(
+            "human_eval.app:create_uvicorn_app",
+            factory=True,
+            workers=args.workers,
+            host=settings.host,
+            port=settings.port,
+            access_log=False,
+        )
+        return 0
     app, settings = build_default_app(args.repo_root)
     # Questions are stored deliberately, but client IP addresses are not part
     # of the evaluation dataset. Keep Uvicorn's per-request access log off.

--- a/human_eval/app.py
+++ b/human_eval/app.py
@@ -98,6 +98,7 @@ class WebSettings:
     daily_question_limit: int = 1
     queue_capacity: int = 20
     model_concurrency: int = 1
+    schema_wait_seconds: float = 0.0
 
     @classmethod
     def from_env(cls, repo_root: Path) -> "WebSettings":
@@ -131,6 +132,11 @@ class WebSettings:
             # Display-only mirror of the scheduler's real limit; share one
             # environment file so both sides normally agree.
             model_concurrency=int(os.environ.get("DOF_MODEL_CONCURRENCY", "1")),
+            # systemd Type=simple only orders process launches. On a fresh
+            # database, give the scheduler time to finish schema preparation.
+            schema_wait_seconds=float(
+                os.environ.get("DOF_SCHEMA_WAIT_SECONDS", "30")
+            ),
         )
 
 
@@ -1086,7 +1092,7 @@ def create_app(
 
     @asynccontextmanager
     async def lifespan(_: Any):
-        service.start()
+        service.start(schema_wait_seconds=settings.schema_wait_seconds)
         try:
             yield
         finally:

--- a/human_eval/scheduler.py
+++ b/human_eval/scheduler.py
@@ -51,8 +51,11 @@ class RunExecutor(Protocol):
 
 
 def execution_lock_path(db_path: str | Path) -> Path:
-    """The singleton execution lock lives next to the evaluation database."""
-    return Path(str(db_path) + ".lock")
+    """Place the lock next to the canonical database, including symlink aliases.
+
+    Hard-link aliases and retargeting symlinks while running are unsupported.
+    """
+    return Path(str(Path(db_path).resolve()) + ".lock")
 
 
 def acquire_execution_lock(db_path: str | Path) -> int:

--- a/human_eval/scheduler.py
+++ b/human_eval/scheduler.py
@@ -137,6 +137,7 @@ class RunScheduler:
         self.model_concurrency = model_concurrency
         self.poll_seconds = poll_seconds
         self._stopping = threading.Event()
+        self._fatal: BaseException | None = None
         self._in_flight: set[Any] = set()
         self._pool: ThreadPoolExecutor | None = None
 
@@ -168,7 +169,15 @@ class RunScheduler:
                         future.exception().__traceback__,
                     ),
                 )
+                if self._fatal is None:
+                    self._fatal = future.exception()
         self._in_flight -= done
+        if self._fatal is not None:
+            # A persistence failure stranded its run in 'started' and only
+            # startup recovery can repair that, so stop claiming and let the
+            # supervisor restart this process (systemd Restart=always).
+            self._stopping.set()
+            return 0
         claimed = 0
         while (
             not self._stopping.is_set()
@@ -184,8 +193,11 @@ class RunScheduler:
         return claimed
 
     def run(self) -> None:
-        """Supervise the queue until ``stop`` is requested, then drain."""
-        self._stopping.clear()
+        """Supervise the queue until ``stop`` or a fatal persistence error.
+
+        Single-use: an early stop request (for example SIGTERM during a slow
+        ``prepare``) is honored instead of cleared.
+        """
         with ThreadPoolExecutor(
             max_workers=self.model_concurrency,
             thread_name_prefix="dof-human-eval-scheduler",
@@ -204,6 +216,10 @@ class RunScheduler:
                 close()
             except Exception:
                 LOGGER.exception("executor shutdown hook failed")
+        if self._fatal is not None:
+            raise RuntimeError(
+                "scheduler stopped after an execution persistence failure"
+            ) from self._fatal
 
     def stop(self) -> None:
         self._stopping.set()

--- a/human_eval/scheduler.py
+++ b/human_eval/scheduler.py
@@ -1,0 +1,259 @@
+"""Singleton scheduler process: the only component that executes runs.
+
+Architecture invariants:
+
+- Web workers only create ``queued`` runs and serve UI/API requests.
+- Exactly one scheduler holds the OS-level execution lock (``flock``); the
+  kernel releases it if the process dies, and a second scheduler or seed
+  process fails immediately instead of violating the singleton.
+- The scheduler owns ``AgentRunExecutor`` and the embedding server.
+- Claiming stamps scheduler provenance and ``started`` in one transaction.
+- An in-process bounded pool enforces ``DOF_MODEL_CONCURRENCY``.
+- Scheduler startup fails every previously ``started`` run: only the
+  scheduler starts runs, so a started run at startup is provably orphaned.
+
+Shutdown contract: SIGTERM/SIGINT stop new claims and let in-flight work
+finish; the supervisor (systemd ``TimeoutStopSec`` + ``KillMode``) bounds the
+wait and kills the whole control group, including embedding-server children.
+Runs still ``started`` after a hard kill are recovered at the next startup.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import logging
+import os
+import signal
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any, Protocol
+
+from .contracts import RunRequest
+from .service import ProgressCallback, PublicExecutionError
+from .store import EvaluationStore
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_POLL_SECONDS = 0.5
+
+
+class RunExecutor(Protocol):
+    def execute(
+        self,
+        request: RunRequest,
+        *,
+        on_progress: ProgressCallback | None = None,
+    ) -> dict[str, Any]: ...
+
+    def provenance(self) -> dict[str, Any]: ...
+
+
+def execution_lock_path(db_path: str | Path) -> Path:
+    """The singleton execution lock lives next to the evaluation database."""
+    return Path(str(db_path) + ".lock")
+
+
+def acquire_execution_lock(db_path: str | Path) -> int:
+    """Take the exclusive scheduler/seed lock; return the open fd.
+
+    The fd is explicitly non-inheritable so executor child processes (the
+    embedding server) cannot retain the lock after this process dies.
+    """
+    path = execution_lock_path(db_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(path, os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        os.set_inheritable(fd, False)
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError as exc:
+        os.close(fd)
+        raise RuntimeError(
+            f"another scheduler or seed process holds the execution lock "
+            f"({path}); stop it before starting a new one"
+        ) from exc
+    return fd
+
+
+def execute_claimed_run(
+    store: EvaluationStore, executor: RunExecutor, run_id: str
+) -> None:
+    """Execute one already-started run and persist its terminal state.
+
+    Shared by the scheduler pool and the seed script (which acts as the
+    scheduler while holding the execution lock).
+    """
+    request = store.get_request(run_id)
+    if request is None:
+        LOGGER.warning("claimed run %s vanished before execution", run_id)
+        return
+    try:
+        result = executor.execute(
+            request,
+            on_progress=lambda event_type, payload: store.append_progress(
+                run_id, event_type, payload
+            ),
+        )
+    except PublicExecutionError as exc:
+        if exc.__cause__ is not None:
+            LOGGER.exception(
+                "human-evaluation run %s failed with %s", run_id, exc.code
+            )
+        store.append_event(
+            run_id, "failed", {"code": exc.code, "message": str(exc)}
+        )
+    except Exception:
+        LOGGER.exception("human-evaluation run %s failed", run_id)
+        store.append_event(
+            run_id,
+            "failed",
+            {
+                "code": "internal_error",
+                "message": "La ejecución no pudo completarse.",
+            },
+        )
+    else:
+        store.append_event(run_id, "succeeded", result)
+
+
+class RunScheduler:
+    """Poll the persistent queue and execute runs on a bounded local pool."""
+
+    def __init__(
+        self,
+        store: EvaluationStore,
+        executor: RunExecutor,
+        *,
+        model_concurrency: int = 1,
+        poll_seconds: float = DEFAULT_POLL_SECONDS,
+    ):
+        if model_concurrency < 1:
+            raise ValueError("model_concurrency must be positive")
+        if poll_seconds <= 0:
+            raise ValueError("poll_seconds must be positive")
+        self.store = store
+        self.executor = executor
+        self.model_concurrency = model_concurrency
+        self.poll_seconds = poll_seconds
+        self._stopping = threading.Event()
+        self._in_flight: set[Any] = set()
+        self._pool: ThreadPoolExecutor | None = None
+
+    def prepare(self) -> int:
+        """Initialize the schema and recover orphaned runs. Lock holder only."""
+        self.store.initialize()
+        recovered = self.store.fail_interrupted_runs()
+        if recovered:
+            LOGGER.warning("recovered %s interrupted executions", recovered)
+        prepare = getattr(self.executor, "prepare", None)
+        if callable(prepare):
+            prepare()
+        return recovered
+
+    def poll_once(self) -> int:
+        """Claim and dispatch runs up to the pool's free capacity."""
+        assert self._pool is not None, "poll_once requires a running pool"
+        done = {future for future in self._in_flight if future.done()}
+        for future in done:
+            # execute_claimed_run handles executor failures; anything here is
+            # a store error after the run ended, leaving it recoverable as
+            # 'started' at the next scheduler startup.
+            if future.exception() is not None:
+                LOGGER.error(
+                    "run execution raised unexpectedly",
+                    exc_info=(
+                        type(future.exception()),
+                        future.exception(),
+                        future.exception().__traceback__,
+                    ),
+                )
+        self._in_flight -= done
+        claimed = 0
+        while (
+            not self._stopping.is_set()
+            and len(self._in_flight) < self.model_concurrency
+        ):
+            run_id = self.store.claim_next_run(provenance=self.executor.provenance())
+            if run_id is None:
+                break
+            claimed += 1
+            self._in_flight.add(
+                self._pool.submit(execute_claimed_run, self.store, self.executor, run_id)
+            )
+        return claimed
+
+    def run(self) -> None:
+        """Supervise the queue until ``stop`` is requested, then drain."""
+        self._stopping.clear()
+        with ThreadPoolExecutor(
+            max_workers=self.model_concurrency,
+            thread_name_prefix="dof-human-eval-scheduler",
+        ) as self._pool:
+            try:
+                while not self._stopping.is_set():
+                    if self.poll_once() == 0:
+                        self._stopping.wait(self.poll_seconds)
+            finally:
+                self._pool = None
+        # The with-block waits for in-flight work; a hung call is bounded by
+        # the supervisor's stop timeout (systemd TimeoutStopSec + SIGKILL).
+        close = getattr(self.executor, "close", None)
+        if callable(close):
+            try:
+                close()
+            except Exception:
+                LOGGER.exception("executor shutdown hook failed")
+
+    def stop(self) -> None:
+        self._stopping.set()
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root", type=Path, default=Path(__file__).resolve().parent.parent
+    )
+    parser.add_argument(
+        "--db",
+        type=Path,
+        default=None,
+        help="evaluation database (default: DOF_HUMAN_EVAL_DB or var/human_evaluation.sqlite)",
+    )
+    args = parser.parse_args()
+
+    from .agent_executor import AgentExecutorConfig, AgentRunExecutor
+
+    root = args.repo_root.resolve()
+    db_path = args.db or Path(
+        os.environ.get("DOF_HUMAN_EVAL_DB", root / "var/human_evaluation.sqlite")
+    )
+    config = AgentExecutorConfig.from_env(root)
+
+    lock_fd = acquire_execution_lock(db_path)
+    store = EvaluationStore(db_path)
+    executor = AgentRunExecutor(config)
+    scheduler = RunScheduler(
+        store,
+        executor,
+        model_concurrency=config.model_concurrency,
+    )
+
+    def handle_signal(signum: int, _frame: Any) -> None:
+        LOGGER.info("received signal %s; stopping claims and draining", signum)
+        scheduler.stop()
+
+    signal.signal(signal.SIGTERM, handle_signal)
+    signal.signal(signal.SIGINT, handle_signal)
+
+    try:
+        scheduler.prepare()
+        scheduler.run()
+    finally:
+        os.close(lock_fd)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/human_eval/scheduler.py
+++ b/human_eval/scheduler.py
@@ -126,11 +126,15 @@ class RunScheduler:
         *,
         model_concurrency: int = 1,
         poll_seconds: float = DEFAULT_POLL_SECONDS,
+        fatal_shutdown_seconds: float = 30.0,
     ):
         if model_concurrency < 1:
             raise ValueError("model_concurrency must be positive")
         if poll_seconds <= 0:
             raise ValueError("poll_seconds must be positive")
+        if fatal_shutdown_seconds <= 0:
+            raise ValueError("fatal_shutdown_seconds must be positive")
+        self.fatal_shutdown_seconds = fatal_shutdown_seconds
         self.store = store
         self.executor = executor
         self.model_concurrency = model_concurrency
@@ -210,24 +214,49 @@ class RunScheduler:
         Single-use: an early stop request (for example SIGTERM during a slow
         ``prepare``) is honored instead of cleared.
         """
+        watchdog: threading.Timer | None = None
+
+        def force_exit() -> None:
+            # ThreadPoolExecutor threads also block normal interpreter exit.
+            # Skip Python cleanup so systemd sees failure and kills remaining
+            # children in the unit's cgroup before restarting. Direct launches
+            # need an external supervisor for child cleanup on this hard path.
+            os._exit(1)
+
         try:
             with ThreadPoolExecutor(
                 max_workers=self.model_concurrency,
                 thread_name_prefix="dof-human-eval-scheduler",
             ) as self._pool:
-                while not self._stopping.is_set():
-                    if self.poll_once() == 0:
-                        self._stopping.wait(self.poll_seconds)
+                try:
+                    while not self._stopping.is_set():
+                        if self.poll_once() == 0:
+                            self._stopping.wait(self.poll_seconds)
+                except BaseException as exc:
+                    self._fatal = exc
+                    raise
+                finally:
+                    if self._fatal is not None:
+                        # Arm before the pool context starts waiting. Unlike a
+                        # signal-driven stop, an internal failure does not start
+                        # systemd's TimeoutStopSec countdown.
+                        watchdog = threading.Timer(
+                            self.fatal_shutdown_seconds, force_exit
+                        )
+                        watchdog.daemon = True
+                        watchdog.start()
         finally:
             self._pool = None
-            # Drain the pool before closing the executor, even if polling raises.
-            # A hung call is bounded by the supervisor's stop timeout.
-            close = getattr(self.executor, "close", None)
-            if callable(close):
-                try:
-                    close()
-                except Exception:
-                    LOGGER.exception("executor shutdown hook failed")
+            try:
+                close = getattr(self.executor, "close", None)
+                if callable(close):
+                    try:
+                        close()
+                    except Exception:
+                        LOGGER.exception("executor shutdown hook failed")
+            finally:
+                if watchdog is not None:
+                    watchdog.cancel()
         if self._fatal is not None:
             raise RuntimeError(
                 "scheduler stopped after an execution persistence failure"

--- a/human_eval/scheduler.py
+++ b/human_eval/scheduler.py
@@ -183,7 +183,12 @@ class RunScheduler:
             not self._stopping.is_set()
             and len(self._in_flight) < self.model_concurrency
         ):
-            run_id = self.store.claim_next_run(provenance=self.executor.provenance())
+            provenance = self.executor.provenance()
+            if self._stopping.is_set():
+                # provenance() runs git and index probes; a stop requested
+                # during that work must still prevent the claim.
+                break
+            run_id = self.store.claim_next_run(provenance=provenance)
             if run_id is None:
                 break
             claimed += 1

--- a/human_eval/scheduler.py
+++ b/human_eval/scheduler.py
@@ -79,11 +79,7 @@ def acquire_execution_lock(db_path: str | Path) -> int:
 def execute_claimed_run(
     store: EvaluationStore, executor: RunExecutor, run_id: str
 ) -> None:
-    """Execute one already-started run and persist its terminal state.
-
-    Shared by the scheduler pool and the seed script (which acts as the
-    scheduler while holding the execution lock).
-    """
+    """Execute one scheduler-claimed run and persist its terminal state."""
     request = store.get_request(run_id)
     if request is None:
         LOGGER.warning("claimed run %s vanished before execution", run_id)
@@ -178,11 +174,19 @@ class RunScheduler:
             # supervisor restart this process (systemd Restart=always).
             self._stopping.set()
             return 0
+        if self._stopping.is_set():
+            return 0
+        # Poll SQLite first so an idle scheduler does not run the much more
+        # expensive git and index provenance probes every poll interval. New
+        # arrivals after this snapshot wait at most one interval.
+        available = min(
+            self.model_concurrency - len(self._in_flight),
+            self.store.queue_depth(),
+        )
         claimed = 0
-        while (
-            not self._stopping.is_set()
-            and len(self._in_flight) < self.model_concurrency
-        ):
+        for _ in range(available):
+            if self._stopping.is_set():
+                break
             provenance = self.executor.provenance()
             if self._stopping.is_set():
                 # provenance() runs git and index probes; a stop requested

--- a/human_eval/scheduler.py
+++ b/human_eval/scheduler.py
@@ -207,24 +207,24 @@ class RunScheduler:
         Single-use: an early stop request (for example SIGTERM during a slow
         ``prepare``) is honored instead of cleared.
         """
-        with ThreadPoolExecutor(
-            max_workers=self.model_concurrency,
-            thread_name_prefix="dof-human-eval-scheduler",
-        ) as self._pool:
-            try:
+        try:
+            with ThreadPoolExecutor(
+                max_workers=self.model_concurrency,
+                thread_name_prefix="dof-human-eval-scheduler",
+            ) as self._pool:
                 while not self._stopping.is_set():
                     if self.poll_once() == 0:
                         self._stopping.wait(self.poll_seconds)
-            finally:
-                self._pool = None
-        # The with-block waits for in-flight work; a hung call is bounded by
-        # the supervisor's stop timeout (systemd TimeoutStopSec + SIGKILL).
-        close = getattr(self.executor, "close", None)
-        if callable(close):
-            try:
-                close()
-            except Exception:
-                LOGGER.exception("executor shutdown hook failed")
+        finally:
+            self._pool = None
+            # Drain the pool before closing the executor, even if polling raises.
+            # A hung call is bounded by the supervisor's stop timeout.
+            close = getattr(self.executor, "close", None)
+            if callable(close):
+                try:
+                    close()
+                except Exception:
+                    LOGGER.exception("executor shutdown hook failed")
         if self._fatal is not None:
             raise RuntimeError(
                 "scheduler stopped after an execution persistence failure"

--- a/human_eval/service.py
+++ b/human_eval/service.py
@@ -1,16 +1,27 @@
-"""Queue and lifecycle management independent of the HTTP transport."""
+"""Web-side admission and query service, independent of the HTTP transport.
+
+Web processes only create ``queued`` runs and read state. Execution lives in
+the singleton scheduler process (``human_eval.scheduler``), which is the only
+component that transitions runs to ``started`` or terminal states.
+"""
 
 from __future__ import annotations
 
 import logging
-import queue
 import threading
 from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
-from typing import Any, Protocol
+from math import ceil
+from typing import Any
 
 from .contracts import FeedbackRequest, RunRequest
-from .store import EvaluationStore
+from .store import (
+    ActiveRunConflict,
+    DailyQuotaConflict,
+    EvaluationStore,
+    IdempotencyPayloadConflict,
+    QueueCapacityConflict,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -18,13 +29,10 @@ LOGGER = logging.getLogger(__name__)
 ProgressCallback = Callable[[str, dict[str, Any]], None]
 
 
-class RunExecutor(Protocol):
-    def execute(
-        self,
-        request: RunRequest,
-        *,
-        on_progress: ProgressCallback | None = None,
-    ) -> dict[str, Any]: ...
+# Fallback per-run inference estimate when no run has finished yet. From the
+# first local measurements (244-1,136 s per question); used only until
+# recent_durations() has real samples.
+DEFAULT_RUN_SECONDS = 480.0
 
 
 class PublicExecutionError(RuntimeError):
@@ -54,87 +62,39 @@ class ReviewRequiredError(RuntimeError):
 
 
 class EvaluationService:
+    """Admission and read model shared by every web worker process."""
+
     def __init__(
         self,
         store: EvaluationStore,
-        executor: RunExecutor,
-        provenance_factory: Callable[[], dict[str, Any]],
         *,
         queue_capacity: int = 20,
-        shutdown_timeout: float = 5.0,
+        model_concurrency: int = 1,
     ):
-        if shutdown_timeout < 0:
-            raise ValueError("shutdown_timeout must not be negative")
+        if queue_capacity < 1:
+            raise ValueError("queue_capacity must be positive")
+        if model_concurrency < 1:
+            raise ValueError("model_concurrency must be positive")
         self.store = store
-        self.executor = executor
-        self.provenance_factory = provenance_factory
-        self.queue: queue.Queue[str | None] = queue.Queue(maxsize=queue_capacity)
-        self.worker = threading.Thread(
-            target=self._worker_loop, name="dof-human-eval-worker", daemon=True
-        )
-        self.shutdown_timeout = shutdown_timeout
-        self._closing = threading.Event()
+        self.queue_capacity = queue_capacity
+        # Display-only mirror of the scheduler's concurrency: the scheduler
+        # enforces the real limit; the web process shows it in the UI.
+        self.model_concurrency = model_concurrency
         self._lifecycle_lock = threading.Lock()
-        self._write_lock = threading.Lock()
-        self._executor_close_lock = threading.Lock()
-        self._executor_closed = False
         self._started = False
 
     def start(self) -> None:
         with self._lifecycle_lock:
             if self._started:
                 return
-            if self.worker.ident is not None:
-                raise RuntimeError("create a new service instance after closing")
-            self._closing.clear()
-            self.store.initialize()
-            for run_id, state in self.store.unfinished_runs():
-                if state == "started":
-                    self.store.append_event(
-                        run_id,
-                        "failed",
-                        {
-                            "code": "service_restarted",
-                            "message": "La ejecución se interrumpió al reiniciar el servicio.",
-                        },
-                    )
-                else:
-                    try:
-                        self.queue.put_nowait(run_id)
-                    except queue.Full:
-                        self.store.append_event(
-                            run_id,
-                            "failed",
-                            {
-                                "code": "queue_full",
-                                "message": "La cola local está llena.",
-                            },
-                        )
-            self.worker.start()
+            # Web workers validate but never migrate; the scheduler owns the
+            # schema, so a migration can never race web startup.
+            self.store.validate_schema()
             self._started = True
 
     def close(self) -> None:
         with self._lifecycle_lock:
-            if not self._started:
-                return
             self._started = False
-            # Serialize this transition with event writes so no progress or
-            # terminal result can be persisted after shutdown begins.
-            with self._write_lock:
-                self._closing.set()
-            try:
-                self.queue.put_nowait(None)
-            except queue.Full:
-                # A full queue means the worker will wake without a sentinel;
-                # it observes _closing before taking another run.
-                pass
-        self.worker.join(timeout=self.shutdown_timeout)
-        if self.worker.is_alive():
-            LOGGER.warning(
-                "human-evaluation worker is still waiting for an in-flight call"
-            )
-        else:
-            self._close_executor()
 
     def submit(
         self,
@@ -144,9 +104,10 @@ class EvaluationService:
         admin: bool = False,
         daily_question_limit: int = 1,
     ) -> dict[str, Any]:
-        # This lock makes has_active_run + create_run atomic inside the one
-        # process supported by the MVP. SQLite constraints still provide
-        # idempotency, but multi-process admission would require a DB lock.
+        # create_run performs the admission checks in one SQLite transaction;
+        # the checks below only produce nicer errors without paying for a
+        # transaction first. The transactional checks are authoritative
+        # across all web processes.
         with self._lifecycle_lock:
             if not self._started:
                 raise RuntimeError("service has not started")
@@ -155,63 +116,73 @@ class EvaluationService:
                 return existing
             if self.store.has_active_run(user_id):
                 LOGGER.warning(
-                    "admission rejected: active run exists "
-                    "(depth=%s, capacity=%s)",
-                    self.queue.qsize(),
-                    self.queue.maxsize,
+                    "admission rejected: active run exists (depth=%s, capacity=%s)",
+                    self.store.queue_depth(),
+                    self.queue_capacity,
                 )
                 raise ActiveRunError("user already has an active run")
+            daily_since: str | None = None
             if not admin:
                 if not self.store.has_review_since_last_submission(user_id):
                     raise ReviewRequiredError(
                         "a published-answer review is required before asking"
                     )
                 if daily_question_limit >= 1:
-                    cutoff = (
+                    daily_since = (
                         (datetime.now(timezone.utc) - timedelta(hours=24))
                         .isoformat()
                         .replace("+00:00", "Z")
                     )
                     if (
-                        self.store.count_submissions_since(user_id, cutoff)
+                        self.store.count_submissions_since(user_id, daily_since)
                         >= daily_question_limit
                     ):
                         raise QuotaExceededError("daily question limit reached")
-            if self.queue.full():
+            queue_depth = self.store.queue_depth()
+            if queue_depth >= self.queue_capacity:
                 LOGGER.warning(
                     "admission rejected: queue full (depth=%s, capacity=%s)",
-                    self.queue.qsize(),
-                    self.queue.maxsize,
+                    queue_depth,
+                    self.queue_capacity,
                 )
                 raise QueueFullError("execution queue is full")
-            prepare_executor = getattr(self.executor, "prepare", None)
-            if callable(prepare_executor):
-                prepare_executor()
-            run, created = self.store.create_run(
-                request,
-                user_id=user_id,
-                provenance=self.provenance_factory(),
-            )
-            if created:
-                try:
-                    self.queue.put_nowait(run["run_id"])
-                except queue.Full:
-                    LOGGER.warning(
-                        "admission rejected after persisting run %s: queue full "
-                        "(depth=%s, capacity=%s)",
-                        run["run_id"],
-                        self.queue.qsize(),
-                        self.queue.maxsize,
-                    )
-                    self.store.append_event(
-                        run["run_id"],
-                        "failed",
-                        {
-                            "code": "queue_full",
-                            "message": "La cola local está llena.",
-                        },
-                    )
-                    raise QueueFullError("execution queue is full")
+            try:
+                run, created = self.store.create_run(
+                    request,
+                    user_id=user_id,
+                    provenance=None,
+                    enforce_active_run=True,
+                    queue_capacity=self.queue_capacity,
+                    daily_question_limit=(
+                        daily_question_limit
+                        if not admin and daily_question_limit >= 1
+                        else None
+                    ),
+                    daily_since=daily_since,
+                )
+            except ActiveRunConflict as exc:
+                LOGGER.warning(
+                    "admission rejected: active run exists (depth=%s, capacity=%s)",
+                    self.store.queue_depth(),
+                    self.queue_capacity,
+                )
+                raise ActiveRunError("user already has an active run") from exc
+            except QueueCapacityConflict as exc:
+                LOGGER.warning(
+                    "admission rejected: queue full (depth=%s, capacity=%s)",
+                    self.store.queue_depth(),
+                    self.queue_capacity,
+                )
+                raise QueueFullError("execution queue is full") from exc
+            except DailyQuotaConflict as exc:
+                raise QuotaExceededError("daily question limit reached") from exc
+            except IdempotencyPayloadConflict as exc:
+                raise IdempotencyConflictError(
+                    "client_request_id was already used for a different request"
+                ) from exc
+            if not created:
+                # Another web process won the idempotency race.
+                return self.public_run(run["run_id"], user_id=user_id, admin=True)
             return self.public_run(run["run_id"], user_id=user_id, admin=True)
 
     def idempotent_run(
@@ -246,7 +217,39 @@ class EvaluationService:
             if user_id is None or not self.store.run_belongs_to(run_id, user_id):
                 raise KeyError(run_id)
         run["events_url"] = f"/runs/{run_id}/events"
+        if run["status"] == "queued":
+            position = self.store.queue_position(run_id)
+            if position is not None:
+                run["queue_position"] = position
+                run["estimated_wait_seconds"] = self.estimated_wait_seconds(position)
+                run["queue_snapshot"] = self.queue_snapshot()
+        elif run["status"] == "running":
+            run["queue_snapshot"] = self.queue_snapshot()
         return run
+
+    def estimated_wait_seconds(self, position: int) -> int:
+        """Rough wait for a queued run at a 1-based FIFO position."""
+        durations = self.store.recent_durations(limit=10)
+        average = (
+            sum(durations) / len(durations) if durations else DEFAULT_RUN_SECONDS
+        )
+        available = self.store.model_activity(self.model_concurrency)["available"]
+        batches = ceil(max(0, position - available) / self.model_concurrency)
+        return max(0, int(round(batches * average)))
+
+    def queue_retry_after(self) -> int:
+        """Estimate when the next completion should free one queue place."""
+        durations = self.store.recent_durations(limit=10)
+        average = (
+            sum(durations) / len(durations) if durations else DEFAULT_RUN_SECONDS
+        )
+        return max(60, int(round(average)))
+
+    def queue_snapshot(self) -> dict[str, int]:
+        """Return shared queue state for the status UI and health endpoints."""
+        activity = self.store.model_activity(self.model_concurrency)
+        activity["queued"] = self.store.queue_depth()
+        return activity
 
     @staticmethod
     def _is_public(run: dict[str, Any]) -> bool:
@@ -274,92 +277,3 @@ class EvaluationService:
     def delete_run(self, run_id: str) -> None:
         """Delete a terminal run and all its data (admin-only action)."""
         self.store.delete_run(run_id)
-
-    def _worker_loop(self) -> None:
-        try:
-            while not self._closing.is_set():
-                run_id = self.queue.get()
-                try:
-                    if run_id is None or self._closing.is_set():
-                        return
-                    request = self.store.get_request(run_id)
-                    if request is None:
-                        continue
-                    if not self._append_event_if_open(run_id, "started"):
-                        return
-                    try:
-                        result = self.executor.execute(
-                            request,
-                            on_progress=lambda event_type,
-                            payload: self._append_progress_if_open(
-                                run_id, event_type, payload
-                            ),
-                        )
-                    except PublicExecutionError as exc:
-                        if exc.__cause__ is not None:
-                            LOGGER.exception(
-                                "human-evaluation run %s failed with %s",
-                                run_id,
-                                exc.code,
-                            )
-                        self._append_event_if_open(
-                            run_id,
-                            "failed",
-                            {"code": exc.code, "message": str(exc)},
-                        )
-                    except Exception:
-                        LOGGER.exception("human-evaluation run %s failed", run_id)
-                        self._append_event_if_open(
-                            run_id,
-                            "failed",
-                            {
-                                "code": "internal_error",
-                                "message": "La ejecución no pudo completarse.",
-                            },
-                        )
-                    else:
-                        self._append_event_if_open(run_id, "succeeded", result)
-                finally:
-                    self.queue.task_done()
-        finally:
-            if self._closing.is_set():
-                self._close_executor()
-
-    def _close_executor(self) -> None:
-        # If shutdown timed out while a run was active, the worker calls this
-        # after execute() returns so it never tears down an active run.
-        with self._executor_close_lock:
-            if self._executor_closed:
-                return
-            self._executor_closed = True
-        close_executor = getattr(self.executor, "close", None)
-        if callable(close_executor):
-            try:
-                close_executor()
-            except Exception:
-                LOGGER.exception("executor shutdown hook failed")
-
-    def _append_event_if_open(
-        self,
-        run_id: str,
-        event_type: str,
-        payload: dict[str, Any] | None = None,
-    ) -> bool:
-        with self._write_lock:
-            if self._closing.is_set():
-                return False
-            self.store.append_event(run_id, event_type, payload)
-            return True
-
-    def _append_progress_if_open(
-        self, run_id: str, event_type: str, payload: dict[str, Any]
-    ) -> None:
-        with self._write_lock:
-            if self._closing.is_set():
-                LOGGER.debug(
-                    "Dropping late progress event %r for run %s during shutdown",
-                    event_type,
-                    run_id,
-                )
-                return
-            self.store.append_progress(run_id, event_type, payload)

--- a/human_eval/service.py
+++ b/human_eval/service.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import threading
+import time
 from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from math import ceil
@@ -21,6 +22,7 @@ from .store import (
     EvaluationStore,
     IdempotencyPayloadConflict,
     QueueCapacityConflict,
+    ReviewRequiredConflict,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -83,13 +85,25 @@ class EvaluationService:
         self._lifecycle_lock = threading.Lock()
         self._started = False
 
-    def start(self) -> None:
+    def start(self, *, schema_wait_seconds: float = 0.0) -> None:
+        if schema_wait_seconds < 0:
+            raise ValueError("schema_wait_seconds must not be negative")
         with self._lifecycle_lock:
             if self._started:
                 return
-            # Web workers validate but never migrate; the scheduler owns the
-            # schema, so a migration can never race web startup.
-            self.store.validate_schema()
+            # Web workers validate but never migrate. Under systemd, After=
+            # orders process starts but Type=simple does not wait for the
+            # scheduler's prepare(), so allow a bounded readiness wait.
+            deadline = time.monotonic() + schema_wait_seconds
+            while True:
+                try:
+                    self.store.validate_schema()
+                    break
+                except RuntimeError:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise
+                    time.sleep(min(0.1, remaining))
             self._started = True
 
     def close(self) -> None:
@@ -104,54 +118,28 @@ class EvaluationService:
         admin: bool = False,
         daily_question_limit: int = 1,
     ) -> dict[str, Any]:
-        # create_run performs the admission checks in one SQLite transaction;
-        # the checks below only produce nicer errors without paying for a
-        # transaction first. The transactional checks are authoritative
-        # across all web processes.
+        # create_run checks idempotency first and performs every admission
+        # decision in one SQLite transaction. No preliminary rejection is
+        # safe here: another web process could commit the same idempotency key
+        # between a lookup and that rejection.
         with self._lifecycle_lock:
             if not self._started:
                 raise RuntimeError("service has not started")
-            existing = self.idempotent_run(request, user_id=user_id)
-            if existing is not None:
-                return existing
-            if self.store.has_active_run(user_id):
-                LOGGER.warning(
-                    "admission rejected: active run exists (depth=%s, capacity=%s)",
-                    self.store.queue_depth(),
-                    self.queue_capacity,
-                )
-                raise ActiveRunError("user already has an active run")
             daily_since: str | None = None
             if not admin:
-                if not self.store.has_review_since_last_submission(user_id):
-                    raise ReviewRequiredError(
-                        "a published-answer review is required before asking"
-                    )
                 if daily_question_limit >= 1:
                     daily_since = (
                         (datetime.now(timezone.utc) - timedelta(hours=24))
                         .isoformat()
                         .replace("+00:00", "Z")
                     )
-                    if (
-                        self.store.count_submissions_since(user_id, daily_since)
-                        >= daily_question_limit
-                    ):
-                        raise QuotaExceededError("daily question limit reached")
-            queue_depth = self.store.queue_depth()
-            if queue_depth >= self.queue_capacity:
-                LOGGER.warning(
-                    "admission rejected: queue full (depth=%s, capacity=%s)",
-                    queue_depth,
-                    self.queue_capacity,
-                )
-                raise QueueFullError("execution queue is full")
             try:
-                run, created = self.store.create_run(
+                run, _ = self.store.create_run(
                     request,
                     user_id=user_id,
                     provenance=None,
                     enforce_active_run=True,
+                    require_review=not admin,
                     queue_capacity=self.queue_capacity,
                     daily_question_limit=(
                         daily_question_limit
@@ -176,32 +164,15 @@ class EvaluationService:
                 raise QueueFullError("execution queue is full") from exc
             except DailyQuotaConflict as exc:
                 raise QuotaExceededError("daily question limit reached") from exc
+            except ReviewRequiredConflict as exc:
+                raise ReviewRequiredError(
+                    "a published-answer review is required before asking"
+                ) from exc
             except IdempotencyPayloadConflict as exc:
                 raise IdempotencyConflictError(
                     "client_request_id was already used for a different request"
                 ) from exc
-            if not created:
-                # Another web process won the idempotency race.
-                return self.public_run(run["run_id"], user_id=user_id, admin=True)
             return self.public_run(run["run_id"], user_id=user_id, admin=True)
-
-    def idempotent_run(
-        self, request: RunRequest, *, user_id: str
-    ) -> dict[str, Any] | None:
-        existing = self.store.find_idempotent_run(user_id, request.client_request_id)
-        if existing is None:
-            return None
-        if any(
-            (
-                existing["question"] != request.question,
-                existing["as_of"] != request.as_of,
-                existing["required_hops"] != request.required_hops,
-            )
-        ):
-            raise IdempotencyConflictError(
-                "client_request_id was already used for a different request"
-            )
-        return self.public_run(existing["run_id"], user_id=user_id, admin=True)
 
     def public_run(
         self,

--- a/human_eval/service.py
+++ b/human_eval/service.py
@@ -86,8 +86,8 @@ class EvaluationService:
         self._started = False
 
     def start(self, *, schema_wait_seconds: float = 0.0) -> None:
-        if schema_wait_seconds < 0:
-            raise ValueError("schema_wait_seconds must not be negative")
+        if not 0 <= schema_wait_seconds < float("inf"):
+            raise ValueError("schema_wait_seconds must be finite and non-negative")
         with self._lifecycle_lock:
             if self._started:
                 return

--- a/human_eval/store.py
+++ b/human_eval/store.py
@@ -39,6 +39,10 @@ class DailyQuotaConflict(RuntimeError):
     """The user has reached the configured rolling question limit."""
 
 
+class ReviewRequiredConflict(RuntimeError):
+    """The user must review an answer before submitting another question."""
+
+
 class IdempotencyPayloadConflict(RuntimeError):
     """An idempotency key was reused for a different request payload."""
 
@@ -216,6 +220,7 @@ class EvaluationStore:
         user_id: str,
         provenance: dict[str, Any] | None = None,
         enforce_active_run: bool = False,
+        require_review: bool = False,
         queue_capacity: int | None = None,
         daily_question_limit: int | None = None,
         daily_since: str | None = None,
@@ -261,6 +266,15 @@ class EvaluationStore:
                 ).fetchone()
                 if active:
                     raise ActiveRunConflict(user_id)
+            if require_review:
+                reviewed = connection.execute(
+                    "SELECT 1 FROM feedback f WHERE f.user_id = ? "
+                    "AND f.created_at > COALESCE((SELECT MAX(r.created_at) "
+                    "FROM runs r WHERE r.user_id = ?), '') LIMIT 1",
+                    (user_id, user_id),
+                ).fetchone()
+                if reviewed is None:
+                    raise ReviewRequiredConflict(user_id)
             if daily_question_limit is not None:
                 submissions = connection.execute(
                     "SELECT COUNT(*) FROM runs WHERE user_id = ? AND created_at >= ?",

--- a/human_eval/store.py
+++ b/human_eval/store.py
@@ -7,6 +7,7 @@ import sqlite3
 import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -25,6 +26,22 @@ PROGRESS_EVENT_TYPES = frozenset(
         "verification_completed",
     }
 )
+
+class ActiveRunConflict(RuntimeError):
+    """The user already has a queued or running execution."""
+
+
+class QueueCapacityConflict(RuntimeError):
+    """The shared persistent queue has reached its configured capacity."""
+
+
+class DailyQuotaConflict(RuntimeError):
+    """The user has reached the configured rolling question limit."""
+
+
+class IdempotencyPayloadConflict(RuntimeError):
+    """An idempotency key was reused for a different request payload."""
+
 
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS schema_meta (
@@ -164,28 +181,101 @@ class EvaluationStore:
                 "ALTER TABLE feedback RENAME COLUMN evaluator_hash TO user_id"
             )
 
+    def validate_schema(self) -> None:
+        """Verify the database is initialized at the current schema version.
+
+        Web processes never migrate: the scheduler (or the seed script, under
+        the same execution lock) is the only component allowed to initialize
+        or upgrade the database, so startup ordering never races a migration.
+        """
+        if not self.path.exists():
+            raise RuntimeError(
+                f"evaluation database {self.path} does not exist; "
+                "start the scheduler once to initialize it"
+            )
+        with self._connect() as connection:
+            try:
+                row = connection.execute(
+                    "SELECT value FROM schema_meta WHERE key = 'schema_version'"
+                ).fetchone()
+            except sqlite3.Error as exc:
+                raise RuntimeError(
+                    f"evaluation database {self.path} is not initialized"
+                ) from exc
+        if row is None or row[0] != SCHEMA_VERSION:
+            raise RuntimeError(
+                f"unsupported evaluation schema "
+                f"{None if row is None else row[0]!r}; expected {SCHEMA_VERSION} "
+                "(the scheduler migrates the database on startup)"
+            )
+
     def create_run(
         self,
         request: RunRequest,
         *,
         user_id: str,
-        provenance: dict[str, Any],
+        provenance: dict[str, Any] | None = None,
+        enforce_active_run: bool = False,
+        queue_capacity: int | None = None,
+        daily_question_limit: int | None = None,
+        daily_since: str | None = None,
     ) -> tuple[dict[str, Any], bool]:
+        if daily_question_limit is not None and daily_question_limit < 1:
+            raise ValueError("daily_question_limit must be positive")
+        if daily_question_limit is not None and daily_since is None:
+            raise ValueError("daily_since is required with daily_question_limit")
+        if queue_capacity is not None and queue_capacity < 1:
+            raise ValueError("queue_capacity must be positive")
         created_at = utc_now()
         run_id = str(uuid.uuid4())
         with self._connect() as connection:
             connection.execute("BEGIN IMMEDIATE")
             if request.client_request_id:
                 existing = connection.execute(
-                    "SELECT run_id FROM runs WHERE user_id = ? "
+                    "SELECT run_id, question, as_of, required_hops FROM runs "
+                    "WHERE user_id = ? "
                     "AND client_request_id = ?",
                     (user_id, request.client_request_id),
                 ).fetchone()
                 if existing:
+                    if any(
+                        (
+                            existing["question"] != request.question,
+                            existing["as_of"] != request.as_of,
+                            existing["required_hops"] != request.required_hops,
+                        )
+                    ):
+                        raise IdempotencyPayloadConflict(request.client_request_id)
                     connection.commit()
-                    found = self.get_run(existing[0])
+                    found = self.get_run(existing["run_id"])
                     assert found is not None
                     return found, False
+            if enforce_active_run:
+                active = connection.execute(
+                    "SELECT 1 FROM runs r JOIN run_events e ON e.run_id = r.run_id "
+                    "WHERE r.user_id = ? AND e.sequence = "
+                    "(SELECT MAX(e2.sequence) FROM run_events e2 "
+                    "WHERE e2.run_id = r.run_id) "
+                    "AND e.event_type IN ('queued', 'started') LIMIT 1",
+                    (user_id,),
+                ).fetchone()
+                if active:
+                    raise ActiveRunConflict(user_id)
+            if daily_question_limit is not None:
+                submissions = connection.execute(
+                    "SELECT COUNT(*) FROM runs WHERE user_id = ? AND created_at >= ?",
+                    (user_id, daily_since),
+                ).fetchone()[0]
+                if int(submissions) >= daily_question_limit:
+                    raise DailyQuotaConflict(daily_question_limit)
+            if queue_capacity is not None:
+                queued = connection.execute(
+                    "SELECT COUNT(*) FROM runs r JOIN run_events e ON e.run_id = r.run_id "
+                    "WHERE e.sequence = (SELECT MAX(e2.sequence) FROM run_events e2 "
+                    "WHERE e2.run_id = r.run_id) AND e.event_type = 'queued'"
+                ).fetchone()[0]
+                if int(queued) >= queue_capacity:
+                    raise QueueCapacityConflict(queue_capacity)
             connection.execute(
                 "INSERT INTO runs(run_id, created_at, question, as_of, required_hops, "
                 "user_id, client_request_id, provenance_json) "
@@ -198,7 +288,7 @@ class EvaluationStore:
                     request.required_hops,
                     user_id,
                     request.client_request_id,
-                    _json(provenance),
+                    _json(provenance or {}),
                 ),
             )
             connection.execute(
@@ -209,6 +299,179 @@ class EvaluationStore:
         found = self.get_run(run_id)
         assert found is not None
         return found, True
+
+    def queue_depth(self) -> int:
+        """Runs currently waiting for the scheduler."""
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT COUNT(*) FROM runs r JOIN run_events e ON e.run_id = r.run_id "
+                "WHERE e.sequence = (SELECT MAX(e2.sequence) FROM run_events e2 "
+                "WHERE e2.run_id = r.run_id) AND e.event_type = 'queued'"
+            ).fetchone()
+        return int(row[0])
+
+    def model_activity(self, capacity: int) -> dict[str, int]:
+        """Active executions (latest event 'started') against the capacity.
+
+        Only the scheduler starts runs, so the count of started runs is the
+        exact in-flight number; ``capacity`` is the scheduler's configured
+        model concurrency, mirrored in the web process for display only.
+        """
+        if capacity < 1:
+            raise ValueError("capacity must be positive")
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT COUNT(*) FROM runs r JOIN run_events e ON e.run_id = r.run_id "
+                "WHERE e.sequence = (SELECT MAX(e2.sequence) FROM run_events e2 "
+                "WHERE e2.run_id = r.run_id) AND e.event_type = 'started'"
+            ).fetchone()
+        active = int(row[0])
+        return {
+            "active": active,
+            "capacity": capacity,
+            "available": max(0, capacity - active),
+        }
+
+    def claim_next_run(self, *, provenance: dict[str, Any]) -> str | None:
+        """Atomically start the oldest queued run, stamping its provenance.
+
+        The singleton scheduler is the only caller, so no fencing is needed;
+        the transaction still keeps the claim atomic against web readers.
+        """
+        with self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            run = connection.execute(
+                "SELECT r.run_id FROM runs r JOIN run_events e ON e.run_id = r.run_id "
+                "WHERE e.sequence = (SELECT MAX(e2.sequence) FROM run_events e2 "
+                "WHERE e2.run_id = r.run_id) AND e.event_type = 'queued' "
+                "ORDER BY r.created_at, r.run_id LIMIT 1"
+            ).fetchone()
+            if run is None:
+                return None
+            run_id = str(run[0])
+            self._start_run_in_connection(connection, run_id, provenance)
+        return run_id
+
+    def start_run(self, run_id: str, *, provenance: dict[str, Any]) -> bool:
+        """Start one specific queued run (used by the seed script)."""
+        with self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            latest = connection.execute(
+                "SELECT event_type FROM run_events WHERE run_id = ? "
+                "ORDER BY sequence DESC LIMIT 1",
+                (run_id,),
+            ).fetchone()
+            if latest is None:
+                raise KeyError(run_id)
+            if latest[0] != "queued":
+                return False
+            self._start_run_in_connection(connection, run_id, provenance)
+        return True
+
+    @staticmethod
+    def _start_run_in_connection(
+        connection: sqlite3.Connection, run_id: str, provenance: dict[str, Any]
+    ) -> None:
+        """Stamp provenance and append 'started' in the caller's transaction."""
+        connection.execute(
+            "UPDATE runs SET provenance_json = ? WHERE run_id = ?",
+            (_json(provenance), run_id),
+        )
+        current = connection.execute(
+            "SELECT sequence FROM run_events WHERE run_id = ? "
+            "ORDER BY sequence DESC LIMIT 1",
+            (run_id,),
+        ).fetchone()
+        if current is None:
+            raise KeyError(run_id)
+        connection.execute(
+            "INSERT INTO run_events(run_id, sequence, event_type, created_at, payload_json) "
+            "VALUES (?, ?, 'started', ?, '{}')",
+            (run_id, int(current[0]) + 1, utc_now()),
+        )
+
+    def fail_interrupted_runs(self) -> int:
+        """Fail every run left 'started' by a previous scheduler lifetime.
+
+        Only the scheduler executes runs, so at scheduler startup (under the
+        execution lock) any started run is provably orphaned.
+        """
+        recovered = 0
+        with self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            runs = connection.execute(
+                "SELECT r.run_id, e.sequence FROM runs r JOIN run_events e "
+                "ON e.run_id = r.run_id WHERE e.sequence = (SELECT MAX(e2.sequence) "
+                "FROM run_events e2 WHERE e2.run_id = r.run_id) "
+                "AND e.event_type = 'started'"
+            ).fetchall()
+            now = utc_now()
+            for run in runs:
+                connection.execute(
+                    "INSERT INTO run_events(run_id, sequence, event_type, created_at, payload_json) "
+                    "VALUES (?, ?, 'failed', ?, ?)",
+                    (
+                        str(run[0]),
+                        int(run[1]) + 1,
+                        now,
+                        _json(
+                            {
+                                "code": "service_restarted",
+                                "message": "La ejecución se interrumpió antes de terminar.",
+                            }
+                        ),
+                    ),
+                )
+                recovered += 1
+        return recovered
+
+    def queue_position(self, run_id: str) -> int | None:
+        """1-based FIFO position among queued runs; None when not queued."""
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT r.created_at FROM runs r WHERE r.run_id = ? AND "
+                "(SELECT e.event_type FROM run_events e WHERE e.run_id = r.run_id "
+                "ORDER BY e.sequence DESC LIMIT 1) = 'queued'",
+                (run_id,),
+            ).fetchone()
+            if row is None:
+                return None
+            ahead = connection.execute(
+                "SELECT COUNT(*) FROM runs r WHERE "
+                "(SELECT e.event_type FROM run_events e WHERE e.run_id = r.run_id "
+                "ORDER BY e.sequence DESC LIMIT 1) = 'queued' AND "
+                "(r.created_at < ? OR (r.created_at = ? AND r.run_id < ?))",
+                (row["created_at"], row["created_at"], run_id),
+            ).fetchone()
+        return int(ahead[0]) + 1
+
+    def recent_durations(self, *, limit: int = 10) -> list[float]:
+        """Inference seconds (started -> terminal) of recent finished runs."""
+        if not 1 <= limit <= 100:
+            raise ValueError("limit must be between 1 and 100")
+        with self._connect() as connection:
+            rows = connection.execute(
+                "SELECT started.created_at AS started_at, "
+                "finished.created_at AS finished_at "
+                "FROM run_events started "
+                "JOIN run_events finished ON finished.run_id = started.run_id "
+                "AND finished.sequence = started.sequence + 1 "
+                "WHERE started.event_type = 'started' "
+                "AND finished.event_type IN ('succeeded', 'failed') "
+                "ORDER BY finished.created_at DESC, finished.run_id DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
+        durations: list[float] = []
+        for row in rows:
+            try:
+                began = datetime.fromisoformat(row["started_at"].replace("Z", "+00:00"))
+                ended = datetime.fromisoformat(
+                    row["finished_at"].replace("Z", "+00:00")
+                )
+            except (TypeError, ValueError):
+                continue
+            durations.append(max(0.0, (ended - began).total_seconds()))
+        return durations
 
     def find_idempotent_run(
         self, user_id: str, client_request_id: str | None
@@ -669,16 +932,6 @@ class EvaluationStore:
             for table in ("run_progress", "run_events", "feedback", "runs"):
                 connection.execute(f"DELETE FROM {table} WHERE run_id = ?", (run_id,))
         return True
-
-    def unfinished_runs(self) -> list[tuple[str, str]]:
-        with self._connect() as connection:
-            rows = connection.execute(
-                "SELECT r.run_id, e.event_type FROM runs r "
-                "JOIN run_events e ON e.run_id = r.run_id "
-                "WHERE e.sequence = (SELECT MAX(e2.sequence) FROM run_events e2 "
-                "WHERE e2.run_id = r.run_id) AND e.event_type IN ('queued', 'started')"
-            ).fetchall()
-        return [(row[0], row[1]) for row in rows]
 
     def feedback_for_run(self, run_id: str) -> list[dict[str, Any]]:
         """Administrative/test helper listing who evaluated the run and how."""

--- a/human_eval/store.py
+++ b/human_eval/store.py
@@ -472,6 +472,8 @@ class EvaluationStore:
                 "AND finished.sequence = started.sequence + 1 "
                 "WHERE started.event_type = 'started' "
                 "AND finished.event_type IN ('succeeded', 'failed') "
+                "AND COALESCE(json_extract(finished.payload_json, '$.code'), '') "
+                "!= 'service_restarted' "
                 "ORDER BY finished.created_at DESC, finished.run_id DESC LIMIT ?",
                 (limit,),
             ).fetchall()

--- a/ops/systemd/dof-human-eval-scheduler.service
+++ b/ops/systemd/dof-human-eval-scheduler.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=DOF human-evaluation scheduler (singleton model executor)
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+# The scheduler executes every agent run and owns the embedding server.
+# Only one scheduler may run per evaluation database; it enforces the
+# singleton itself with an flock next to the database and exits
+# immediately if another scheduler or the seed script holds it.
+ExecStart=@DOF_REPO_DIR@/.venv/bin/python -m human_eval.scheduler
+WorkingDirectory=@DOF_REPO_DIR@
+EnvironmentFile=-@DOF_REPO_DIR@/.env
+# Restart is the recovery mechanism: on startup the scheduler fails every
+# run left 'started' by the previous lifetime and resumes queued work.
+Restart=always
+RestartSec=2
+# SIGTERM stops new claims and lets in-flight runs finish within this
+# window; systemd then SIGKILLs the whole control group, including the
+# embedding-server child process.
+TimeoutStopSec=30
+KillMode=control-group
+StandardOutput=append:@DOF_REPO_DIR@/logs/human-eval-scheduler.log
+StandardError=append:@DOF_REPO_DIR@/logs/human-eval-scheduler.error.log
+
+[Install]
+WantedBy=default.target

--- a/ops/systemd/dof-human-eval-scheduler.service
+++ b/ops/systemd/dof-human-eval-scheduler.service
@@ -17,10 +17,11 @@ EnvironmentFile=-@DOF_REPO_DIR@/.env
 Restart=always
 RestartSec=2
 # SIGTERM stops new claims and lets in-flight runs finish within this
-# window; systemd then SIGKILLs the whole control group, including the
-# embedding-server child process.
+# window; it goes only to the scheduler so a managed embedding server keeps
+# serving in-flight hybrid runs during the drain, then SIGKILL reaches every
+# remaining process in the control group.
 TimeoutStopSec=30
-KillMode=control-group
+KillMode=mixed
 StandardOutput=append:@DOF_REPO_DIR@/logs/human-eval-scheduler.log
 StandardError=append:@DOF_REPO_DIR@/logs/human-eval-scheduler.error.log
 

--- a/ops/systemd/dof-human-eval-scheduler.service
+++ b/ops/systemd/dof-human-eval-scheduler.service
@@ -7,7 +7,7 @@ After=network-online.target
 Type=simple
 # The scheduler executes every agent run and owns the embedding server.
 # Only one scheduler may run per evaluation database; it enforces the
-# singleton itself with an flock next to the database and exits
+# singleton itself with a flock next to the database and exits
 # immediately if another scheduler or the seed script holds it.
 ExecStart=@DOF_REPO_DIR@/.venv/bin/python -m human_eval.scheduler
 WorkingDirectory=@DOF_REPO_DIR@

--- a/ops/systemd/dof-human-eval-web.service
+++ b/ops/systemd/dof-human-eval-web.service
@@ -6,8 +6,8 @@ After=network-online.target dof-human-eval-scheduler.service
 [Service]
 Type=simple
 # Web workers only admit and read runs; the scheduler process executes
-# them. Start the scheduler first so it initializes/migrates the database
-# before web workers validate it.
+# them. The scheduler is launched first, and web workers wait up to
+# DOF_SCHEMA_WAIT_SECONDS (30 seconds by default) for schema preparation.
 ExecStart=@DOF_REPO_DIR@/.venv/bin/python -m human_eval.app --workers 2
 WorkingDirectory=@DOF_REPO_DIR@
 EnvironmentFile=-@DOF_REPO_DIR@/.env

--- a/ops/systemd/dof-human-eval-web.service
+++ b/ops/systemd/dof-human-eval-web.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=DOF human-evaluation web app (admission and UI)
+Wants=network-online.target
+After=network-online.target dof-human-eval-scheduler.service
+
+[Service]
+Type=simple
+# Web workers only admit and read runs; the scheduler process executes
+# them. Start the scheduler first so it initializes/migrates the database
+# before web workers validate it.
+ExecStart=@DOF_REPO_DIR@/.venv/bin/python -m human_eval.app --workers 2
+WorkingDirectory=@DOF_REPO_DIR@
+EnvironmentFile=-@DOF_REPO_DIR@/.env
+Restart=always
+RestartSec=2
+StandardOutput=append:@DOF_REPO_DIR@/logs/human-eval-web.log
+StandardError=append:@DOF_REPO_DIR@/logs/human-eval-web.error.log
+
+[Install]
+WantedBy=default.target

--- a/scripts/install_human_eval_systemd.sh
+++ b/scripts/install_human_eval_systemd.sh
@@ -1,16 +1,23 @@
 #!/bin/bash
 # Install the DOF human-evaluation services (scheduler + web) as systemd
 # --user units. Renders @DOF_REPO_DIR@ in the checked-in unit templates
-# with the actual checkout path, so clones may live anywhere.
+# with the actual checkout path.
 set -eu
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_dir="$(dirname "$script_dir")"
 target_dir="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
 
+case "$repo_dir" in
+    *[[:space:]]*)
+        echo "error: the checkout path must not contain whitespace: $repo_dir" >&2
+        exit 1
+        ;;
+esac
+
 mkdir -p "$target_dir" "$repo_dir/logs"
 
-# Escape sed's replacement metacharacters so spaces and & are preserved.
+# Escape sed's replacement metacharacters.
 escaped_repo_dir=$(printf '%s' "$repo_dir" | sed 's/[&|\]/\\&/g')
 
 for unit in dof-human-eval-scheduler.service dof-human-eval-web.service; do
@@ -21,7 +28,7 @@ for unit in dof-human-eval-scheduler.service dof-human-eval-web.service; do
 done
 
 systemctl --user daemon-reload
-# The scheduler migrates the database before the web workers validate it.
+# Launch the scheduler first; web workers perform a bounded schema-readiness wait.
 systemctl --user enable --now dof-human-eval-scheduler.service
 systemctl --user enable --now dof-human-eval-web.service
 systemctl --user status dof-human-eval-scheduler.service dof-human-eval-web.service --no-pager || true

--- a/scripts/install_human_eval_systemd.sh
+++ b/scripts/install_human_eval_systemd.sh
@@ -27,11 +27,19 @@ for unit in dof-human-eval-scheduler.service dof-human-eval-web.service; do
     mv "$temporary" "$target_dir/$unit"
 done
 
+# Installation starts inactive services but deliberately does not interrupt
+# active runs. After upgrading code/units, operators must stop web admission
+# and restart both processes explicitly (daemon-reload alone is insufficient).
 systemctl --user daemon-reload
 # Launch the scheduler first; web workers perform a bounded schema-readiness wait.
 systemctl --user enable --now dof-human-eval-scheduler.service
 systemctl --user enable --now dof-human-eval-web.service
 systemctl --user status dof-human-eval-scheduler.service dof-human-eval-web.service --no-pager || true
+
+echo "For upgrades, apply the new code/units with:"
+echo "  systemctl --user stop dof-human-eval-web.service"
+echo "  systemctl --user restart dof-human-eval-scheduler.service"
+echo "  systemctl --user start dof-human-eval-web.service"
 
 if [ "$(loginctl show-user "$USER" --property=Linger --value 2>/dev/null)" != "yes" ]; then
     echo "note: run 'loginctl enable-linger $USER' so the services survive logout"

--- a/scripts/install_human_eval_systemd.sh
+++ b/scripts/install_human_eval_systemd.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Install the DOF human-evaluation services (scheduler + web) as systemd
+# --user units. Renders @DOF_REPO_DIR@ in the checked-in unit templates
+# with the actual checkout path, so clones may live anywhere.
+set -eu
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_dir="$(dirname "$script_dir")"
+target_dir="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+
+mkdir -p "$target_dir" "$repo_dir/logs"
+
+# Escape sed's replacement metacharacters so spaces and & are preserved.
+escaped_repo_dir=$(printf '%s' "$repo_dir" | sed 's/[&|\]/\\&/g')
+
+for unit in dof-human-eval-scheduler.service dof-human-eval-web.service; do
+    temporary="$target_dir/$unit.new"
+    sed "s|@DOF_REPO_DIR@|$escaped_repo_dir|g" "$repo_dir/ops/systemd/$unit" \
+        > "$temporary"
+    mv "$temporary" "$target_dir/$unit"
+done
+
+systemctl --user daemon-reload
+# The scheduler migrates the database before the web workers validate it.
+systemctl --user enable --now dof-human-eval-scheduler.service
+systemctl --user enable --now dof-human-eval-web.service
+systemctl --user status dof-human-eval-scheduler.service dof-human-eval-web.service --no-pager || true
+
+if [ "$(loginctl show-user "$USER" --property=Linger --value 2>/dev/null)" != "yes" ]; then
+    echo "note: run 'loginctl enable-linger $USER' so the services survive logout"
+fi

--- a/scripts/seed_human_eval_v4_hybrid.py
+++ b/scripts/seed_human_eval_v4_hybrid.py
@@ -10,7 +10,11 @@ Idempotent: each seed run uses
 ``seed:eval-v4`` system user. ``--replace`` deletes existing ``seed:`` runs
 first (the store keeps deletion restricted to seed users).
 
+The seed script executes runs itself, so it takes the same exclusive
+execution lock as the scheduler: stop the scheduler service before seeding.
+
 Usage:
+    systemctl --user stop dof-human-eval-scheduler  # free the execution lock
     set -a; source .env; set +a
     export DOF_AGENT_PROVIDER=kimi-code DOF_AGENT_MODEL=kimi-for-coding \
         DOF_RETRIEVAL_MODE=hybrid
@@ -21,6 +25,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Any
@@ -29,6 +34,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from human_eval.agent_executor import AgentExecutorConfig, AgentRunExecutor
 from human_eval.contracts import RunRequest
+from human_eval.scheduler import acquire_execution_lock
 from human_eval.service import PublicExecutionError
 from human_eval.store import EvaluationStore
 
@@ -65,13 +71,13 @@ def seed_live_run(
         else:
             # Do not delete a queued/running run owned by another process.
             return "pending"
-    record, created = store.create_run(
-        request, user_id=SEED_USER, provenance=executor.provenance()
-    )
+    record, created = store.create_run(request, user_id=SEED_USER)
     if not created:
         return "skipped"
     run_id = record["run_id"]
-    store.append_event(run_id, "started")
+    # The seed script holds the execution lock and acts as the scheduler:
+    # stamp provenance atomically with the started transition.
+    store.start_run(run_id, provenance=executor.provenance())
     try:
         result = executor.execute(
             request,
@@ -135,6 +141,10 @@ def main() -> int:
             parser.error(f"unknown query ids: {sorted(missing)}")
 
     store = EvaluationStore(args.db)
+    # Only one process may execute runs against a database. Seeding normally
+    # happens with the scheduler service stopped; the lock makes an
+    # accidental overlap fail immediately instead of double-executing.
+    lock_fd = acquire_execution_lock(args.db)
     store.initialize()
     config = AgentExecutorConfig.from_env(args.repo_root)
     executor = AgentRunExecutor(config)
@@ -164,6 +174,7 @@ def main() -> int:
         )
     finally:
         executor.close()
+        os.close(lock_fd)
     return 1 if counts["failed"] or counts["pending"] else 0
 
 

--- a/scripts/seed_human_eval_v4_hybrid.py
+++ b/scripts/seed_human_eval_v4_hybrid.py
@@ -112,7 +112,8 @@ def main() -> int:
         "--queries", type=Path, default=Path("eval/dof_queries_v4.jsonl")
     )
     parser.add_argument(
-        "--db", type=Path, default=Path("var/human_evaluation.sqlite")
+        "--db", type=Path, default=None,
+        help="evaluation database (default: DOF_HUMAN_EVAL_DB or var/human_evaluation.sqlite)",
     )
     parser.add_argument(
         "--repo-root",
@@ -140,13 +141,17 @@ def main() -> int:
         if missing:
             parser.error(f"unknown query ids: {sorted(missing)}")
 
-    store = EvaluationStore(args.db)
+    root = args.repo_root.resolve()
+    db_path = args.db or Path(
+        os.environ.get("DOF_HUMAN_EVAL_DB", root / "var/human_evaluation.sqlite")
+    )
+    store = EvaluationStore(db_path)
     # Only one process may execute runs against a database. Seeding normally
     # happens with the scheduler service stopped; the lock makes an
     # accidental overlap fail immediately instead of double-executing.
-    lock_fd = acquire_execution_lock(args.db)
+    lock_fd = acquire_execution_lock(db_path)
     store.initialize()
-    config = AgentExecutorConfig.from_env(args.repo_root)
+    config = AgentExecutorConfig.from_env(root)
     executor = AgentRunExecutor(config)
     # Pre-warm the embedding server so provenance records vector_used from the
     # first run on (the embedder otherwise starts lazily mid-run).

--- a/scripts/seed_human_eval_v4_hybrid.py
+++ b/scripts/seed_human_eval_v4_hybrid.py
@@ -71,13 +71,16 @@ def seed_live_run(
         else:
             # Do not delete a queued/running run owned by another process.
             return "pending"
+    # Probe before persisting work so a provenance failure cannot strand a
+    # queued seed run outside this script's execution/publishing flow.
+    provenance = executor.provenance()
     record, created = store.create_run(request, user_id=SEED_USER)
     if not created:
         return "skipped"
     run_id = record["run_id"]
     # The seed script holds the execution lock and acts as the scheduler:
     # stamp provenance atomically with the started transition.
-    store.start_run(run_id, provenance=executor.provenance())
+    store.start_run(run_id, provenance=provenance)
     try:
         result = executor.execute(
             request,

--- a/tests/test_human_eval.py
+++ b/tests/test_human_eval.py
@@ -28,6 +28,7 @@ from human_eval.app import (
 from human_eval.auth import FakeAuthBackend, User
 from human_eval.contracts import ContractError, FeedbackRequest, RunRequest
 from human_eval.markdown_render import render_markdown_html
+from human_eval.scheduler import RunScheduler
 from human_eval.service import (
     ActiveRunError,
     EvaluationService,
@@ -118,6 +119,40 @@ def wait_for_terminal(service: EvaluationService, run_id: str) -> dict:
     raise AssertionError("run did not reach a terminal state")
 
 
+def start_scheduler(
+    store: EvaluationStore, executor, **kwargs
+) -> tuple[RunScheduler, threading.Thread]:
+    """Run a background scheduler against the store, like production."""
+    scheduler = RunScheduler(store, executor, poll_seconds=0.02, **kwargs)
+    scheduler.prepare()
+    thread = threading.Thread(
+        target=scheduler.run, name="test-scheduler", daemon=True
+    )
+    thread.start()
+    return scheduler, thread
+
+
+def stop_scheduler(scheduler: RunScheduler, thread: threading.Thread) -> None:
+    scheduler.stop()
+    thread.join(timeout=3)
+
+
+class SchedulerTestCase(unittest.TestCase):
+    """Web service plus a background scheduler against one temporary store."""
+
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.store = EvaluationStore(Path(self.tempdir.name) / "evaluation.sqlite")
+
+    def make_service(self, executor=None, **service_kwargs):
+        executor = executor or FakeExecutor()
+        harness = start_scheduler(self.store, executor)
+        self.addCleanup(stop_scheduler, *harness)
+        service = EvaluationService(self.store, **service_kwargs)
+        service.start()
+        self.addCleanup(service.close)
+        return service, executor
 class ContractTests(unittest.TestCase):
     def test_run_request_validates_and_normalizes(self):
         request = RunRequest.from_dict(
@@ -811,53 +846,41 @@ class StoreTests(unittest.TestCase):
         self.assertNotEqual(first["run_id"], third["run_id"])
 
 
-class ServiceTests(unittest.TestCase):
-    def setUp(self):
-        self.tempdir = tempfile.TemporaryDirectory()
-        self.store = EvaluationStore(Path(self.tempdir.name) / "evaluation.sqlite")
-
-    def tearDown(self):
-        self.tempdir.cleanup()
-
-    def test_worker_persists_success_and_provenance(self):
-        executor = FakeExecutor()
-        service = EvaluationService(self.store, executor, executor.provenance)
-        service.start()
-        try:
-            created = service.submit(
-                RunRequest("pregunta válida", client_request_id="request-1"),
+class ServiceTests(SchedulerTestCase):
+    def test_run_persists_success_and_provenance(self):
+        service, _ = self.make_service()
+        created = service.submit(
+            RunRequest("pregunta válida", client_request_id="request-1"),
+            user_id="evaluator",
+            admin=True,
+        )
+        finished = wait_for_terminal(service, created["run_id"])
+        self.assertEqual(finished["status"], "succeeded")
+        self.assertEqual(finished["result"]["answer"]["citation_ids"], [123])
+        self.assertEqual(
+            [event["event_type"] for event in finished["progress"]],
+            ["agent_started", "tool_completed"],
+        )
+        self.assertEqual(finished["provenance"]["code_revision"], "abc123")
+        self.assertEqual(
+            finished["events_url"], f"/runs/{created['run_id']}/events"
+        )
+        self.assertNotIn("status_url", finished)
+        self.assertNotIn("feedback_url", finished)
+        repeated = service.submit(
+            RunRequest("pregunta válida", client_request_id="request-1"),
+            user_id="evaluator",
+            admin=True,
+        )
+        self.assertEqual(repeated["run_id"], created["run_id"])
+        with self.assertRaises(IdempotencyConflictError):
+            service.submit(
+                RunRequest("otra pregunta", client_request_id="request-1"),
                 user_id="evaluator",
                 admin=True,
             )
-            finished = wait_for_terminal(service, created["run_id"])
-            self.assertEqual(finished["status"], "succeeded")
-            self.assertEqual(finished["result"]["answer"]["citation_ids"], [123])
-            self.assertEqual(
-                [event["event_type"] for event in finished["progress"]],
-                ["agent_started", "tool_completed"],
-            )
-            self.assertEqual(finished["provenance"]["code_revision"], "abc123")
-            self.assertEqual(
-                finished["events_url"], f"/runs/{created['run_id']}/events"
-            )
-            self.assertNotIn("status_url", finished)
-            self.assertNotIn("feedback_url", finished)
-            repeated = service.submit(
-                RunRequest("pregunta válida", client_request_id="request-1"),
-                user_id="evaluator",
-                admin=True,
-            )
-            self.assertEqual(repeated["run_id"], created["run_id"])
-            with self.assertRaises(IdempotencyConflictError):
-                service.submit(
-                    RunRequest("otra pregunta", client_request_id="request-1"),
-                    user_id="evaluator",
-                    admin=True,
-                )
-        finally:
-            service.close()
 
-    def test_worker_logs_the_private_cause_of_a_public_failure(self):
+    def test_scheduler_logs_the_private_cause_of_a_public_failure(self):
         class FailingExecutor(FakeExecutor):
             def execute(self, request, *, on_progress=None):
                 try:
@@ -867,17 +890,12 @@ class ServiceTests(unittest.TestCase):
                         "provider_unavailable", "El proveedor no está disponible."
                     ) from exc
 
-        executor = FailingExecutor()
-        service = EvaluationService(self.store, executor, executor.provenance)
-        with mock.patch("human_eval.service.LOGGER.exception") as log_exception:
-            service.start()
-            try:
-                created = service.submit(
-                    RunRequest("pregunta válida"), user_id="evaluator", admin=True
-                )
-                finished = wait_for_terminal(service, created["run_id"])
-            finally:
-                service.close()
+        with mock.patch("human_eval.scheduler.LOGGER.exception") as log_exception:
+            service, _ = self.make_service(FailingExecutor())
+            created = service.submit(
+                RunRequest("pregunta válida"), user_id="evaluator", admin=True
+            )
+            finished = wait_for_terminal(service, created["run_id"])
 
         self.assertEqual(finished["status"], "failed")
         self.assertEqual(finished["error"]["code"], "provider_unavailable")
@@ -887,7 +905,7 @@ class ServiceTests(unittest.TestCase):
             "provider_unavailable",
         )
 
-    def test_submit_prepares_executor_before_snapshotting_provenance(self):
+    def test_scheduler_prepares_executor_before_snapshotting_provenance(self):
         class PreparingExecutor(FakeExecutor):
             def __init__(self):
                 self.prepared = False
@@ -900,179 +918,71 @@ class ServiceTests(unittest.TestCase):
                 provenance["vector_used"] = self.prepared
                 return provenance
 
-        executor = PreparingExecutor()
-        service = EvaluationService(self.store, executor, executor.provenance)
-        service.start()
-        try:
-            created = service.submit(
-                RunRequest("pregunta híbrida"), user_id="evaluator", admin=True
-            )
-            self.assertTrue(
-                service.public_run(created["run_id"], admin=True)["provenance"][
-                    "vector_used"
-                ]
-            )
-        finally:
-            service.close()
+        service, executor = self.make_service(PreparingExecutor())
+        self.assertTrue(executor.prepared)
+        created = service.submit(
+            RunRequest("pregunta híbrida"), user_id="evaluator", admin=True
+        )
+        finished = wait_for_terminal(service, created["run_id"])
+        self.assertTrue(finished["provenance"]["vector_used"])
 
     def test_only_one_active_run_per_evaluator(self):
-        executor = BlockingExecutor()
-        service = EvaluationService(self.store, executor, executor.provenance)
-        service.start()
-        try:
+        service, executor = self.make_service(BlockingExecutor())
+        service.submit(
+            RunRequest("primera pregunta"), user_id="evaluator", admin=True
+        )
+        self.assertTrue(executor.started.wait(timeout=1))
+        with self.assertRaises(ActiveRunError):
             service.submit(
-                RunRequest("primera pregunta"), user_id="evaluator", admin=True
+                RunRequest("segunda pregunta"), user_id="evaluator", admin=True
             )
-            self.assertTrue(executor.started.wait(timeout=1))
-            with self.assertRaises(ActiveRunError):
-                service.submit(
-                    RunRequest("segunda pregunta"), user_id="evaluator", admin=True
-                )
-            executor.release.set()
-            service.queue.join()
-        finally:
-            executor.release.set()
-            service.close()
+        executor.release.set()
 
     def test_queue_full_rejection_is_logged(self):
-        executor = BlockingExecutor()
-        service = EvaluationService(
-            self.store, executor, executor.provenance, queue_capacity=1
+        service, executor = self.make_service(BlockingExecutor(), queue_capacity=1)
+        service.submit(
+            RunRequest("primera", client_request_id="q1"),
+            user_id="u1",
+            admin=True,
         )
-        service.start()
-        try:
-            service.submit(
-                RunRequest("primera", client_request_id="q1"),
-                user_id="u1",
-                admin=True,
-            )
-            self.assertTrue(executor.started.wait(timeout=3))
-            service.submit(
-                RunRequest("segunda", client_request_id="q2"),
-                user_id="u2",
-                admin=True,
-            )
-            with self.assertLogs("human_eval.service", level="WARNING") as captured:
-                with self.assertRaises(QueueFullError):
-                    service.submit(
-                        RunRequest("tercera", client_request_id="q3"),
-                        user_id="u3",
-                        admin=True,
-                    )
-            self.assertIn("queue full", captured.output[0])
-            self.assertIn("capacity=1", captured.output[0])
-        finally:
-            executor.release.set()
-            service.close()
+        self.assertTrue(executor.started.wait(timeout=3))
+        service.submit(
+            RunRequest("segunda", client_request_id="q2"),
+            user_id="u2",
+            admin=True,
+        )
+        with self.assertLogs("human_eval.service", level="WARNING") as captured:
+            with self.assertRaises(QueueFullError):
+                service.submit(
+                    RunRequest("tercera", client_request_id="q3"),
+                    user_id="u3",
+                    admin=True,
+                )
+        self.assertIn("queue full", captured.output[0])
+        self.assertIn("capacity=1", captured.output[0])
+        executor.release.set()
 
     def test_active_run_rejection_is_logged_without_user_id(self):
-        executor = BlockingExecutor()
-        service = EvaluationService(
-            self.store, executor, executor.provenance, queue_capacity=2
+        service, executor = self.make_service(BlockingExecutor(), queue_capacity=2)
+        service.submit(
+            RunRequest("primera", client_request_id="active-1"),
+            user_id="sensitive-user-id",
+            admin=True,
         )
-        service.start()
-        try:
-            service.submit(
-                RunRequest("primera", client_request_id="active-1"),
-                user_id="sensitive-user-id",
-                admin=True,
-            )
-            self.assertTrue(executor.started.wait(timeout=3))
-            with self.assertLogs("human_eval.service", level="WARNING") as captured:
-                with self.assertRaises(ActiveRunError):
-                    service.submit(
-                        RunRequest("segunda", client_request_id="active-2"),
-                        user_id="sensitive-user-id",
-                        admin=True,
-                    )
-            message = captured.output[0]
-            self.assertIn("active run exists", message)
-            self.assertIn("depth=0", message)
-            self.assertIn("capacity=2", message)
-            self.assertNotIn("sensitive-user-id", message)
-        finally:
-            executor.release.set()
-            service.close()
-
-    def test_close_runs_the_executor_shutdown_hook(self):
-        class ClosingExecutor(FakeExecutor):
-            def __init__(self):
-                self.closed = False
-
-            def close(self):
-                self.closed = True
-
-        executor = ClosingExecutor()
-        service = EvaluationService(self.store, executor, executor.provenance)
-        service.start()
-        service.close()
-        self.assertTrue(executor.closed)
-
-    def test_close_does_not_shutdown_executor_while_worker_is_active(self):
-        class ClosingBlockingExecutor(BlockingExecutor):
-            def __init__(self):
-                super().__init__()
-                self.closed = False
-
-            def close(self):
-                self.closed = True
-
-        executor = ClosingBlockingExecutor()
-        service = EvaluationService(
-            self.store,
-            executor,
-            executor.provenance,
-            shutdown_timeout=0.01,
-        )
-        service.start()
-        service.submit(RunRequest("pregunta activa"), user_id="one", admin=True)
-        self.assertTrue(executor.started.wait(timeout=1))
-        service.close()
-        self.assertFalse(executor.closed)
+        self.assertTrue(executor.started.wait(timeout=3))
+        with self.assertLogs("human_eval.service", level="WARNING") as captured:
+            with self.assertRaises(ActiveRunError):
+                service.submit(
+                    RunRequest("segunda", client_request_id="active-2"),
+                    user_id="sensitive-user-id",
+                    admin=True,
+                )
+        message = captured.output[0]
+        self.assertIn("active run exists", message)
+        self.assertIn("depth=0", message)
+        self.assertIn("capacity=2", message)
+        self.assertNotIn("sensitive-user-id", message)
         executor.release.set()
-        service.worker.join(timeout=1)
-        self.assertTrue(executor.closed)
-
-    def test_close_never_blocks_on_full_queue_or_writes_late_results(self):
-        executor = BlockingExecutor()
-        service = EvaluationService(
-            self.store,
-            executor,
-            executor.provenance,
-            queue_capacity=1,
-            shutdown_timeout=0.01,
-        )
-        service.start()
-        first = service.submit(RunRequest("primera"), user_id="one", admin=True)
-        self.assertTrue(executor.started.wait(timeout=1))
-        second = service.submit(RunRequest("segunda"), user_id="two", admin=True)
-
-        started = time.monotonic()
-        service.close()
-        service.close()
-        self.assertLess(time.monotonic() - started, 0.5)
-        executor.release.set()
-        service.worker.join(timeout=1)
-
-        self.assertEqual(
-            service.public_run(first["run_id"], admin=True)["status"], "running"
-        )
-        self.assertEqual(
-            service.public_run(second["run_id"], admin=True)["status"], "queued"
-        )
-
-        replacement = EvaluationService(
-            self.store, FakeExecutor(), lambda: dict(PROVENANCE)
-        )
-        replacement.start()
-        try:
-            recovered_first = service.public_run(first["run_id"], admin=True)
-            recovered_second = wait_for_terminal(replacement, second["run_id"])
-            self.assertEqual(recovered_first["status"], "failed")
-            self.assertEqual(recovered_first["error"]["code"], "service_restarted")
-            self.assertEqual(recovered_second["status"], "succeeded")
-        finally:
-            replacement.close()
 
 
 class AirAppTestCase(unittest.TestCase):
@@ -1083,7 +993,11 @@ class AirAppTestCase(unittest.TestCase):
         self.db_path = Path(self.tempdir.name) / "evaluation.sqlite"
         store = EvaluationStore(self.db_path)
         self.executor = FakeExecutor()
-        self.service = EvaluationService(store, self.executor, self.executor.provenance)
+        # Web service admits and reads; a background scheduler executes.
+        self.scheduler, self.scheduler_thread = start_scheduler(
+            store, self.executor
+        )
+        self.service = EvaluationService(store)
         self.settings = WebSettings(
             host="127.0.0.1",
             port=0,
@@ -1102,6 +1016,7 @@ class AirAppTestCase(unittest.TestCase):
 
     def tearDown(self):
         self.client_context.__exit__(None, None, None)
+        stop_scheduler(self.scheduler, self.scheduler_thread)
         self.tempdir.cleanup()
 
     @staticmethod
@@ -1721,7 +1636,7 @@ class LoginPageTests(AirAppTestCase):
             session_secret="test-session-secret-that-is-at-least-32-bytes",
         )
         store = EvaluationStore(self.db_path)
-        service = EvaluationService(store, self.executor, self.executor.provenance)
+        service = EvaluationService(store)
         app = create_app(
             service,
             settings,

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -439,3 +439,28 @@ class SchedulerFailureTests(unittest.TestCase):
         scheduler.stop()
         scheduler.run()
         self.assertEqual(self.store.get_run(run["run_id"])["status"], "queued")
+
+    def test_stop_during_provenance_prevents_the_claim(self):
+        class SlowProvenanceExecutor(FakeExecutor):
+            def __init__(self):
+                self.inside = threading.Event()
+                self.release = threading.Event()
+
+            def provenance(self):
+                self.inside.set()
+                if not self.release.wait(3):
+                    raise RuntimeError("test provenance barrier timed out")
+                return super().provenance()
+
+        executor = SlowProvenanceExecutor()
+        scheduler, thread = start_scheduler(self.store, executor)
+        service = EvaluationService(self.store)
+        service.start()
+        run = service.submit(RunRequest("pregunta"), user_id="one", admin=True)
+        self.assertTrue(executor.inside.wait(1))
+        # SIGTERM arrives while provenance runs its git and index probes.
+        scheduler.stop()
+        executor.release.set()
+        thread.join(timeout=3)
+        self.assertFalse(thread.is_alive())
+        self.assertEqual(self.store.get_run(run["run_id"])["status"], "queued")

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -53,6 +53,26 @@ class ExecutionLockTests(unittest.TestCase):
         second = acquire_execution_lock(self.db_path)
         os.close(second)
 
+    def test_database_symlink_shares_execution_lock(self):
+        alias = self.db_path.with_name("alias.sqlite")
+        alias.symlink_to(self.db_path.name)
+        # Also resolve a dangling alias before SQLite creates the database.
+        for exists in (False, True):
+            with self.subTest(database_exists=exists):
+                if exists:
+                    self.db_path.touch()
+                self.assertEqual(
+                    execution_lock_path(alias), execution_lock_path(self.db_path)
+                )
+                fd = acquire_execution_lock(self.db_path)
+                try:
+                    with self.assertRaisesRegex(RuntimeError, "execution lock"):
+                        acquire_execution_lock(alias)
+                finally:
+                    os.close(fd)
+                second = acquire_execution_lock(alias)
+                os.close(second)
+
     def test_lock_fd_is_not_inheritable_by_child_processes(self):
         fd = acquire_execution_lock(self.db_path)
         try:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,395 @@
+"""Tests for the singleton scheduler, execution lock, and split web/executor roles."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from human_eval.app import _queue_status_event, _status_fragment
+from human_eval.contracts import RunRequest
+from human_eval.scheduler import (
+    RunScheduler,
+    acquire_execution_lock,
+    execution_lock_path,
+)
+from human_eval.service import (
+    ActiveRunError,
+    EvaluationService,
+    IdempotencyConflictError,
+    QueueFullError,
+)
+from human_eval.store import EvaluationStore
+from tests.test_human_eval import (
+    PROVENANCE,
+    BlockingExecutor,
+    FakeExecutor,
+    start_scheduler,
+    stop_scheduler,
+    wait_for_terminal,
+)
+
+
+class ExecutionLockTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.db_path = Path(self.tempdir.name) / "evaluation.sqlite"
+
+    def test_only_one_process_holds_the_execution_lock(self):
+        fd = acquire_execution_lock(self.db_path)
+        try:
+            with self.assertRaises(RuntimeError) as caught:
+                acquire_execution_lock(self.db_path)
+            self.assertIn("execution lock", str(caught.exception))
+        finally:
+            os.close(fd)
+        # The kernel releases the lock when the holder's fd closes.
+        second = acquire_execution_lock(self.db_path)
+        os.close(second)
+
+    def test_lock_fd_is_not_inheritable_by_child_processes(self):
+        fd = acquire_execution_lock(self.db_path)
+        try:
+            self.assertFalse(os.get_inheritable(fd))
+        finally:
+            os.close(fd)
+
+    def test_lock_lives_next_to_the_database(self):
+        self.assertEqual(
+            execution_lock_path(self.db_path),
+            Path(str(self.db_path) + ".lock"),
+        )
+
+
+class WebStartupTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.db_path = Path(self.tempdir.name) / "evaluation.sqlite"
+
+    def test_web_startup_never_migrates(self):
+        # A missing database must fail validation, not trigger a migration:
+        # the scheduler (or seed, under the execution lock) is the only
+        # component allowed to initialize or upgrade the schema.
+        service = EvaluationService(EvaluationStore(self.db_path))
+        with self.assertRaises(RuntimeError) as caught:
+            service.start()
+        self.assertIn("scheduler", str(caught.exception))
+        self.assertFalse(self.db_path.exists())
+
+    def test_web_startup_rejects_an_unknown_schema_version(self):
+        store = EvaluationStore(self.db_path)
+        store.initialize()
+        with store._connect() as connection:
+            connection.execute(
+                "UPDATE schema_meta SET value = '99' WHERE key = 'schema_version'"
+            )
+        with self.assertRaises(RuntimeError):
+            EvaluationService(store).start()
+
+    def test_web_startup_accepts_a_migrated_database(self):
+        EvaluationStore(self.db_path).initialize()
+        service = EvaluationService(EvaluationStore(self.db_path))
+        service.start()
+        service.close()
+
+
+class SchedulerRecoveryTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.store = EvaluationStore(Path(self.tempdir.name) / "evaluation.sqlite")
+        self.store.initialize()
+
+    def test_startup_fails_orphaned_started_runs_before_claiming(self):
+        orphaned, _ = self.store.create_run(
+            RunRequest("interrumpida"), user_id="one", provenance=PROVENANCE
+        )
+        # Simulate a run left started by a dead scheduler process.
+        self.store.append_event(orphaned["run_id"], "started")
+        queued, _ = self.store.create_run(
+            RunRequest("en cola"), user_id="two", provenance=PROVENANCE
+        )
+
+        scheduler = RunScheduler(self.store, FakeExecutor(), poll_seconds=0.02)
+        self.assertEqual(scheduler.prepare(), 1)
+
+        recovered = self.store.get_run(orphaned["run_id"])
+        self.assertEqual(recovered["status"], "failed")
+        self.assertEqual(recovered["error"]["code"], "service_restarted")
+        # Recovery happens before any claiming begins.
+        self.assertEqual(self.store.get_run(queued["run_id"])["status"], "queued")
+
+        thread = threading.Thread(target=scheduler.run, daemon=True)
+        thread.start()
+        try:
+            service = EvaluationService(self.store)
+            finished = wait_for_terminal(service, queued["run_id"])
+            self.assertEqual(finished["status"], "succeeded")
+        finally:
+            stop_scheduler(scheduler, thread)
+
+    def test_claim_stamps_scheduler_provenance_with_started(self):
+        service = EvaluationService(self.store)
+        run, created = self.store.create_run(RunRequest("pregunta"), user_id="one")
+        self.assertTrue(created)
+        self.assertEqual(run["provenance"], {})
+
+        claimed = self.store.claim_next_run(provenance=dict(PROVENANCE))
+        self.assertEqual(claimed, run["run_id"])
+
+        record = self.store.get_run(run["run_id"])
+        self.assertEqual(record["status"], "running")
+        self.assertEqual(record["provenance"], PROVENANCE)
+        self.assertIsNotNone(record["started_at"])
+        # The started run counts as occupied capacity for the queue UI.
+        self.assertEqual(
+            self.store.model_activity(1),
+            {"active": 1, "capacity": 1, "available": 0},
+        )
+        # Web-side reads of a running run include the shared snapshot.
+        service.public_run(run["run_id"], admin=True)
+        with self.assertRaises(KeyError):
+            # Not public and not owned by this user.
+            service.public_run(run["run_id"], user_id="other")
+
+    def test_stop_halts_new_claims_and_drains_in_flight(self):
+        executor = BlockingExecutor()
+        scheduler, thread = start_scheduler(
+            self.store, executor, model_concurrency=1
+        )
+        service = EvaluationService(self.store)
+        service.start()
+        first = service.submit(RunRequest("primera"), user_id="one", admin=True)
+        second = service.submit(RunRequest("segunda"), user_id="two", admin=True)
+        self.assertTrue(executor.started.wait(1))
+
+        scheduler.stop()  # what the SIGTERM/SIGINT handler calls
+        # While the first run is still blocked, the second must never be
+        # claimed, and the pool keeps waiting for the in-flight call (the
+        # supervisor's stop timeout bounds this wait in production).
+        time.sleep(0.1)
+        self.assertEqual(self.store.get_run(second["run_id"])["status"], "queued")
+        self.assertTrue(thread.is_alive())
+
+        executor.release.set()
+        thread.join(timeout=3)
+        self.assertFalse(thread.is_alive())
+        # In-flight work drained to a terminal state instead of orphaning.
+        self.assertEqual(
+            self.store.get_run(first["run_id"])["status"], "succeeded"
+        )
+        self.assertEqual(self.store.get_run(second["run_id"])["status"], "queued")
+
+    def test_model_concurrency_never_exceeds_the_pool_limit(self):
+        class OverlapTracker(FakeExecutor):
+            def __init__(self):
+                self.active = 0
+                self.max_active = 0
+                self.lock = threading.Lock()
+
+            def execute(self, request, *, on_progress=None):
+                with self.lock:
+                    self.active += 1
+                    self.max_active = max(self.max_active, self.active)
+                try:
+                    time.sleep(0.05)
+                    return super().execute(request, on_progress=on_progress)
+                finally:
+                    with self.lock:
+                        self.active -= 1
+
+        for concurrency in (1, 2):
+            with self.subTest(concurrency=concurrency):
+                store = EvaluationStore(
+                    Path(self.tempdir.name) / f"conc-{concurrency}.sqlite"
+                )
+                store.initialize()
+                executor = OverlapTracker()
+                scheduler, thread = start_scheduler(
+                    store, executor, model_concurrency=concurrency
+                )
+                try:
+                    service = EvaluationService(store)
+                    service.start()
+                    runs = [
+                        service.submit(
+                            RunRequest(f"pregunta {index}"),
+                            user_id=f"user-{index}",
+                            admin=True,
+                        )
+                        for index in range(3)
+                    ]
+                    for run in runs:
+                        self.assertEqual(
+                            wait_for_terminal(service, run["run_id"])["status"],
+                            "succeeded",
+                        )
+                finally:
+                    stop_scheduler(scheduler, thread)
+                self.assertEqual(executor.max_active, concurrency)
+
+
+class CrossProcessAdmissionTests(unittest.TestCase):
+    """Independent web processes share one persistent admission state."""
+
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.store = EvaluationStore(Path(self.tempdir.name) / "evaluation.sqlite")
+        self.store.initialize()
+
+    def test_queue_capacity_is_shared_across_web_processes(self):
+        first = EvaluationService(self.store, queue_capacity=1)
+        second = EvaluationService(
+            EvaluationStore(self.store.path), queue_capacity=1
+        )
+        first.start()
+        second.start()
+        first.submit(RunRequest("una"), user_id="one", admin=True)
+        with self.assertRaises(QueueFullError):
+            second.submit(RunRequest("dos"), user_id="two", admin=True)
+
+    def test_active_run_limit_is_shared_across_web_processes(self):
+        first = EvaluationService(self.store)
+        second = EvaluationService(EvaluationStore(self.store.path))
+        first.start()
+        second.start()
+        first.submit(RunRequest("una"), user_id="same-user", admin=True)
+        with self.assertRaises(ActiveRunError):
+            second.submit(RunRequest("dos"), user_id="same-user", admin=True)
+
+    def test_idempotency_conflict_is_detected_across_web_processes(self):
+        first = EvaluationService(self.store)
+        second = EvaluationService(EvaluationStore(self.store.path))
+        first.start()
+        second.start()
+        request = RunRequest("original", client_request_id="shared-key")
+        created = first.submit(request, user_id="user", admin=True)
+        # Let the first run finish so the active-run pre-check passes; the
+        # loser's transactional payload check inside create_run must still
+        # reject a reused key for a different payload even when its
+        # preliminary lookup raced and missed.
+        self.store.append_event(created["run_id"], "started")
+        self.store.append_event(created["run_id"], "succeeded", {"answer": {}})
+        with mock.patch.object(
+            second.store, "find_idempotent_run", return_value=None
+        ):
+            with self.assertRaises(IdempotencyConflictError):
+                second.submit(
+                    RunRequest("distinta", client_request_id="shared-key"),
+                    user_id="user",
+                    admin=True,
+                )
+
+
+class QueuePresentationTests(unittest.TestCase):
+    def test_near_zero_wait_has_consistent_html_and_stream_text(self):
+        for wait in (0, 1, 59):
+            with self.subTest(wait=wait):
+                run = {
+                    "created_at": "2026-09-05T00:00:00Z",
+                    "run_id": "test",
+                    "status": "queued",
+                    "queue_position": 1,
+                    "estimated_wait_seconds": wait,
+                    "queue_snapshot": {"active": 0, "capacity": 4},
+                }
+                event = _queue_status_event(run)
+                self.assertIn("Espera aproximada: menos de 1 min", event[1])
+                html = _status_fragment(run)
+                self.assertIn("Espera aproximada: menos de 1 min", html)
+
+    def test_queue_event_requires_a_complete_snapshot(self):
+        base = {
+            "created_at": "2026-09-05T00:00:00Z",
+            "run_id": "test",
+            "status": "queued",
+            "queue_position": 2,
+            "estimated_wait_seconds": 480,
+            "queue_snapshot": {"active": 1, "capacity": 1},
+        }
+        self.assertIsNotNone(_queue_status_event(base))
+        incomplete = dict(base, queue_snapshot={})
+        self.assertIsNone(_queue_status_event(incomplete))
+        running = dict(base, status="running")
+        self.assertIsNone(_queue_status_event(running))
+
+
+class QueuePresentationAppTests(unittest.TestCase):
+    """Queue visibility in the web UI while no scheduler is executing."""
+
+    def setUp(self):
+        import re
+
+        from starlette.testclient import TestClient
+
+        from human_eval.app import WebSettings, create_app
+        from human_eval.auth import FakeAuthBackend
+
+        self._re = re
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.store = EvaluationStore(Path(self.tempdir.name) / "evaluation.sqlite")
+        self.store.initialize()
+        self.service = EvaluationService(self.store, queue_capacity=1)
+        settings = WebSettings(
+            host="127.0.0.1",
+            port=0,
+            db_path=self.store.path,
+            session_secret="test-session-secret-that-is-at-least-32-bytes",
+            queue_capacity=1,
+        )
+        app = create_app(
+            self.service,
+            settings,
+            lambda: dict(PROVENANCE),
+            auth_backend=FakeAuthBackend(),
+        )
+        self.client_context = TestClient(app)
+        self.client = self.client_context.__enter__()
+        self.addCleanup(self.client_context.__exit__, None, None, None)
+
+    def _hidden(self, response, name: str) -> str:
+        match = self._re.search(rf'name="{name}" value="([^"]+)"', response.text)
+        self.assertIsNotNone(match, f"missing hidden field {name}")
+        return match.group(1)
+
+    def _ask(self, question: str, user: str = "alice"):
+        self.client.headers["x-eval-user"] = user
+        # Admins bypass the review gate, so the question form is rendered.
+        self.client.headers["x-eval-role"] = "admin"
+        page = self.client.get("/")
+        return self.client.post(
+            "/runs",
+            data={
+                "csrf_token": self._hidden(page, "csrf_token"),
+                "client_request_id": self._hidden(page, "client_request_id"),
+                "question": question,
+                "as_of": "",
+                "required_hops": "1",
+            },
+            follow_redirects=False,
+        )
+
+    def test_full_queue_returns_retry_after(self):
+        response = self._ask("primera pregunta", user="alice")
+        self.assertEqual(response.status_code, 303)
+        response = self._ask("segunda pregunta", user="bob")
+        self.assertEqual(response.status_code, 503)
+        self.assertIn("cola de preguntas", response.text)
+        retry_after = int(response.headers["retry-after"])
+        self.assertGreaterEqual(retry_after, 60)
+
+    def test_status_page_shows_queue_position_and_capacity(self):
+        response = self._ask("pregunta en cola")
+        run_id = response.headers["location"].split("/")[-1]
+        page = self.client.get(f"/runs/{run_id}")
+        self.assertEqual(page.status_code, 200)
+        self.assertIn("Posición en la cola: 1", page.text)
+        self.assertIn("0 de 1 slots ocupados", page.text)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -248,13 +248,18 @@ class SchedulerRecoveryTests(unittest.TestCase):
                 self.active = 0
                 self.max_active = 0
                 self.lock = threading.Lock()
+                self.first_wave = threading.Barrier(concurrency)
+                self.calls = 0
 
             def execute(self, request, *, on_progress=None):
                 with self.lock:
                     self.active += 1
+                    self.calls += 1
+                    first_wave = self.calls <= concurrency
                     self.max_active = max(self.max_active, self.active)
                 try:
-                    time.sleep(0.05)
+                    if first_wave:
+                        self.first_wave.wait(timeout=5)
                     return super().execute(request, on_progress=on_progress)
                 finally:
                     with self.lock:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -99,6 +99,16 @@ class WebStartupTests(unittest.TestCase):
         service.start()
         service.close()
 
+    def test_web_startup_can_wait_for_scheduler_schema_preparation(self):
+        store = mock.Mock()
+        store.validate_schema.side_effect = [RuntimeError("not ready"), None]
+        service = EvaluationService(store)
+        with mock.patch("human_eval.service.time.sleep") as sleep:
+            service.start(schema_wait_seconds=1)
+        self.assertEqual(store.validate_schema.call_count, 2)
+        sleep.assert_called_once()
+        service.close()
+
 
 class SchedulerRecoveryTests(unittest.TestCase):
     def setUp(self):
@@ -158,6 +168,31 @@ class SchedulerRecoveryTests(unittest.TestCase):
         with self.assertRaises(KeyError):
             # Not public and not owned by this user.
             service.public_run(run["run_id"], user_id="other")
+
+    def test_idle_scheduler_does_not_snapshot_provenance(self):
+        class CountingExecutor(FakeExecutor):
+            def __init__(self):
+                self.provenance_calls = 0
+
+            def provenance(self):
+                self.provenance_calls += 1
+                return super().provenance()
+
+        executor = CountingExecutor()
+        scheduler, thread = start_scheduler(self.store, executor)
+        try:
+            time.sleep(0.08)
+            self.assertEqual(executor.provenance_calls, 0)
+
+            service = EvaluationService(self.store)
+            service.start()
+            run = service.submit(RunRequest("pregunta"), user_id="one", admin=True)
+            self.assertEqual(
+                wait_for_terminal(service, run["run_id"])["status"], "succeeded"
+            )
+            self.assertEqual(executor.provenance_calls, 1)
+        finally:
+            stop_scheduler(scheduler, thread)
 
     def test_stop_halts_new_claims_and_drains_in_flight(self):
         executor = BlockingExecutor()
@@ -287,6 +322,48 @@ class CrossProcessAdmissionTests(unittest.TestCase):
                     user_id="user",
                     admin=True,
                 )
+
+    def test_same_idempotency_retry_wins_over_admission_rejections(self):
+        first = EvaluationService(self.store, queue_capacity=1)
+        second = EvaluationService(
+            EvaluationStore(self.store.path), queue_capacity=1
+        )
+        first.start()
+        second.start()
+        request = RunRequest("original", client_request_id="shared-key")
+        created = first.submit(request, user_id="user", admin=True)
+
+        # A preflight lookup could miss a concurrent winner and let the
+        # active-run or queue checks reject this retry. Admission must instead
+        # enter create_run's transaction, where idempotency is checked first.
+        with mock.patch.object(
+            second.store, "find_idempotent_run", return_value=None
+        ) as preflight_lookup:
+            repeated = second.submit(request, user_id="user", admin=True)
+
+        preflight_lookup.assert_not_called()
+        self.assertEqual(repeated["run_id"], created["run_id"])
+
+    def test_same_idempotency_retry_wins_over_review_and_quota(self):
+        first = EvaluationService(self.store)
+        second = EvaluationService(EvaluationStore(self.store.path))
+        first.start()
+        second.start()
+        request = RunRequest("original", client_request_id="shared-key")
+        created = first.submit(request, user_id="user", admin=True)
+        self.store.append_event(created["run_id"], "started")
+        self.store.append_event(created["run_id"], "succeeded", {"answer": {}})
+
+        # The successful submission consumed both the review gate and daily
+        # quota. An identical retry must still return it instead of being
+        # treated as a new question.
+        with mock.patch.object(
+            second.store, "find_idempotent_run", return_value=None
+        ) as preflight_lookup:
+            repeated = second.submit(request, user_id="user", admin=False)
+
+        preflight_lookup.assert_not_called()
+        self.assertEqual(repeated["run_id"], created["run_id"])
 
 
 class QueuePresentationTests(unittest.TestCase):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import sqlite3
 import tempfile
 import threading
 import time
@@ -393,3 +394,48 @@ class QueuePresentationAppTests(unittest.TestCase):
         self.assertEqual(page.status_code, 200)
         self.assertIn("Posición en la cola: 1", page.text)
         self.assertIn("0 de 1 slots ocupados", page.text)
+
+
+class SchedulerFailureTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.store = EvaluationStore(Path(self.tempdir.name) / "evaluation.sqlite")
+        self.store.initialize()
+
+    def test_persistence_failure_stops_scheduler_for_supervised_restart(self):
+        scheduler, thread = start_scheduler(self.store, FakeExecutor())
+        service = EvaluationService(self.store)
+        service.start()
+        # A terminal write that cannot persist strands the run in 'started';
+        # only startup recovery repairs that, so the scheduler must stop and
+        # let the supervisor (systemd Restart=always) restart it.
+        with mock.patch.object(
+            self.store,
+            "append_event",
+            side_effect=sqlite3.OperationalError("disk I/O error"),
+        ):
+            run = service.submit(RunRequest("pregunta"), user_id="one", admin=True)
+            thread.join(timeout=3)
+        self.assertFalse(thread.is_alive())
+        self.assertEqual(self.store.get_run(run["run_id"])["status"], "running")
+
+        replacement, replacement_thread = start_scheduler(self.store, FakeExecutor())
+        try:
+            recovered = self.store.get_run(run["run_id"])
+            self.assertEqual(recovered["status"], "failed")
+            self.assertEqual(recovered["error"]["code"], "service_restarted")
+        finally:
+            stop_scheduler(replacement, replacement_thread)
+
+    def test_stop_requested_during_prepare_is_honored(self):
+        scheduler = RunScheduler(self.store, FakeExecutor(), poll_seconds=0.02)
+        scheduler.prepare()
+        service = EvaluationService(self.store)
+        service.start()
+        run = service.submit(RunRequest("pregunta"), user_id="one", admin=True)
+        # SIGTERM can arrive while prepare() (embedding-server startup) is
+        # still running; run() must not erase that stop request.
+        scheduler.stop()
+        scheduler.run()
+        self.assertEqual(self.store.get_run(run["run_id"])["status"], "queued")

--- a/tests/test_scheduler_cleanup.py
+++ b/tests/test_scheduler_cleanup.py
@@ -1,7 +1,10 @@
 """Regression tests for scheduler cleanup, duration sampling, and seed paths."""
 
 import os
+import subprocess
+import sys
 import tempfile
+import textwrap
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -13,6 +16,43 @@ from scripts import seed_human_eval_v4_hybrid as seed
 
 
 class SchedulerCleanupTests(unittest.TestCase):
+    def test_signal_stop_does_not_arm_fatal_watchdog(self):
+        scheduler = RunScheduler(mock.Mock(), mock.Mock())
+        scheduler.stop()
+        with mock.patch("human_eval.scheduler.threading.Timer") as timer:
+            scheduler.run()
+        timer.assert_not_called()
+        scheduler.executor.close.assert_called_once()
+
+    def test_fatal_errors_force_process_exit_with_hung_work(self):
+        for failure in ("poll", "persistence"):
+            with self.subTest(failure=failure):
+                program = textwrap.dedent('''
+                    import threading
+                    from unittest import mock
+                    from human_eval.scheduler import RunScheduler
+
+                    scheduler = RunScheduler(
+                        mock.Mock(), mock.Mock(), fatal_shutdown_seconds=0.1
+                    )
+                    def poll():
+                        scheduler._pool.submit(threading.Event().wait)
+                        if FAILURE == "poll":
+                            raise RuntimeError("poll failed")
+                        from concurrent.futures import Future
+                        failed = Future()
+                        failed.set_exception(RuntimeError("persistence failed"))
+                        scheduler._in_flight.add(failed)
+                        return RunScheduler.poll_once(scheduler)
+                    scheduler.poll_once = poll
+                    scheduler.run()
+                ''').replace("FAILURE", repr(failure))
+                result = subprocess.run(
+                    [sys.executable, "-c", program],
+                    capture_output=True, text=True, timeout=10,
+                )
+                self.assertEqual(result.returncode, 1, result.stderr)
+
     def test_poll_errors_drain_work_before_closing_executor(self):
         for source in ("queue_depth", "provenance", "claim_next_run"):
             with self.subTest(source=source):
@@ -37,6 +77,33 @@ class SchedulerCleanupTests(unittest.TestCase):
                 executor.close.assert_called_once()
                 self.assertEqual(closed_after, [True])
                 self.assertIsNone(scheduler._pool)
+
+
+class WebWorkerStartupTests(unittest.TestCase):
+    def test_multiple_workers_use_factory_and_propagate_root(self):
+        from human_eval import app
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            with (
+                mock.patch.dict(os.environ, {}, clear=True),
+                mock.patch("sys.argv", ["app", "--workers", "2", "--repo-root", directory]),
+                mock.patch.object(app, "uvicorn") as uvicorn,
+                mock.patch.object(app, "WebSettings") as settings,
+                mock.patch.object(app, "build_default_app") as build,
+            ):
+                settings.from_env.return_value = mock.Mock(host="127.0.0.1", port=8000)
+                self.assertEqual(app.main(), 0)
+                settings.from_env.assert_called_once_with(root)
+                self.assertEqual(os.environ["DOF_APP_REPO_ROOT"], str(root))
+                uvicorn.run.assert_called_once_with(
+                    "human_eval.app:create_uvicorn_app", factory=True,
+                    workers=2, host="127.0.0.1", port=8000, access_log=False,
+                )
+                build.assert_not_called()
+                build.return_value = (mock.sentinel.app, mock.sentinel.settings)
+                self.assertIs(app.create_uvicorn_app(), mock.sentinel.app)
+                build.assert_called_once_with(root)
 
 
 class DurationSamplingTests(unittest.TestCase):

--- a/tests/test_scheduler_cleanup.py
+++ b/tests/test_scheduler_cleanup.py
@@ -1,0 +1,96 @@
+"""Regression tests for scheduler cleanup, duration sampling, and seed paths."""
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from human_eval.contracts import RunRequest
+from human_eval.scheduler import RunScheduler
+from human_eval.store import EvaluationStore
+from scripts import seed_human_eval_v4_hybrid as seed
+
+
+class SchedulerCleanupTests(unittest.TestCase):
+    def test_poll_errors_drain_work_before_closing_executor(self):
+        for source in ("queue_depth", "provenance", "claim_next_run"):
+            with self.subTest(source=source):
+                store = mock.Mock()
+                store.queue_depth.return_value = 1
+                executor = mock.Mock()
+                target = executor if source == "provenance" else store
+                getattr(target, source).side_effect = RuntimeError(source)
+                scheduler = RunScheduler(store, executor)
+                completed = []
+                original_poll = scheduler.poll_once
+
+                def poll():
+                    scheduler._pool.submit(lambda: completed.append(True))
+                    return original_poll()
+
+                closed_after = []
+                executor.close.side_effect = lambda: closed_after.extend(completed)
+                with mock.patch.object(scheduler, "poll_once", side_effect=poll):
+                    with self.assertRaisesRegex(RuntimeError, source):
+                        scheduler.run()
+                executor.close.assert_called_once()
+                self.assertEqual(closed_after, [True])
+                self.assertIsNone(scheduler._pool)
+
+
+class DurationSamplingTests(unittest.TestCase):
+    def test_recovery_is_excluded_before_sample_limit(self):
+        with tempfile.TemporaryDirectory() as directory:
+            store = EvaluationStore(Path(directory) / "eval.sqlite")
+            store.initialize()
+            for index, terminal in enumerate(("succeeded", "failed", "recovery")):
+                run, _ = store.create_run(RunRequest("question"), user_id=str(index))
+                run_id = run["run_id"]
+                store.append_event(run_id, "started")
+                if terminal == "recovery":
+                    store.fail_interrupted_runs()
+                else:
+                    store.append_event(run_id, terminal, {})
+                with store._connect() as connection:
+                    connection.execute(
+                        "UPDATE run_events SET created_at = ? WHERE run_id = ? "
+                        "AND event_type = 'started'",
+                        ("2026-01-01T00:00:00+00:00", run_id),
+                    )
+                    connection.execute(
+                        "UPDATE run_events SET created_at = ? WHERE run_id = ? "
+                        "AND event_type IN ('succeeded', 'failed')",
+                        (f"2026-01-0{index + 1}T00:00:10+00:00", run_id),
+                    )
+            self.assertEqual(store.recent_durations(limit=2), [86410.0, 10.0])
+
+
+class SeedDatabaseTests(unittest.TestCase):
+    def test_database_precedence_matches_lock_and_store(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            for cli, env, expected in (
+                (None, None, root / "var/human_evaluation.sqlite"),
+                (None, str(root / "env.sqlite"), root / "env.sqlite"),
+                (str(root / "cli.sqlite"), str(root / "env.sqlite"), root / "cli.sqlite"),
+            ):
+                with self.subTest(cli=cli, env=env):
+                    argv = ["seed", "--repo-root", str(root)]
+                    if cli:
+                        argv.extend(["--db", cli])
+                    environment = {"DOF_HUMAN_EVAL_DB": env} if env else {}
+                    with (
+                        mock.patch.dict(os.environ, environment, clear=True),
+                        mock.patch("sys.argv", argv),
+                        mock.patch.object(seed, "load_queries", return_value=[]),
+                        mock.patch.object(seed, "EvaluationStore") as store,
+                        mock.patch.object(seed, "acquire_execution_lock", return_value=123) as lock,
+                        mock.patch.object(seed, "AgentExecutorConfig"),
+                        mock.patch.object(seed, "AgentRunExecutor"),
+                        mock.patch.object(seed.os, "close"),
+                        mock.patch("builtins.print"),
+                    ):
+                        self.assertEqual(seed.main(), 0)
+                    store.assert_called_once_with(expected)
+                    lock.assert_called_once_with(expected)

--- a/tests/test_scheduler_cleanup.py
+++ b/tests/test_scheduler_cleanup.py
@@ -67,6 +67,25 @@ class DurationSamplingTests(unittest.TestCase):
 
 
 class SeedDatabaseTests(unittest.TestCase):
+    def test_provenance_failure_does_not_persist_seed_work(self):
+        with tempfile.TemporaryDirectory() as directory:
+            store = EvaluationStore(Path(directory) / "eval.sqlite")
+            store.initialize()
+            executor = mock.Mock()
+            executor.provenance.side_effect = RuntimeError("probe failed")
+            item = {"id": "probe-test", "question": "question"}
+            # Repeated attempts must retry the probe, not return 'pending'.
+            for _ in range(2):
+                with self.assertRaisesRegex(RuntimeError, "probe failed"):
+                    seed.seed_live_run(store, executor, item, publish=True)
+                self.assertIsNone(
+                    store.find_idempotent_run(
+                        seed.SEED_USER, "eval-v4-hybrid:probe-test"
+                    )
+                )
+                self.assertEqual(store.queue_depth(), 0)
+            executor.execute.assert_not_called()
+
     def test_database_precedence_matches_lock_and_store(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory).resolve()


### PR DESCRIPTION
## Summary

Clean replacement for #84, redesigned after its review rounds showed that cross-process leases/heartbeats/fencing were generating edge cases faster than they could be fixed. This branch keeps the durable parts of #84 and removes the distributed-liveness protocol entirely.

**Architecture invariants:**

- Web workers only create `queued` runs and serve UI/API requests.
- Exactly one scheduler holds an OS-level `flock` (non-inheritable fd, so executor children like the embedding server can't retain it); the kernel releases it if the process dies.
- The scheduler owns `AgentRunExecutor` and the embedding server.
- Claiming stamps scheduler provenance and `started` in one transaction.
- An in-process bounded pool enforces `DOF_MODEL_CONCURRENCY`.
- Only the scheduler writes progress and terminal events.
- Scheduler startup fails every previously `started` run — provably orphaned, since only the scheduler starts runs.
- The seed script acquires the same execution lock (normally with the scheduler service stopped).
- systemd uses `Restart=always` and `KillMode=mixed`; SIGTERM goes only to the scheduler so it can stop new claims and drain in-flight work within `TimeoutStopSec`, then SIGKILL reaches the whole control group (including embedding-server children). Runs left `started` by a hard kill are recovered at the next startup.

**Kept from #84:** transactional admission (active-run, review gate, daily quota, queue capacity, idempotency payload check — now authoritative across web processes), persistent queue, queue position / estimated wait / occupied slots UI, SSE `queue`/`running` events, `Retry-After` on 503, multi-worker uvicorn via `--workers`.

**Removed vs. #84:** `model_slots`, leases, heartbeats, fenced writes, worker IDs, migration serialization, the wake-up queue, and `DOF_MANAGE_EMBED_SERVER`. Schema stays at v3 — no migration needed (the v4 bump never shipped).

**Deliberate trade:** recovery of a dead scheduler now depends on systemd restarting it rather than peer processes detecting lease expiry. For a single-machine deployment this is equal-or-better in practice, and a hung inference was never solved by leases anyway (heartbeats renew independently of the stuck call) — run-level timeouts remain on the roadmap as the real fix.

## Deployment

- `ops/systemd/dof-human-eval-scheduler.service` + `dof-human-eval-web.service`, installed by `scripts/install_human_eval_systemd.sh`. The scheduler is launched first; web workers wait up to `DOF_SCHEMA_WAIT_SECONDS` (30 seconds by default) for schema preparation before failing startup. The installer rejects checkout paths containing whitespace because systemd tokenizes an unquoted `ExecStart` path.
- Web `DOF_MODEL_CONCURRENCY` is display-only (queue UI capacity); share one environment file so both sides agree. The scheduler enforces the real limit.
- Development databases touched by the unmerged #84 (schema v4 with `model_slots`) should be backed up and reset; no downgrade compatibility is shipped.

## Validation

- `uv run python -m unittest tests.test_human_eval tests.test_scheduler -q` — 106 passed, including regressions for cross-worker same-payload idempotency against active-run, review, quota, and queue limits; idle scheduler polling; and bounded web schema readiness.
- `uv run python -m unittest discover -s tests -q` — 189 tests exercised in the isolated worktree: 188 passed and the unrelated FTS test could not load the locally generated `poc/extensions/sqlitezstd.dylib`, which is not present in that worktree. The prior full branch run passed all 182 tests that existed at that revision.
- `uv run ruff check human_eval tests scripts/seed_human_eval_v4_hybrid.py` — clean.
- `bash -n scripts/install_human_eval_systemd.sh` and `git diff --check` — clean.

Closes the approach explored in #84.
